### PR TITLE
Round 4 batch 2: collapse predict/plot/file (8→3, –5 surface)

### DIFF
--- a/app/tools/prediction.py
+++ b/app/tools/prediction.py
@@ -1,34 +1,83 @@
-"""Prediction tools for the agent."""
+"""ML prediction tools.
+
+The unified `predict` tool replaces the prior `predict_property` (formula-
+based, classical ML) and `predict_structure` (crystal-structure GNN) tools
+with a single entry point dispatched by `target`. `list_models` remains a
+separate tool — it's a different abstraction (registry inspection) that
+doesn't fit the predict dispatcher.
+
+The dataset-wide `predict_properties` Skill is registered through a
+different code path (SkillRegistry.register_all_as_tools) and is not
+collapsed here — it's a workflow-shaped abstraction that auto-trains
+models on demand, distinct from the atomic predictors.
+"""
 from app.tools.base import Tool, ToolRegistry
 
 
-def _predict_property(**kwargs) -> dict:
-    formula = kwargs["formula"]
-    property_name = kwargs.get("property_name", "band_gap")
-    algorithm = kwargs.get("algorithm", "random_forest")
+# ---------------------------------------------------------------------------
+# Per-target handlers
+# ---------------------------------------------------------------------------
 
+def _predict_formula(**kw) -> dict:
+    """Composition-based ML prediction (matminer Magpie features + sklearn)."""
+    formula = kw.get("formula")
+    if not formula:
+        return {"error": "Action target='formula' requires `formula`"}
     try:
         from app.tools.ml.predictor import Predictor
         predictor = Predictor()
-        return predictor.predict(formula, property_name, algorithm)
-    except Exception as e:
-        return {"error": str(e)}
-
-
-def _predict_structure(**kwargs) -> dict:
-    """Predict a property from a crystal structure using a pre-trained GNN."""
-    model_name = kwargs.get("model", "m3gnet-eform")
-    structure_data = kwargs.get("structure")
-
-    try:
-        from app.tools.ml.pretrained import predict_with_pretrained
-        return predict_with_pretrained(
-            model_name=model_name,
-            structure_data=structure_data,
+        return predictor.predict(
+            formula,
+            kw.get("property_name", "band_gap"),
+            kw.get("algorithm", "random_forest"),
         )
     except Exception as e:
         return {"error": str(e)}
 
+
+def _predict_structure(**kw) -> dict:
+    """Crystal-structure prediction via pre-trained GNN (M3GNet, MEGNet)."""
+    structure = kw.get("structure")
+    if not structure:
+        return {"error": "Action target='structure' requires `structure` dict"}
+    try:
+        from app.tools.ml.pretrained import predict_with_pretrained
+        return predict_with_pretrained(
+            model_name=kw.get("model", "m3gnet-eform"),
+            structure_data=structure,
+        )
+    except Exception as e:
+        return {"error": str(e)}
+
+
+_DISPATCH = {
+    "formula":   _predict_formula,
+    "structure": _predict_structure,
+}
+
+
+def _predict(**kwargs) -> dict:
+    target = kwargs.pop("target", None)
+    if not target:
+        return {
+            "error": f"Missing 'target'. Valid: {list(_DISPATCH.keys())}",
+            "hint": (
+                "predict(target='formula', formula='LiCoO2') or "
+                "predict(target='structure', structure={...})"
+            ),
+        }
+    handler = _DISPATCH.get(target)
+    if not handler:
+        return {"error": f"Unknown target '{target}'. Valid: {list(_DISPATCH.keys())}"}
+    try:
+        return handler(**kwargs)
+    except Exception as e:
+        return {"error": str(e), "target": target}
+
+
+# ---------------------------------------------------------------------------
+# list_models — separate tool (different abstraction, not part of predict)
+# ---------------------------------------------------------------------------
 
 def _list_models(**kwargs) -> dict:
     try:
@@ -51,74 +100,115 @@ def _list_models(**kwargs) -> dict:
         return {"error": str(e)}
 
 
+# ---------------------------------------------------------------------------
+# Tool descriptions
+# ---------------------------------------------------------------------------
+
+_PREDICT_DESCRIPTION = (
+    "Predict a material property using ML. ONE tool, two targets:\n"
+    "  • target='formula' — composition-based ML (matminer Magpie features + "
+    "trained scikit-learn model). Requires `formula` (e.g. 'LiCoO2'). "
+    "Optional: `property_name` (band_gap, formation_energy, ...), "
+    "`algorithm` (random_forest, xgboost, ...). Use list_models first to "
+    "see what's trained.\n"
+    "  • target='structure' — pre-trained GNN (M3GNet, MEGNet); no training "
+    "needed. Requires `structure` dict with `lattice` (3×3), `species` "
+    "(list), `coords` (list). Optional: `model` (default 'm3gnet-eform').\n"
+    "Use target='formula' when you only know the chemistry; use target='structure' "
+    "when you have actual atomic coordinates. NOT for batch dataset prediction "
+    "(use the predict_properties skill) and NOT for property selection "
+    "(use list_predictable_properties)."
+)
+
+_PREDICT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "target": {
+            "type": "string",
+            "enum": list(_DISPATCH.keys()),
+            "description": (
+                "Whether to predict from a chemical formula or from a "
+                "crystal structure."
+            ),
+        },
+        "formula": {
+            "type": "string",
+            "description": (
+                "Chemical formula (e.g. 'LiCoO2'). Required for "
+                "target='formula'."
+            ),
+        },
+        "property_name": {
+            "type": "string",
+            "description": (
+                "Property to predict for target='formula' (band_gap, "
+                "formation_energy, ...)."
+            ),
+        },
+        "algorithm": {
+            "type": "string",
+            "description": (
+                "ML algorithm for target='formula' (random_forest, "
+                "xgboost, ...)."
+            ),
+        },
+        "structure": {
+            "type": "object",
+            "description": (
+                "Crystal structure for target='structure'. Keys: `lattice` "
+                "(3×3 Angstrom matrix), `species` (element symbols), "
+                "`coords` (fractional or Cartesian). Optional `cartesian: "
+                "true` if coords are Cartesian."
+            ),
+            "properties": {
+                "lattice":   {"type": "array"},
+                "species":   {"type": "array", "items": {"type": "string"}},
+                "coords":    {"type": "array"},
+                "cartesian": {"type": "boolean"},
+            },
+        },
+        "model": {
+            "type": "string",
+            "description": (
+                "Pre-trained GNN model for target='structure': "
+                "m3gnet-eform, megnet-eform, megnet-bandgap."
+            ),
+        },
+    },
+    "required": ["target"],
+    "additionalProperties": False,
+}
+
+
+_LIST_MODELS_DESCRIPTION = (
+    "ML property-prediction models — trained composition models + "
+    "pre-trained GNN models (M3GNet, MEGNet) for materials property "
+    "prediction. Use this to choose a model BEFORE calling predict. "
+    "NOT for hosted chat LLMs (use models_list for those) and NOT for "
+    "compute hardware (use compute(action='list_gpus') for that)."
+)
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
 def create_prediction_tools(registry: ToolRegistry) -> None:
-    """Register prediction tools."""
-    registry.register(Tool(
-        name="predict_property",
-        description=(
-            "Predict a material property from its chemical formula using trained "
-            "ML models (composition-based). Available properties depend on trained "
-            "models — check with list_models first. Uses matminer Magpie features "
-            "if installed, otherwise built-in features."
-        ),
-        input_schema={
-            "type": "object",
-            "properties": {
-                "formula": {"type": "string", "description": "Chemical formula, e.g. 'LiCoO2'"},
-                "property_name": {"type": "string", "description": "Property to predict (band_gap, formation_energy, etc.)"},
-                "algorithm": {"type": "string", "description": "Algorithm to use (random_forest, xgboost, etc.)"},
-            },
-            "required": ["formula"],
-        },
-        func=_predict_property,
-    ))
+    """Register the unified `predict` tool and `list_models`.
 
+    Replaces the prior `predict_property` + `predict_structure` tools
+    with a single `predict(target=...)` dispatcher. `list_models` stays
+    separate — it's a registry-inspection tool, not a property predictor.
+    """
     registry.register(Tool(
-        name="predict_structure",
-        description=(
-            "Predict a material property from its crystal structure using a "
-            "pre-trained GNN model (M3GNet, MEGNet). No training needed — "
-            "models ship with the package. Requires lattice vectors, species, "
-            "and atomic coordinates."
-        ),
-        input_schema={
-            "type": "object",
-            "properties": {
-                "model": {
-                    "type": "string",
-                    "description": "Pre-trained model: m3gnet-eform, megnet-eform, megnet-bandgap",
-                },
-                "structure": {
-                    "type": "object",
-                    "description": (
-                        "Crystal structure as dict with keys: "
-                        "'lattice' (3x3 matrix), 'species' (list of element symbols), "
-                        "'coords' (list of [x,y,z] fractional coordinates). "
-                        "Set 'cartesian': true if coords are Cartesian (Angstroms)."
-                    ),
-                    "properties": {
-                        "lattice": {"type": "array", "description": "3x3 lattice matrix in Angstroms"},
-                        "species": {"type": "array", "items": {"type": "string"}, "description": "Element symbols"},
-                        "coords": {"type": "array", "description": "Atomic coordinates (fractional by default)"},
-                        "cartesian": {"type": "boolean", "description": "True if coords are Cartesian"},
-                    },
-                    "required": ["lattice", "species", "coords"],
-                },
-            },
-            "required": ["structure"],
-        },
-        func=_predict_structure,
+        name="predict",
+        description=_PREDICT_DESCRIPTION,
+        input_schema=_PREDICT_SCHEMA,
+        func=_predict,
     ))
-
     registry.register(Tool(
         name="list_models",
-        description=(
-            "ML property-prediction models — trained composition models + "
-            "pre-trained GNN models (M3GNet, MEGNet) for materials property "
-            "prediction. Use this to choose a model BEFORE calling predict_property. "
-            "NOT for hosted chat LLMs (use models_list for those) and NOT for "
-            "compute hardware (use compute_providers for that)."
-        ),
+        description=_LIST_MODELS_DESCRIPTION,
         input_schema={"type": "object", "properties": {}},
         func=_list_models,
     ))

--- a/app/tools/system.py
+++ b/app/tools/system.py
@@ -127,98 +127,122 @@ def _show_scratchpad(**kwargs) -> dict:
     return {"text": scratchpad.to_text()}
 
 
+_FILE_DISPATCH = {
+    "read":  _read_file,
+    "write": _write_file,
+    "edit":  _edit_file,
+}
+
+
+def _file(**kwargs) -> dict:
+    """Unified file I/O dispatcher.
+
+    Replaces the prior `read_file`, `write_file`, and `edit_file` tools.
+    Each action validates its required args before touching the filesystem.
+    Sandbox enforcement (paths must resolve inside PRISM project root) is
+    inherited from `_is_safe_path`, applied by each handler.
+    """
+    action = kwargs.pop("action", None)
+    if not action:
+        return {
+            "error": f"Missing 'action'. Valid: {list(_FILE_DISPATCH.keys())}",
+            "hint": (
+                "file(action='read', path='./README.md') / "
+                "file(action='write', path=..., content=...) / "
+                "file(action='edit', path=..., old_text=..., new_text=...)"
+            ),
+        }
+    handler = _FILE_DISPATCH.get(action)
+    if not handler:
+        return {"error": f"Unknown action '{action}'. Valid: {list(_FILE_DISPATCH.keys())}"}
+    # Per-action arg validation
+    if action == "read":
+        if not kwargs.get("path"):
+            return {"error": "Action 'read' requires `path`"}
+    elif action == "write":
+        if not kwargs.get("path"):
+            return {"error": "Action 'write' requires `path`"}
+        if kwargs.get("content") is None:
+            return {"error": "Action 'write' requires `content`"}
+    elif action == "edit":
+        if not kwargs.get("path"):
+            return {"error": "Action 'edit' requires `path`"}
+        if kwargs.get("old_text") is None or kwargs.get("new_text") is None:
+            return {"error": "Action 'edit' requires `old_text` and `new_text`"}
+    try:
+        return handler(**kwargs)
+    except Exception as e:
+        return {"error": str(e), "action": action}
+
+
+_FILE_DESCRIPTION = (
+    "Text file I/O inside the current PRISM project. ONE tool, three actions:\n"
+    "  • action='read' — read a text file. Requires `path`. Returns content + size.\n"
+    "  • action='write' — overwrite (or create) a file. Requires `path` + "
+    "`content`. Replaces existing contents completely.\n"
+    "  • action='edit' — targeted in-file replace. Requires `path`, `old_text`, "
+    "`new_text`. Fails if old_text matches multiple locations unless "
+    "`replace_all=true`. Use this when you want a surgical change rather than "
+    "rewriting the whole file with action='write'.\n"
+    "Paths are resolved relative to the project root (CWD); absolute paths "
+    "must still be inside the project tree (sandbox enforced). NOT for binary "
+    "files and NOT for shell access (use execute_bash)."
+)
+
+_FILE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "action": {
+            "type": "string",
+            "enum": list(_FILE_DISPATCH.keys()),
+            "description": "Which file operation to perform.",
+        },
+        "path": {
+            "type": "string",
+            "description": (
+                "Project-relative or absolute path inside the PRISM "
+                "project. Required for all actions."
+            ),
+        },
+        "content": {
+            "type": "string",
+            "description": (
+                "Full file content for action='write'. Replaces existing contents."
+            ),
+        },
+        "old_text": {
+            "type": "string",
+            "description": (
+                "Exact text snippet to replace for action='edit'. Must be "
+                "specific enough to match only the intended location."
+            ),
+        },
+        "new_text": {
+            "type": "string",
+            "description": "Replacement text for action='edit'.",
+        },
+        "replace_all": {
+            "type": "boolean",
+            "default": False,
+            "description": (
+                "For action='edit': replace every match instead of failing "
+                "on multiple matches."
+            ),
+        },
+    },
+    "required": ["action"],
+    "additionalProperties": False,
+}
+
+
 def create_system_tools(registry: ToolRegistry) -> None:
-    # These core coding tools need procedural descriptions because the model
-    # should choose them intentionally instead of falling back to shell habits.
+    # Unified file tool replaces read_file / write_file / edit_file.
     registry.register(Tool(
-        name="read_file",
-        description=(
-            "Read a text file inside the current PRISM project. Use this for "
-            "source files, config files, logs, and other textual project files "
-            "when you need the file contents directly in the model context. Use "
-            "this instead of execute_bash for straightforward file reads."
-        ),
-        input_schema={
-            "type": "object",
-            "properties": {
-                "path": {
-                    "type": "string",
-                    "description": (
-                        "Project-relative or absolute path to a text file inside "
-                        "the current PRISM project."
-                    ),
-                }
-            },
-            "required": ["path"],
-        },
-        func=_read_file))
-    registry.register(Tool(
-        name="write_file",
-        description=(
-            "Write text content to a file inside the current PRISM project. "
-            "This overwrites the target file completely, so use it when you want "
-            "to replace a file body or create a new text file directly."
-        ),
-        input_schema={
-            "type": "object",
-            "properties": {
-                "path": {
-                    "type": "string",
-                    "description": (
-                        "Project-relative or absolute path to a file inside the "
-                        "current PRISM project."
-                    ),
-                },
-                "content": {
-                    "type": "string",
-                    "description": (
-                        "Full text content to write. This replaces any existing "
-                        "file contents."
-                    ),
-                },
-            },
-            "required": ["path", "content"],
-        },
-        func=_write_file))
-    registry.register(Tool(
-        name="edit_file",
-        description=(
-            "Edit a text file inside the current PRISM project by replacing an "
-            "exact old_text snippet with new_text. Use this when you want a "
-            "targeted in-file change instead of overwriting the whole file with "
-            "write_file or shelling out through execute_bash."
-        ),
-        input_schema={
-            "type": "object",
-            "properties": {
-                "path": {
-                    "type": "string",
-                    "description": (
-                        "Project-relative or absolute path to a text file inside "
-                        "the current PRISM project."
-                    ),
-                },
-                "old_text": {
-                    "type": "string",
-                    "description": (
-                        "Exact text snippet to replace. Keep this specific enough "
-                        "to match only the intended location."
-                    ),
-                },
-                "new_text": {
-                    "type": "string",
-                    "description": "Replacement text for the matched snippet.",
-                },
-                "replace_all": {
-                    "type": "boolean",
-                    "description": (
-                        "Replace every exact match instead of failing on multiple matches."
-                    ),
-                },
-            },
-            "required": ["path", "old_text", "new_text"],
-        },
-        func=_edit_file))
+        name="file",
+        description=_FILE_DESCRIPTION,
+        input_schema=_FILE_SCHEMA,
+        func=_file,
+    ))
     registry.register(Tool(
         name="web_search",
         description=(

--- a/app/tools/visualization.py
+++ b/app/tools/visualization.py
@@ -1,13 +1,26 @@
-"""Visualization tools for materials data."""
+"""Visualization tools for materials data.
+
+The unified `plot` tool replaces the prior `plot_materials_comparison`,
+`plot_property_distribution`, and `plot_correlation_matrix` tools with
+a single entry point dispatched by `kind`. Each kind owns its own
+required-args contract, validated up front before any matplotlib work.
+"""
 from app.tools.base import Tool, ToolRegistry
 
 
-def _plot_materials_comparison(**kwargs) -> dict:
-    materials = kwargs["materials"]
-    prop_x = kwargs["property_x"]
-    prop_y = kwargs["property_y"]
-    output_path = kwargs.get("output_path", "comparison.png")
-    title = kwargs.get("title", f"{prop_x} vs {prop_y}")
+# ---------------------------------------------------------------------------
+# Per-kind handlers
+# ---------------------------------------------------------------------------
+
+def _kind_materials_comparison(**kw) -> dict:
+    materials = kw.get("materials")
+    prop_x = kw.get("property_x")
+    prop_y = kw.get("property_y")
+    if not materials or not prop_x or not prop_y:
+        return {"error": "kind='materials_comparison' requires `materials`, `property_x`, `property_y`"}
+
+    output_path = kw.get("output_path", "comparison.png")
+    title = kw.get("title", f"{prop_x} vs {prop_y}")
     try:
         import matplotlib
         matplotlib.use("Agg")
@@ -25,17 +38,20 @@ def _plot_materials_comparison(**kwargs) -> dict:
         fig.tight_layout()
         fig.savefig(output_path, dpi=150)
         plt.close(fig)
-        return {"success": True, "path": output_path}
+        return {"success": True, "path": output_path, "kind": "materials_comparison"}
     except ImportError:
-        return {"error": "matplotlib not installed. Install with: pip install matplotlib"}
+        return {"error": "matplotlib not installed"}
     except Exception as e:
         return {"error": str(e)}
 
 
-def _plot_property_distribution(**kwargs) -> dict:
-    values = kwargs["values"]
-    prop_name = kwargs.get("property_name", "property")
-    output_path = kwargs.get("output_path", "distribution.png")
+def _kind_property_distribution(**kw) -> dict:
+    values = kw.get("values")
+    if values is None:
+        return {"error": "kind='property_distribution' requires `values` list"}
+
+    prop_name = kw.get("property_name", "property")
+    output_path = kw.get("output_path", "distribution.png")
     try:
         import matplotlib
         matplotlib.use("Agg")
@@ -48,28 +64,27 @@ def _plot_property_distribution(**kwargs) -> dict:
         fig.tight_layout()
         fig.savefig(output_path, dpi=150)
         plt.close(fig)
-        return {"success": True, "path": output_path}
+        return {"success": True, "path": output_path, "kind": "property_distribution"}
     except ImportError:
-        return {"error": "matplotlib not installed. Install with: pip install matplotlib"}
+        return {"error": "matplotlib not installed"}
     except Exception as e:
         return {"error": str(e)}
 
 
-def _plot_correlation_matrix(**kwargs) -> dict:
-    """Plot correlation heatmap for numeric columns in a dataset."""
-    dataset_name = kwargs.get("dataset_name")
+def _kind_correlation_matrix(**kw) -> dict:
+    dataset_name = kw.get("dataset_name")
     if not dataset_name:
-        return {"error": "dataset_name is required"}
-    columns = kwargs.get("columns")
-    output_path = kwargs.get("output_path")
+        return {"error": "kind='correlation_matrix' requires `dataset_name`"}
 
     from app.tools.data_collectors.store import DataStore
-
     store = DataStore()
     try:
         df = store.load(dataset_name)
     except FileNotFoundError:
         return {"error": f"Dataset '{dataset_name}' not found in DataStore"}
+
+    columns = kw.get("columns")
+    output_path = kw.get("output_path") or f"{dataset_name}_correlation.png"
 
     numeric = df.select_dtypes(include=["float64", "float32", "int64", "int32"])
     if columns:
@@ -80,14 +95,10 @@ def _plot_correlation_matrix(**kwargs) -> dict:
 
     corr = numeric.corr()
 
-    if not output_path:
-        output_path = f"{dataset_name}_correlation.png"
-
     try:
         import matplotlib
         matplotlib.use("Agg")
         import matplotlib.pyplot as plt
-
         fig, ax = plt.subplots(figsize=(max(8, numeric.shape[1]), max(6, numeric.shape[1] * 0.8)))
         im = ax.imshow(corr.values, cmap="RdBu_r", vmin=-1, vmax=1, aspect="auto")
         ax.set_xticks(range(len(corr.columns)))
@@ -95,16 +106,16 @@ def _plot_correlation_matrix(**kwargs) -> dict:
         ax.set_xticklabels(corr.columns, rotation=45, ha="right", fontsize=8)
         ax.set_yticklabels(corr.columns, fontsize=8)
         fig.colorbar(im)
-        ax.set_title(f"Correlation Matrix \u2014 {dataset_name}")
+        ax.set_title(f"Correlation Matrix — {dataset_name}")
         fig.tight_layout()
         fig.savefig(output_path, dpi=150)
         plt.close(fig)
     except ImportError:
-        return {"error": "matplotlib not installed. Install with: pip install matplotlib"}
+        return {"error": "matplotlib not installed"}
     except Exception as e:
         return {"error": str(e)}
 
-    # Return top correlations (excluding self-correlation)
+    # Top correlations excluding self-correlation
     pairs = []
     for i in range(len(corr.columns)):
         for j in range(i + 1, len(corr.columns)):
@@ -118,139 +129,135 @@ def _plot_correlation_matrix(**kwargs) -> dict:
     return {
         "success": True,
         "path": output_path,
+        "kind": "correlation_matrix",
         "dataset_name": dataset_name,
         "n_properties": len(corr.columns),
         "top_correlations": pairs[:10],
     }
 
 
+_DISPATCH = {
+    "materials_comparison":  _kind_materials_comparison,
+    "property_distribution": _kind_property_distribution,
+    "correlation_matrix":    _kind_correlation_matrix,
+}
+
+
+# Internal aliases preserved for tests / skills that import the
+# private helpers directly. Public surface is the unified `plot` tool.
+_plot_materials_comparison = _kind_materials_comparison
+_plot_property_distribution = _kind_property_distribution
+_plot_correlation_matrix = _kind_correlation_matrix
+
+
+def _plot(**kwargs) -> dict:
+    kind = kwargs.pop("kind", None)
+    if not kind:
+        return {
+            "error": f"Missing 'kind'. Valid: {list(_DISPATCH.keys())}",
+            "hint": (
+                "plot(kind='property_distribution', values=[...]) or "
+                "plot(kind='correlation_matrix', dataset_name='alloys')"
+            ),
+        }
+    handler = _DISPATCH.get(kind)
+    if not handler:
+        return {"error": f"Unknown kind '{kind}'. Valid: {list(_DISPATCH.keys())}"}
+    try:
+        return handler(**kwargs)
+    except Exception as e:
+        return {"error": str(e), "kind": kind}
+
+
+# ---------------------------------------------------------------------------
+# Description + schema
+# ---------------------------------------------------------------------------
+
+_DESCRIPTION = (
+    "Generate a PNG plot of materials data. ONE tool, three kinds:\n"
+    "  • kind='materials_comparison' — scatter plot of property_x vs "
+    "property_y across a list of materials. Requires `materials` (list of "
+    "dicts), `property_x`, `property_y`. Use when comparing N materials "
+    "on two properties.\n"
+    "  • kind='property_distribution' — histogram of one property's "
+    "values. Requires `values` (list of numbers). Optional `property_name` "
+    "for labelling. Use to see the spread of one property.\n"
+    "  • kind='correlation_matrix' — heatmap of pairwise correlations "
+    "across numeric columns in a stored dataset. Requires `dataset_name` "
+    "(must already be in the DataStore — use import_dataset first). "
+    "Optional `columns` to restrict to specific fields.\n"
+    "All kinds output a PNG; pass `output_path` to override the default. "
+    "Returns {success, path}. NOT for crystal-structure visualization "
+    "(no 3D viewer here) and NOT for interactive plots."
+)
+
+
+_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "kind": {
+            "type": "string",
+            "enum": list(_DISPATCH.keys()),
+            "description": "Which chart type to render.",
+        },
+        # materials_comparison
+        "materials": {
+            "type": "array",
+            "items": {"type": "object"},
+            "description": "List of material dicts for kind='materials_comparison'.",
+        },
+        "property_x": {
+            "type": "string",
+            "description": "X-axis property name for kind='materials_comparison'.",
+        },
+        "property_y": {
+            "type": "string",
+            "description": "Y-axis property name for kind='materials_comparison'.",
+        },
+        # property_distribution
+        "values": {
+            "type": "array",
+            "items": {"type": "number"},
+            "description": "Numeric values for kind='property_distribution'.",
+        },
+        "property_name": {
+            "type": "string",
+            "description": "Property label for kind='property_distribution'.",
+        },
+        # correlation_matrix
+        "dataset_name": {
+            "type": "string",
+            "description": "DataStore dataset name for kind='correlation_matrix'.",
+        },
+        "columns": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Restrict kind='correlation_matrix' to these columns.",
+        },
+        # shared
+        "output_path": {
+            "type": "string",
+            "description": "Output PNG path. Default depends on kind.",
+        },
+        "title": {
+            "type": "string",
+            "description": "Plot title (kind='materials_comparison').",
+        },
+    },
+    "required": ["kind"],
+    "additionalProperties": False,
+}
+
+
 def create_visualization_tools(registry: ToolRegistry) -> None:
+    """Register the unified `plot` tool (replaces 3 prior tools).
+
+    Function name preserved (`create_visualization_tools`) for
+    bootstrap.py backward-compatibility.
+    """
     registry.register(Tool(
-        name="plot_materials_comparison",
-        description=(
-            "Render a scatter plot showing how a list of candidate "
-            "materials compare on two property axes (X vs Y). Use this "
-            "when the user has specific materials they want to visually "
-            "rank — e.g. 'show me the trade-off between bulk modulus "
-            "and density for these 12 alloys' or 'plot Inconel 718 "
-            "vs CMSX-4 vs Haynes 282 on creep_resistance vs cost'. "
-            "Each material becomes one point; labels are drawn from "
-            "name or formula. NOT for plotting a single property's "
-            "shape across many materials (use `plot_property_distribution` "
-            "for that) and NOT for showing correlations between many "
-            "properties (use `plot_correlation_matrix`). Output is a "
-            "PNG file path."
-        ),
-        input_schema={
-            "type": "object",
-            "properties": {
-                "materials": {
-                    "type": "array",
-                    "items": {"type": "object"},
-                    "description": (
-                        "List of material dicts. Each dict must have the "
-                        "two property keys named in property_x / property_y, "
-                        "plus a 'name' or 'formula' field used as the point label."
-                    ),
-                },
-                "property_x": {
-                    "type": "string",
-                    "description": "Property name plotted on the X axis (must be a key in every material dict).",
-                },
-                "property_y": {
-                    "type": "string",
-                    "description": "Property name plotted on the Y axis.",
-                },
-                "output_path": {
-                    "type": "string",
-                    "description": "Where to save the PNG (defaults to a temp path under ~/.prism/plots/).",
-                },
-                "title": {
-                    "type": "string",
-                    "description": "Optional plot title — defaults to '{property_y} vs {property_x}'.",
-                },
-            },
-            "required": ["materials", "property_x", "property_y"],
-            "additionalProperties": False,
-        },
-        func=_plot_materials_comparison,
-    ))
-    registry.register(Tool(
-        name="plot_property_distribution",
-        description=(
-            "Render a histogram of one property's distribution across a "
-            "set of values. Use this when the user wants to understand "
-            "the SHAPE of a property — 'is the formation energy of these "
-            "candidates centered around zero or skewed?', 'what's the "
-            "spread of band gaps in my dataset?'. Single-property; pass "
-            "the values array directly. NOT for comparing multiple "
-            "materials side-by-side (use `plot_materials_comparison`) "
-            "and NOT for property-vs-property relationships (use "
-            "`plot_correlation_matrix`). Output is a PNG file path."
-        ),
-        input_schema={
-            "type": "object",
-            "properties": {
-                "values": {
-                    "type": "array",
-                    "items": {"type": "number"},
-                    "description": "Numeric values whose distribution will be plotted.",
-                },
-                "property_name": {
-                    "type": "string",
-                    "description": "Name of the property — used as X-axis label.",
-                },
-                "output_path": {
-                    "type": "string",
-                    "description": "Where to save the PNG.",
-                },
-            },
-            "required": ["values"],
-            "additionalProperties": False,
-        },
-        func=_plot_property_distribution,
-    ))
-    registry.register(Tool(
-        name="plot_correlation_matrix",
-        description=(
-            "Render a heatmap showing pairwise Pearson correlations "
-            "between every pair of numeric columns in a stored dataset. "
-            "Use this when the user wants to find which properties "
-            "covary — 'which features matter for predicting bulk "
-            "modulus?', 'show me what's correlated with creep "
-            "resistance in my screening data'. Operates on a dataset "
-            "already in the PRISM DataStore (use `import_dataset` "
-            "first if your data lives in a CSV). Pass `columns` to "
-            "restrict to a subset; default is every numeric column. "
-            "NOT for ad-hoc point clouds (use `plot_materials_comparison`) "
-            "and NOT for one-property shape (use `plot_property_distribution`). "
-            "Output is a PNG file path."
-        ),
-        input_schema={
-            "type": "object",
-            "properties": {
-                "dataset_name": {
-                    "type": "string",
-                    "description": (
-                        "Dataset registered in the PRISM DataStore. "
-                        "Use `import_dataset` first if you need to load a CSV."
-                    ),
-                },
-                "columns": {
-                    "type": "array",
-                    "items": {"type": "string"},
-                    "description": (
-                        "Optional subset of columns. Omit to use every "
-                        "numeric column in the dataset."
-                    ),
-                },
-                "output_path": {
-                    "type": "string",
-                    "description": "Where to save the PNG.",
-                },
-            },
-            "required": ["dataset_name"],
-            "additionalProperties": False,
-        },
-        func=_plot_correlation_matrix,
+        name="plot",
+        description=_DESCRIPTION,
+        input_schema=_SCHEMA,
+        func=_plot,
     ))

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -27,12 +27,12 @@ class TestBuildFullRegistry:
     def test_has_visualization_tools(self):
         registry, _prov, _agents = build_full_registry(enable_mcp=False, enable_plugins=False)
         names = {t.name for t in registry.list_tools()}
-        assert "plot_materials_comparison" in names or "plot_property_distribution" in names
+        assert "plot" in names  # unified tool replaced plot_materials_comparison + plot_property_distribution + plot_correlation_matrix
 
     def test_has_prediction_tools(self):
         registry, _prov, _agents = build_full_registry(enable_mcp=False, enable_plugins=False)
         names = {t.name for t in registry.list_tools()}
-        assert "predict_property" in names or "train_model" in names
+        assert "predict" in names or "train_model" in names  # unified `predict(target=...)` replaces predict_property + predict_structure
 
     def test_has_builtin_skills(self):
         registry, _prov, _agents = build_full_registry(enable_mcp=False, enable_plugins=False)
@@ -78,7 +78,9 @@ class TestBuildFullRegistry:
         assert "review_dataset" in names
 
     def test_has_correlation_matrix_tool(self):
-        """plot_correlation_matrix tool is registered."""
+        """correlation_matrix is now a kind of the unified `plot` tool."""
         registry, _prov, _agents = build_full_registry(enable_mcp=False, enable_plugins=False)
         names = {t.name for t in registry.list_tools()}
-        assert "plot_correlation_matrix" in names
+        assert "plot" in names
+        plot_tool = registry.get("plot")
+        assert "correlation_matrix" in plot_tool.input_schema["properties"]["kind"]["enum"]

--- a/tests/test_materials_discovery_flow.py
+++ b/tests/test_materials_discovery_flow.py
@@ -71,10 +71,14 @@ class TestMaterialsDiscoveryFlow:
     # ── Step 4: Prediction tool handles missing model gracefully ───
 
     def test_step4_predict_graceful_when_no_model(self):
-        """predict_property should return an error, not crash, when no model."""
-        from app.tools.prediction import _predict_property
+        """predict(target='formula') should return an error, not crash, when no model.
 
-        result = _predict_property(formula="TiAl", target_property="band_gap")
+        After Round 4 batch 2: predict_property/predict_structure were
+        collapsed into the unified `predict(target=…)` tool.
+        """
+        from app.tools.prediction import _predict
+
+        result = _predict(target="formula", formula="TiAl", property_name="band_gap")
         # Should return an error dict, not raise
         assert isinstance(result, dict)
         assert "error" in result
@@ -134,11 +138,12 @@ class TestMaterialsDiscoveryFlow:
         reg, _, _ = build_full_registry(enable_mcp=False, enable_plugins=False)
         tool_names = {t.name for t in reg.list_tools()}
 
+        # Note: predict_property + predict_structure were collapsed in
+        # Round 4 batch 2 into the unified `predict(target=…)` tool.
         required = [
             "search_materials",
             "query_materials_project",
-            "predict_property",
-            "predict_structure",
+            "predict",
             "list_models",
             "export_results_csv",
             "import_dataset",

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -25,7 +25,8 @@ class TestMCPServer:
         assert "search_materials" in tool_names
         assert "query_materials_project" in tool_names
         assert "export_results_csv" in tool_names
-        assert "predict_property" in tool_names
+        # `predict_property` was collapsed into the unified `predict(target=...)` tool.
+        assert "predict" in tool_names
         assert "list_models" in tool_names
         assert len(tool_names) >= 10
 
@@ -71,11 +72,11 @@ class TestMCPServer:
                 return {t.name: t.inputSchema for t in tools}
 
         schemas = asyncio.run(run())
-        # predict_property: formula is required, property_name and algorithm are optional
-        predict_schema = schemas["predict_property"]
-        assert "formula" in predict_schema.get("required", [])
-        assert "property_name" not in predict_schema.get("required", [])
-        assert predict_schema["properties"]["property_name"]["default"] is None
+        # Unified `predict` tool: target is required; formula/property_name/etc.
+        # are optional (validated by the dispatcher per-target).
+        predict_schema = schemas["predict"]
+        assert "target" in predict_schema.get("required", [])
+        assert "formula" not in predict_schema.get("required", [])
 
     def test_tools_resource_returns_json(self):
         server = create_mcp_server()

--- a/tests/test_ml_features.py
+++ b/tests/test_ml_features.py
@@ -140,14 +140,22 @@ class TestAlgorithmRegistry:
 
 
 class TestPredictStructureTool:
-    def test_tool_registered(self):
+    """After Round 4 batch 2: predict_property + predict_structure were
+    collapsed into a unified `predict(target='formula'|'structure')` tool.
+    """
+
+    def test_unified_predict_tool_registered(self):
         from app.tools.base import ToolRegistry
         from app.tools.prediction import create_prediction_tools
         reg = ToolRegistry()
         create_prediction_tools(reg)
-        tool = reg.get("predict_structure")
-        assert tool.name == "predict_structure"
-        assert "structure" in tool.input_schema["required"]
+        tool = reg.get("predict")
+        assert tool.name == "predict"
+        # target is required; both formula + structure modes are advertised
+        assert "target" in tool.input_schema["required"]
+        targets = tool.input_schema["properties"]["target"]["enum"]
+        assert "structure" in targets
+        assert "formula" in targets
 
     def test_list_models_includes_pretrained(self):
         from app.tools.base import ToolRegistry
@@ -159,10 +167,13 @@ class TestPredictStructureTool:
         assert "pretrained_models" in result
         assert "feature_backend" in result
 
-    def test_predict_structure_in_bootstrap(self):
+    def test_predict_in_bootstrap(self):
         from app.plugins.bootstrap import build_full_registry
         tool_reg, _, _ = build_full_registry(enable_mcp=False, enable_plugins=False)
         names = {t.name for t in tool_reg.list_tools()}
-        assert "predict_structure" in names
-        assert "predict_property" in names
+        # Unified `predict` replaces predict_property + predict_structure
+        assert "predict" in names
         assert "list_models" in names
+        # Old names must be gone
+        assert "predict_property" not in names
+        assert "predict_structure" not in names

--- a/tests/test_tools_prediction.py
+++ b/tests/test_tools_prediction.py
@@ -1,4 +1,9 @@
-"""Tests for prediction agent tools."""
+"""Tests for prediction agent tools.
+
+After Round 4 batch 2: `predict_property` and `predict_structure` were
+collapsed into a single `predict(target=…)` tool. `list_models` stays
+separate (different abstraction — registry inspection, not prediction).
+"""
 import pytest
 from app.tools.prediction import create_prediction_tools
 from app.tools.base import ToolRegistry
@@ -9,16 +14,62 @@ class TestPredictionTools:
         registry = ToolRegistry()
         create_prediction_tools(registry)
         names = [t.name for t in registry.list_tools()]
-        assert "predict_property" in names
+        # Unified predict tool replaces predict_property + predict_structure
+        assert "predict" in names
         assert "list_models" in names
+        # Old names must be gone — collapse, no aliases
+        assert "predict_property" not in names
+        assert "predict_structure" not in names
 
-    def test_predict_no_model(self):
+    def test_predict_target_formula(self):
+        """target='formula' calls into the composition-based predictor."""
         registry = ToolRegistry()
         create_prediction_tools(registry)
-        tool = registry.get("predict_property")
-        result = tool.execute(formula="Si", property_name="band_gap")
-        # Should return error since no model is trained in default models/ dir
-        assert "error" in result or "prediction" in result
+        tool = registry.get("predict")
+        result = tool.execute(target="formula", formula="Si", property_name="band_gap")
+        # No trained models in default models/ dir → error path; but the
+        # dispatch must have routed correctly (no "Missing 'target'" or
+        # "Unknown target" errors).
+        if "error" in result:
+            err = result["error"]
+            assert "Missing 'target'" not in err
+            assert "Unknown target" not in err
+            assert "requires `formula`" not in err  # we DID supply formula
+        else:
+            assert "prediction" in result or "predicted_value" in result
+
+    def test_predict_target_structure_requires_dict(self):
+        registry = ToolRegistry()
+        create_prediction_tools(registry)
+        tool = registry.get("predict")
+        # No structure → clear validation error
+        result = tool.execute(target="structure")
+        assert "error" in result
+        assert "requires `structure` dict" in result["error"]
+
+    def test_predict_missing_target(self):
+        registry = ToolRegistry()
+        create_prediction_tools(registry)
+        tool = registry.get("predict")
+        result = tool.execute()
+        assert "error" in result
+        assert "Missing 'target'" in result["error"]
+
+    def test_predict_unknown_target(self):
+        registry = ToolRegistry()
+        create_prediction_tools(registry)
+        tool = registry.get("predict")
+        result = tool.execute(target="bogus_target")
+        assert "error" in result
+        assert "Unknown target" in result["error"]
+
+    def test_predict_target_formula_requires_formula(self):
+        registry = ToolRegistry()
+        create_prediction_tools(registry)
+        tool = registry.get("predict")
+        result = tool.execute(target="formula")
+        assert "error" in result
+        assert "requires `formula`" in result["error"]
 
     def test_list_models(self):
         registry = ToolRegistry()
@@ -28,3 +79,11 @@ class TestPredictionTools:
         assert "trained_models" in result
         assert "pretrained_models" in result
         assert "feature_backend" in result
+
+    def test_predict_schema_advertises_two_targets(self):
+        """The action enum must be 'formula' and 'structure'."""
+        registry = ToolRegistry()
+        create_prediction_tools(registry)
+        tool = registry.get("predict")
+        targets = tool.input_schema["properties"]["target"]["enum"]
+        assert set(targets) == {"formula", "structure"}

--- a/tests/test_tools_system.py
+++ b/tests/test_tools_system.py
@@ -1,4 +1,9 @@
-"""Tests for system tools."""
+"""Tests for system tools.
+
+After Round 4 batch 2: `read_file`, `write_file`, and `edit_file` were
+collapsed into a single `file(action=…)` tool. The sandbox enforcement
+(_is_safe_path / _ALLOWED_BASE) is unchanged.
+"""
 import pytest
 from unittest.mock import patch
 from pathlib import Path
@@ -11,96 +16,144 @@ class TestSystemTools:
         registry = ToolRegistry()
         create_system_tools(registry)
         names = [t.name for t in registry.list_tools()]
+        # web_search and show_scratchpad still standalone
         assert "web_search" in names
-        assert "read_file" in names
-        assert "write_file" in names
-        assert "edit_file" in names
+        # Unified file tool replaced read_file/write_file/edit_file
+        assert "file" in names
+        assert "read_file" not in names
+        assert "write_file" not in names
+        assert "edit_file" not in names
 
-    def test_read_file_tool(self, tmp_path):
+    def test_action_enum_advertises_three_actions(self):
+        registry = ToolRegistry()
+        create_system_tools(registry)
+        tool = registry.get("file")
+        actions = tool.input_schema["properties"]["action"]["enum"]
+        assert set(actions) == {"read", "write", "edit"}
+
+    def test_missing_action(self):
+        registry = ToolRegistry()
+        create_system_tools(registry)
+        tool = registry.get("file")
+        result = tool.execute()
+        assert "error" in result and "Missing 'action'" in result["error"]
+
+    def test_unknown_action(self):
+        registry = ToolRegistry()
+        create_system_tools(registry)
+        tool = registry.get("file")
+        result = tool.execute(action="bogus")
+        assert "error" in result and "Unknown action" in result["error"]
+
+    def test_read_action(self, tmp_path):
         registry = ToolRegistry()
         create_system_tools(registry)
         f = tmp_path / "test.txt"
         f.write_text("hello world")
-        tool = registry.get("read_file")
-        # Patch allowed base to tmp_path for testing
+        tool = registry.get("file")
         with patch("app.tools.system._ALLOWED_BASE", tmp_path.resolve()):
-            result = tool.execute(path=str(f))
+            result = tool.execute(action="read", path=str(f))
         assert result["content"] == "hello world"
         assert result["path"] == str(f.resolve())
         assert result["size_bytes"] == len("hello world".encode("utf-8"))
 
+    def test_read_requires_path(self):
+        registry = ToolRegistry()
+        create_system_tools(registry)
+        tool = registry.get("file")
+        result = tool.execute(action="read")
+        assert "error" in result
+        assert "requires `path`" in result["error"]
+
     def test_read_file_not_found(self):
         registry = ToolRegistry()
         create_system_tools(registry)
-        tool = registry.get("read_file")
-        result = tool.execute(path="/nonexistent/path.txt")
+        tool = registry.get("file")
+        result = tool.execute(action="read", path="/nonexistent/path.txt")
         assert "error" in result
 
-    def test_write_file_tool(self, tmp_path):
+    def test_write_action(self, tmp_path):
         registry = ToolRegistry()
         create_system_tools(registry)
         f = tmp_path / "out.txt"
-        tool = registry.get("write_file")
+        tool = registry.get("file")
         with patch("app.tools.system._ALLOWED_BASE", tmp_path.resolve()):
-            result = tool.execute(path=str(f), content="written by prism")
+            result = tool.execute(
+                action="write", path=str(f), content="written by prism",
+            )
         assert result["success"] is True
         assert result["path"] == str(f.resolve())
         assert result["size_bytes"] == len("written by prism".encode("utf-8"))
         assert f.read_text() == "written by prism"
 
-    def test_edit_file_tool(self, tmp_path):
+    def test_write_requires_path_and_content(self):
+        registry = ToolRegistry()
+        create_system_tools(registry)
+        tool = registry.get("file")
+        result = tool.execute(action="write")
+        assert "error" in result and "requires `path`" in result["error"]
+        result = tool.execute(action="write", path="/x")
+        assert "error" in result and "requires `content`" in result["error"]
+
+    def test_edit_action(self, tmp_path):
         registry = ToolRegistry()
         create_system_tools(registry)
         f = tmp_path / "edit.txt"
         f.write_text("hello world")
-        tool = registry.get("edit_file")
+        tool = registry.get("file")
         with patch("app.tools.system._ALLOWED_BASE", tmp_path.resolve()):
             result = tool.execute(
-                path=str(f),
-                old_text="world",
-                new_text="prism",
+                action="edit", path=str(f),
+                old_text="world", new_text="prism",
             )
         assert result["success"] is True
         assert result["path"] == str(f.resolve())
         assert result["replacements"] == 1
         assert f.read_text() == "hello prism"
 
-    def test_edit_file_multiple_matches_requires_replace_all(self, tmp_path):
+    def test_edit_requires_path_old_new(self):
+        registry = ToolRegistry()
+        create_system_tools(registry)
+        tool = registry.get("file")
+        result = tool.execute(action="edit")
+        assert "error" in result and "requires `path`" in result["error"]
+        result = tool.execute(action="edit", path="/x")
+        assert "error" in result and "requires `old_text` and `new_text`" in result["error"]
+
+    def test_edit_multiple_matches_requires_replace_all(self, tmp_path):
         registry = ToolRegistry()
         create_system_tools(registry)
         f = tmp_path / "edit-many.txt"
         f.write_text("x\nx\n")
-        tool = registry.get("edit_file")
+        tool = registry.get("file")
         with patch("app.tools.system._ALLOWED_BASE", tmp_path.resolve()):
             result = tool.execute(
-                path=str(f),
-                old_text="x",
-                new_text="y",
+                action="edit", path=str(f),
+                old_text="x", new_text="y",
             )
         assert "error" in result
         assert "multiple locations" in result["error"]
         assert result["match_count"] == 2
 
-    def test_read_file_path_traversal_blocked(self, tmp_path):
+    def test_read_path_traversal_blocked(self, tmp_path):
         """Prevent reading files outside allowed directory."""
         registry = ToolRegistry()
         create_system_tools(registry)
-        # Create a file outside the allowed base
         outside = tmp_path / "sensitive.txt"
         outside.write_text("SECRET")
-        tool = registry.get("read_file")
-        # Allowed base is cwd, not tmp_path
-        result = tool.execute(path=str(outside))
+        tool = registry.get("file")
+        # Allowed base is cwd, not tmp_path → outside should be denied
+        result = tool.execute(action="read", path=str(outside))
         assert "error" in result
         assert "Access denied" in result["error"]
 
-    def test_write_file_path_traversal_blocked(self, tmp_path):
+    def test_write_path_traversal_blocked(self, tmp_path):
         """Prevent writing files outside allowed directory."""
         registry = ToolRegistry()
         create_system_tools(registry)
         outside = tmp_path / "malicious.txt"
-        tool = registry.get("write_file")
-        result = tool.execute(path=str(outside), content="MALWARE")
+        tool = registry.get("file")
+        result = tool.execute(action="write", path=str(outside), content="MALWARE")
         assert "error" in result
         assert "Access denied" in result["error"]
 

--- a/tests/test_tools_viz.py
+++ b/tests/test_tools_viz.py
@@ -1,29 +1,98 @@
-"""Tests for visualization tools."""
+"""Tests for visualization tools.
+
+After Round 4 batch 2: `plot_materials_comparison`, `plot_property_distribution`,
+and `plot_correlation_matrix` were collapsed into a single `plot(kind=…)` tool.
+"""
 import pytest
 from app.tools.visualization import create_visualization_tools
 from app.tools.base import ToolRegistry
 
 
 class TestVisualizationTools:
-    def test_tools_registered(self):
+    def test_tool_registered(self):
         registry = ToolRegistry()
         create_visualization_tools(registry)
         names = [t.name for t in registry.list_tools()]
-        assert "plot_materials_comparison" in names
-        assert "plot_property_distribution" in names
+        # Unified plot tool replaces the 3 plot_* tools
+        assert "plot" in names
+        # Old names must be gone
+        assert "plot_materials_comparison" not in names
+        assert "plot_property_distribution" not in names
+        assert "plot_correlation_matrix" not in names
+
+    def test_kind_enum(self):
+        registry = ToolRegistry()
+        create_visualization_tools(registry)
+        tool = registry.get("plot")
+        kinds = tool.input_schema["properties"]["kind"]["enum"]
+        assert set(kinds) == {
+            "materials_comparison",
+            "property_distribution",
+            "correlation_matrix",
+        }
 
     def test_comparison_plot(self, tmp_path):
         registry = ToolRegistry()
         create_visualization_tools(registry)
-        tool = registry.get("plot_materials_comparison")
+        tool = registry.get("plot")
         result = tool.execute(
-            materials=[{"name": "Si", "band_gap": 1.1, "formation_energy": -0.5}, {"name": "Ge", "band_gap": 0.67, "formation_energy": -0.3}],
-            property_x="band_gap", property_y="formation_energy", output_path=str(tmp_path / "comparison.png"))
+            kind="materials_comparison",
+            materials=[
+                {"name": "Si", "band_gap": 1.1, "formation_energy": -0.5},
+                {"name": "Ge", "band_gap": 0.67, "formation_energy": -0.3},
+            ],
+            property_x="band_gap",
+            property_y="formation_energy",
+            output_path=str(tmp_path / "comparison.png"),
+        )
+        # Either it rendered successfully, OR matplotlib is missing — both fine
         assert result.get("success") is True or "error" in result
 
     def test_distribution_plot(self, tmp_path):
         registry = ToolRegistry()
         create_visualization_tools(registry)
-        tool = registry.get("plot_property_distribution")
-        result = tool.execute(values=[1.1, 2.3, 0.5, 1.8, 3.2], property_name="band_gap", output_path=str(tmp_path / "dist.png"))
+        tool = registry.get("plot")
+        result = tool.execute(
+            kind="property_distribution",
+            values=[1.1, 2.3, 0.5, 1.8, 3.2],
+            property_name="band_gap",
+            output_path=str(tmp_path / "dist.png"),
+        )
         assert result.get("success") is True or "error" in result
+
+    def test_missing_kind_returns_clear_error(self):
+        registry = ToolRegistry()
+        create_visualization_tools(registry)
+        tool = registry.get("plot")
+        result = tool.execute()
+        assert "error" in result
+        assert "Missing 'kind'" in result["error"]
+
+    def test_unknown_kind_returns_clear_error(self):
+        registry = ToolRegistry()
+        create_visualization_tools(registry)
+        tool = registry.get("plot")
+        result = tool.execute(kind="bogus_kind")
+        assert "error" in result
+        assert "Unknown kind" in result["error"]
+
+    def test_kind_specific_arg_validation(self):
+        """Each kind validates its required args before doing matplotlib work."""
+        registry = ToolRegistry()
+        create_visualization_tools(registry)
+        tool = registry.get("plot")
+
+        # materials_comparison without materials/property_x/property_y
+        r = tool.execute(kind="materials_comparison")
+        assert "error" in r
+        assert "materials" in r["error"]
+
+        # property_distribution without values
+        r = tool.execute(kind="property_distribution")
+        assert "error" in r
+        assert "`values`" in r["error"]
+
+        # correlation_matrix without dataset_name
+        r = tool.execute(kind="correlation_matrix")
+        assert "error" in r
+        assert "`dataset_name`" in r["error"]


### PR DESCRIPTION
## Summary

Continuation of [PR #13](https://github.com/Darth-Hidious/PRISM/pull/13)'s tool collapse. This batch handles the three clusters whose tests reference tool names directly, requiring coordinated test updates.

| Cluster | Was | Now |
|---|---|---|
| predict | 2 (`predict_property`, `predict_structure`) | `predict(target='formula'\|'structure')` |
| plot | 3 (`plot_materials_comparison`, `plot_property_distribution`, `plot_correlation_matrix`) | `plot(kind=…)` |
| file | 3 (`read_file`, `write_file`, `edit_file`) | `file(action='read'\|'write'\|'edit')` |

**Net surface: 8 → 3 (–5)**

Combined with PR #13: **25 sibling tools → 6 unified, –19 net** for Stage 2.1 retrieval.

`list_models` and the `predict_properties` Skill stay separate — different abstractions. Internal `_plot_*` aliases preserved for tests/skills that import the private helpers. Sandbox enforcement on `file` is unchanged.

## Test plan

- [x] `test_tools_prediction.py` (3 → 8 tests)
- [x] `test_tools_viz.py` (2 → 7 tests)
- [x] `test_tools_system.py` (11 → 16 tests)
- [x] `test_bootstrap.py` and `test_mcp_server.py` updated for unified tool names
- [x] `test_visualization_correlation.py` + `test_skill_visualization.py` unchanged (use preserved private aliases)
- [x] **78/78 targeted tests pass**
- [x] Pre-existing failures (`test_mcp_roundtrip::test_read_resources_via_client`, `test_llm.py` import) verified to fail on plain main without these changes

## Ordering with other open work

- This branch is off `main` (commit `fcb9538`).
- [PR #13](https://github.com/Darth-Hidious/PRISM/pull/13) is also off main and green; the two batches don't touch the same files and rebase cleanly.
- **Land #13 first; this PR rebases against it before merge.**
- The stateful memory branch (`round4/stateful-memory`) is independent and goes through its own review cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor

* Consolidated prediction tools into a unified interface; use `target` parameter to specify formula or structure prediction
* Merged file operation tools into a single tool; use `action` parameter for read, write, or edit operations
* Unified visualization tools into one plot tool; use `kind` parameter to select plot type (comparison, distribution, or correlation matrix)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->