### PR TITLE
research(): wire MARC27 RLM engine — monetization-critical tool

### DIFF
--- a/app/plugins/bootstrap.py
+++ b/app/plugins/bootstrap.py
@@ -50,6 +50,15 @@ def build_full_registry(
     except Exception:
         pass
 
+    # MARC27 RLM Research tool — server-side recursive LLM that explores
+    # the knowledge graph + vector store + academic web. Real-money tool.
+    # See app/tools/research.py for the SSE protocol + cost notes.
+    try:
+        from app.tools.research import create_research_tools
+        create_research_tools(registry)
+    except Exception:
+        pass
+
     # MARC27 Compute Broker tools (GPU dispatch, job management)
     try:
         from app.tools.compute import create_compute_tools

--- a/app/tools/research.py
+++ b/app/tools/research.py
@@ -1,0 +1,392 @@
+"""Research tool — wraps the MARC27 RLM research engine.
+
+POST /api/v1/knowledge/research/query is a server-side Recursive Language
+Model implementation (arxiv:2512.24601v2). The server's research engine
+runs its OWN LLM in a Python REPL, recursively decomposing the question,
+querying graph + vector + web sources, and streaming SSE events back.
+
+Two LLMs at different abstraction levels:
+
+    User → [chat LLM] decides "I'll call research(...)"
+                 ↓
+                 HTTP → [server LLM] runs the recursive REPL loop
+                          ↓
+                 SSE ← progress events + final answer
+                 ↓
+            [chat LLM] receives one structured result and continues
+
+The chat LLM never recurses; the server-side LLM does. This tool's
+job is to (a) submit the question, (b) consume the SSE stream, (c)
+return a clean structured result, and (d) cost-cap the request via
+the harness approval gate (it's a money-spending action).
+
+Server-side persistence: every completed session is written to the
+`research_sessions` Postgres table with full provenance (steps, tenant,
+cost, metrics) AND the answer is auto-embedded into the vector store
+under doc_id `research-session-{uuid}`. So future agents in any session
+can find this answer via `knowledge(action='semantic')` or `recall()`.
+
+See docs/stateful_tools_2026.md for the broader stateful architecture.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Optional
+
+from app.tools.base import Tool, ToolRegistry
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# SSE event handling
+# ---------------------------------------------------------------------------
+
+# Events emitted by the server's research engine. We surface a curated
+# subset to the user via the progress log; the rest are silent.
+_USER_VISIBLE_STEPS: frozenset[str] = frozenset({
+    "started",
+    "decompose",
+    "sub_session_start",
+    "sub_session_complete",
+    "answer",
+    "complete",
+    "error",
+})
+
+
+def _format_progress_line(step: str, data: dict) -> str:
+    """One-liner suitable for streaming back to the agent's scratchpad."""
+    if step == "started":
+        sid = data.get("session_id", "?")
+        q = data.get("question", "")
+        return f"[research started] session={sid[:12]} question={q[:80]}"
+    if step == "decompose":
+        return f"[research decompose] {data.get('reason', '')[:120]}"
+    if step == "sub_session_start":
+        sub_q = data.get("sub_query", data.get("question", ""))
+        return f"[research sub-session] {sub_q[:120]}"
+    if step == "sub_session_complete":
+        return f"[research sub-session done] cost=${data.get('cost_usd', 0):.4f}"
+    if step == "answer":
+        text = data.get("text", "")
+        turns = data.get("turns", "?")
+        return f"[research answer ready] {turns} turns, {len(text)} chars"
+    if step == "complete":
+        return f"[research complete] session={data.get('session_id', '?')[:12]}"
+    if step == "error":
+        return f"[research error] {data.get('message', '')[:200]}"
+    return f"[research {step}]"
+
+
+def _parse_sse_line(line: str) -> Optional[dict]:
+    """Parse one `data: {...}` line. Returns None for keepalives / empty."""
+    line = line.strip()
+    if not line or not line.startswith("data:"):
+        return None
+    payload = line[len("data:"):].strip()
+    if not payload or payload == "[DONE]":
+        return None
+    try:
+        return json.loads(payload)
+    except json.JSONDecodeError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Implementation
+# ---------------------------------------------------------------------------
+
+def _research(**kwargs) -> dict:
+    """Run a research-mode query against the MARC27 RLM engine.
+
+    Args:
+        question (str, required): Natural-language research question.
+        depth (int, optional, default=1): Recursion depth.
+            0 = local sources only, 1+ = web search + sub-session decomposition.
+            The server caps at MAX_RESEARCH_DEPTH (default 10).
+        timeout_seconds (int, optional, default=600): SSE stream timeout.
+            Long research sessions can take 5–10 minutes legitimately.
+
+    Returns:
+        Either a result dict with the structure documented below, or an
+        error dict with `error` key. Storage failure (ingest log unable
+        to persist on the server) does not block the answer return.
+
+        Result shape:
+          {
+            "session_id": "<uuid>",
+            "answer": "<full text>",
+            "cost_usd": <float>,
+            "turns": <int>,
+            "metrics": {
+                "graph_queries": <int>,
+                "vector_queries": <int>,
+                "web_searches": <int>,
+                "papers_fetched": <int>,
+                "papers_ingested": <int>,
+                "entities_created": <int>,
+                "embeddings_created": <int>,
+                "llm_calls": <int>,
+            },
+            "progress_log": ["...", "...", ...],   # high-level steps only
+            "source": "marc27_research_rlm",
+          }
+    """
+    question = kwargs.get("question")
+    if not question or not question.strip():
+        return {"error": "`question` is required"}
+
+    depth = int(kwargs.get("depth", 1))
+    if depth < 0:
+        return {"error": "`depth` must be >= 0"}
+    if depth > 10:
+        # Server enforces this anyway; rejecting client-side gives a clearer error
+        return {"error": "`depth` cannot exceed 10 (server max)"}
+
+    timeout_seconds = int(kwargs.get("timeout_seconds", 600))
+
+    # ---------------------- HTTP call setup ----------------------
+    api_url, api_key = _resolve_credentials()
+    if not api_key:
+        return {
+            "error": (
+                "MARC27 platform not connected. Run `prism login` or set "
+                "MARC27_API_KEY before calling research()."
+            )
+        }
+
+    try:
+        import requests
+    except ImportError:
+        return {"error": "requests library not available"}
+
+    url = f"{api_url}/knowledge/research/query"
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Accept": "text/event-stream",
+        "Content-Type": "application/json",
+    }
+    body = {"question": question, "depth": depth}
+
+    progress: list[str] = []
+    session_id: Optional[str] = None
+    answer: Optional[str] = None
+    turns: Optional[int] = None
+    final_metrics: Optional[dict] = None
+    error_message: Optional[str] = None
+
+    try:
+        # stream=True keeps the connection open for SSE
+        resp = requests.post(
+            url,
+            headers=headers,
+            json=body,
+            stream=True,
+            timeout=(30, timeout_seconds),  # (connect, read)
+        )
+    except requests.exceptions.RequestException as e:
+        return {"error": f"failed to reach research endpoint: {e}"}
+
+    if resp.status_code != 200:
+        try:
+            err_body = resp.text[:500]
+        except Exception:
+            err_body = "<unreadable>"
+        return {
+            "error": (
+                f"research endpoint returned HTTP {resp.status_code}: {err_body}"
+            )
+        }
+
+    # ---------------------- Consume the SSE stream ----------------------
+    try:
+        for raw_line in resp.iter_lines(decode_unicode=True):
+            if raw_line is None:
+                continue
+            event = _parse_sse_line(raw_line)
+            if event is None:
+                continue
+
+            step = event.get("step")
+            data = event.get("data") or {}
+
+            if step in _USER_VISIBLE_STEPS:
+                progress.append(_format_progress_line(step, data))
+
+            if step == "started":
+                session_id = data.get("session_id")
+            elif step == "answer":
+                answer = data.get("text")
+                turns = data.get("turns")
+            elif step == "complete":
+                # Final metrics summary
+                if "metrics" in data:
+                    final_metrics = data["metrics"]
+                if not session_id and "session_id" in data:
+                    session_id = data["session_id"]
+                # The server has finished; no more events expected
+                break
+            elif step == "error":
+                error_message = data.get("message", "research session failed")
+                break
+    except requests.exceptions.RequestException as e:
+        return {
+            "error": f"SSE stream interrupted: {e}",
+            "session_id": session_id,
+            "partial_progress": progress,
+        }
+    finally:
+        try:
+            resp.close()
+        except Exception:
+            pass
+
+    if error_message:
+        return {
+            "error": error_message,
+            "session_id": session_id,
+            "progress_log": progress,
+        }
+
+    if answer is None:
+        return {
+            "error": "research session ended without producing an answer",
+            "session_id": session_id,
+            "progress_log": progress,
+        }
+
+    cost_usd = 0.0
+    if final_metrics and "cost_usd" in final_metrics:
+        cost_usd = float(final_metrics["cost_usd"])
+    elif "cost_usd" in (final_metrics or {}):
+        cost_usd = float(final_metrics["cost_usd"])
+
+    return {
+        "session_id": session_id,
+        "answer": answer,
+        "cost_usd": cost_usd,
+        "turns": turns,
+        "metrics": final_metrics or {},
+        "progress_log": progress,
+        "source": "marc27_research_rlm",
+    }
+
+
+def _resolve_credentials() -> tuple[str, str]:
+    """Return (api_url, api_key). Reads MARC27_API_KEY env or ~/.prism/credentials.json."""
+    api_url = os.environ.get(
+        "MARC27_API_URL", "https://api.marc27.com/api/v1"
+    ).rstrip("/")
+    api_key = os.environ.get("MARC27_API_KEY", "")
+
+    if not api_key:
+        # Try ~/.prism/credentials.json (the prism login output)
+        try:
+            from pathlib import Path
+            creds_path = Path.home() / ".prism" / "credentials.json"
+            if creds_path.exists():
+                creds = json.loads(creds_path.read_text())
+                api_key = creds.get("access_token", "")
+                # Override URL if credentials say so
+                if creds.get("platform_url"):
+                    api_url = creds["platform_url"].rstrip("/")
+                    # platform_url might be the bare host; ensure /api/v1 suffix
+                    if not api_url.endswith("/api/v1"):
+                        api_url = api_url + "/api/v1"
+        except Exception:
+            pass
+
+    return api_url, api_key
+
+
+# ---------------------------------------------------------------------------
+# Tool description + schema
+# ---------------------------------------------------------------------------
+
+_DESCRIPTION = (
+    "Run a deep research query against the MARC27 RLM (Recursive Language "
+    "Model) engine. ONE call dispatches a server-side specialist LLM that "
+    "recursively explores the knowledge graph + 6K+ embedded documents + "
+    "academic web (Semantic Scholar / arXiv / PubMed / OpenAlex), writing "
+    "Python code in a sandboxed REPL to slice, filter, and summarize "
+    "evidence. Returns a structured answer with provenance.\n"
+    "\n"
+    "WHEN TO USE THIS over knowledge(action='search') or web_search:\n"
+    "  • Question is OPEN-ENDED and requires synthesis ('compare creep "
+    "performance of nickel superalloys for turbine blades').\n"
+    "  • Answer requires combining literature + structured data + reasoning.\n"
+    "  • The user wants a written report, not a list of hits.\n"
+    "\n"
+    "When NOT to use it:\n"
+    "  • Single-fact lookup → use knowledge(action='entity') or web_search.\n"
+    "  • Structure search by formula/elements → use materials_search.\n"
+    "  • Already in the agent's recent context → use recall().\n"
+    "\n"
+    "COST: REAL-MONEY ACTION. Each call runs a server LLM for several "
+    "turns; cost typically ~$0.01–$2 depending on `depth`. Results stream "
+    "back as SSE; the call blocks until completion (5 sec to 10 min).\n"
+    "\n"
+    "Result is auto-persisted server-side (research_sessions Postgres "
+    "row + answer auto-embedded) and locally as an artifact, so future "
+    "agents can recall it without re-running."
+)
+
+_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "question": {
+            "type": "string",
+            "description": (
+                "Natural-language research question. Be specific — the "
+                "RLM produces better answers from concrete questions "
+                "('what alloy systems show solid-solution strengthening "
+                "above 1000°C?') than vague ones ('alloys?')."
+            ),
+        },
+        "depth": {
+            "type": "integer",
+            "default": 1,
+            "minimum": 0,
+            "maximum": 10,
+            "description": (
+                "Recursion depth budget. 0 = local KB only (cheap, fast). "
+                "1 (default) = local + web search. 2+ = sub-session "
+                "decomposition for hard multi-part questions. Each "
+                "additional level multiplies cost ~3-5x."
+            ),
+        },
+        "timeout_seconds": {
+            "type": "integer",
+            "default": 600,
+            "minimum": 30,
+            "maximum": 1800,
+            "description": (
+                "How long to wait for the SSE stream before giving up. "
+                "Default 10 minutes. Deep sessions (depth 2+) may need "
+                "the full 30-minute cap."
+            ),
+        },
+    },
+    "required": ["question"],
+    "additionalProperties": False,
+}
+
+
+def create_research_tools(registry: ToolRegistry) -> None:
+    """Register the `research` tool.
+
+    `requires_approval=True` because this is a real-money action — every
+    call spends server LLM budget. The harness must show the user
+    "agent wants to run research(question='…', depth=2). Approve?"
+    before each invocation.
+    """
+    registry.register(Tool(
+        name="research",
+        description=_DESCRIPTION,
+        input_schema=_SCHEMA,
+        func=_research,
+        requires_approval=True,
+    ))

--- a/tests/test_research_tool.py
+++ b/tests/test_research_tool.py
@@ -1,0 +1,325 @@
+"""Tests for the research() tool.
+
+The real /api/v1/knowledge/research/query endpoint costs real money per
+call ($0.01–$2 each). All tests here use a mocked SSE stream. A live
+integration test is gated by the env var PRISM_LIVE_RESEARCH_TEST=1
+so CI never accidentally spends.
+"""
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.tools.base import ToolRegistry
+from app.tools.research import (
+    create_research_tools,
+    _format_progress_line,
+    _parse_sse_line,
+    _research,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — fake SSE stream
+# ---------------------------------------------------------------------------
+
+def _sse_lines_from_events(events: list[dict]) -> list[str]:
+    """Format a list of {step, data} events as SSE `data: ...` lines."""
+    lines = []
+    for ev in events:
+        lines.append(f"data: {json.dumps(ev)}")
+        lines.append("")  # blank line separates events
+    return lines
+
+
+def _make_mock_response(status_code: int, sse_events: list[dict]):
+    """Build a requests.Response stand-in that yields SSE lines."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.iter_lines = MagicMock(return_value=iter(_sse_lines_from_events(sse_events)))
+    resp.text = ""
+    resp.close = MagicMock()
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+class TestRegistration:
+    def test_tool_registered(self):
+        reg = ToolRegistry()
+        create_research_tools(reg)
+        names = [t.name for t in reg.list_tools()]
+        assert "research" in names
+
+    def test_requires_approval(self):
+        reg = ToolRegistry()
+        create_research_tools(reg)
+        tool = reg.get("research")
+        # Real-money action MUST be gated
+        assert tool.requires_approval is True
+
+    def test_question_is_required_in_schema(self):
+        reg = ToolRegistry()
+        create_research_tools(reg)
+        tool = reg.get("research")
+        assert "question" in tool.input_schema["required"]
+
+    def test_depth_bounds_in_schema(self):
+        reg = ToolRegistry()
+        create_research_tools(reg)
+        tool = reg.get("research")
+        depth = tool.input_schema["properties"]["depth"]
+        assert depth["minimum"] == 0
+        assert depth["maximum"] == 10
+
+
+# ---------------------------------------------------------------------------
+# Argument validation
+# ---------------------------------------------------------------------------
+
+class TestArgValidation:
+    def test_missing_question(self):
+        result = _research()
+        assert "error" in result
+        assert "question" in result["error"]
+
+    def test_empty_question(self):
+        result = _research(question="   ")
+        assert "error" in result
+        assert "question" in result["error"]
+
+    def test_negative_depth(self):
+        result = _research(question="x", depth=-1)
+        assert "error" in result
+        assert "depth" in result["error"]
+
+    def test_excessive_depth(self):
+        result = _research(question="x", depth=99)
+        assert "error" in result
+        assert "depth" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Credentials
+# ---------------------------------------------------------------------------
+
+class TestCredentials:
+    def test_no_credentials_returns_error(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("MARC27_API_KEY", raising=False)
+        # Point credentials.json lookup at an empty home
+        monkeypatch.setenv("HOME", str(tmp_path))
+        result = _research(question="anything")
+        assert "error" in result
+        assert "MARC27" in result["error"] or "platform" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# SSE parsing
+# ---------------------------------------------------------------------------
+
+class TestSSEParsing:
+    def test_parse_data_line(self):
+        ev = _parse_sse_line('data: {"step": "started", "data": {"x": 1}}')
+        assert ev == {"step": "started", "data": {"x": 1}}
+
+    def test_parse_blank_line(self):
+        assert _parse_sse_line("") is None
+
+    def test_parse_done_sentinel(self):
+        assert _parse_sse_line("data: [DONE]") is None
+
+    def test_parse_non_data_line(self):
+        assert _parse_sse_line(":keepalive") is None
+        assert _parse_sse_line("event: anything") is None
+
+    def test_parse_malformed_json(self):
+        assert _parse_sse_line("data: {not json") is None
+
+    def test_format_progress_started(self):
+        out = _format_progress_line("started", {
+            "session_id": "abc-123-uuid", "question": "what is steel?",
+        })
+        assert "research started" in out
+        assert "abc-123-uuid"[:12] in out
+
+    def test_format_progress_answer(self):
+        out = _format_progress_line("answer", {
+            "text": "Steel is...",
+            "turns": 5,
+        })
+        assert "answer ready" in out
+        assert "5 turns" in out
+
+    def test_format_progress_error(self):
+        out = _format_progress_line("error", {"message": "LLM down"})
+        assert "research error" in out
+        assert "LLM down" in out
+
+
+# ---------------------------------------------------------------------------
+# End-to-end with mocked SSE
+# ---------------------------------------------------------------------------
+
+class TestEndToEnd:
+    @patch("app.tools.research._resolve_credentials")
+    @patch("requests.post")
+    def test_happy_path(self, mock_post, mock_creds):
+        """A full research session: started → llm_response → answer → complete."""
+        mock_creds.return_value = ("https://api.marc27.test/api/v1", "test-key")
+
+        events = [
+            {"step": "started", "data": {
+                "session_id": "session-uuid-abc",
+                "question": "test question",
+                "max_depth": 1,
+                "mode": "repl",
+            }},
+            {"step": "reasoning", "data": {"text": "Let me think..."}},
+            {"step": "repl_exec", "data": {"code": "results = graph_search('Ti')"}},
+            {"step": "repl_result", "data": {"output": "[{name: 'Ti'}]"}},
+            {"step": "answer", "data": {
+                "text": "Titanium is an element with atomic number 22.",
+                "turns": 3,
+            }},
+            {"step": "complete", "data": {
+                "session_id": "session-uuid-abc",
+                "metrics": {
+                    "graph_queries": 1,
+                    "vector_queries": 0,
+                    "web_searches": 0,
+                    "papers_fetched": 0,
+                    "papers_ingested": 0,
+                    "entities_created": 0,
+                    "embeddings_created": 0,
+                    "llm_calls": 3,
+                    "cost_usd": 0.0123,
+                },
+            }},
+        ]
+        mock_post.return_value = _make_mock_response(200, events)
+
+        result = _research(question="test question", depth=1)
+
+        assert "error" not in result, f"unexpected error: {result}"
+        assert result["session_id"] == "session-uuid-abc"
+        assert "Titanium" in result["answer"]
+        assert result["turns"] == 3
+        assert result["cost_usd"] == 0.0123
+        assert result["metrics"]["llm_calls"] == 3
+        assert result["source"] == "marc27_research_rlm"
+        # progress_log should include the user-visible steps
+        assert any("research started" in p for p in result["progress_log"])
+        assert any("research complete" in p for p in result["progress_log"])
+
+    @patch("app.tools.research._resolve_credentials")
+    @patch("requests.post")
+    def test_http_error(self, mock_post, mock_creds):
+        mock_creds.return_value = ("https://api.marc27.test/api/v1", "test-key")
+        resp = _make_mock_response(503, [])
+        resp.text = "service unavailable"
+        mock_post.return_value = resp
+
+        result = _research(question="test")
+        assert "error" in result
+        assert "503" in result["error"]
+
+    @patch("app.tools.research._resolve_credentials")
+    @patch("requests.post")
+    def test_server_error_event(self, mock_post, mock_creds):
+        """Server emits {step:'error', data:{message:'...'}} mid-stream."""
+        mock_creds.return_value = ("https://api.marc27.test/api/v1", "test-key")
+        events = [
+            {"step": "started", "data": {"session_id": "s1", "question": "q"}},
+            {"step": "error", "data": {"message": "LLM service unreachable"}},
+        ]
+        mock_post.return_value = _make_mock_response(200, events)
+
+        result = _research(question="anything")
+        assert "error" in result
+        assert "LLM service unreachable" in result["error"]
+        assert result["session_id"] == "s1"
+
+    @patch("app.tools.research._resolve_credentials")
+    @patch("requests.post")
+    def test_no_answer_emitted(self, mock_post, mock_creds):
+        """Stream ends without an `answer` event — should fail cleanly."""
+        mock_creds.return_value = ("https://api.marc27.test/api/v1", "test-key")
+        events = [
+            {"step": "started", "data": {"session_id": "s1", "question": "q"}},
+            {"step": "complete", "data": {"session_id": "s1"}},
+        ]
+        mock_post.return_value = _make_mock_response(200, events)
+
+        result = _research(question="anything")
+        assert "error" in result
+        assert "without producing an answer" in result["error"]
+        assert result["session_id"] == "s1"
+
+    @patch("app.tools.research._resolve_credentials")
+    @patch("requests.post")
+    def test_keepalive_lines_ignored(self, mock_post, mock_creds):
+        """Server may emit `:keepalive` pings — must not break parsing."""
+        mock_creds.return_value = ("https://api.marc27.test/api/v1", "test-key")
+
+        # Mix in keepalive comments and blank lines
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.iter_lines = MagicMock(return_value=iter([
+            ":keepalive",
+            "",
+            f'data: {json.dumps({"step": "started", "data": {"session_id": "s1", "question": "q"}})}',
+            "",
+            ":another keepalive",
+            f'data: {json.dumps({"step": "answer", "data": {"text": "answer", "turns": 1}})}',
+            "",
+            f'data: {json.dumps({"step": "complete", "data": {"session_id": "s1", "metrics": {"cost_usd": 0.001}}})}',
+            "",
+        ]))
+        resp.text = ""
+        resp.close = MagicMock()
+        mock_post.return_value = resp
+
+        result = _research(question="test")
+        assert "error" not in result
+        assert result["answer"] == "answer"
+
+    @patch("app.tools.research._resolve_credentials")
+    @patch("requests.post")
+    def test_request_exception_returns_error(self, mock_post, mock_creds):
+        """Connection error → clean error dict, no exception bubbled up."""
+        import requests
+        mock_creds.return_value = ("https://api.marc27.test/api/v1", "test-key")
+        mock_post.side_effect = requests.exceptions.ConnectionError("DNS lookup failed")
+
+        result = _research(question="test")
+        assert "error" in result
+        assert "research endpoint" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Live integration test — runs ONLY when explicitly enabled. Costs real $.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(
+    os.environ.get("PRISM_LIVE_RESEARCH_TEST") != "1",
+    reason="Live research test costs real money; set PRISM_LIVE_RESEARCH_TEST=1 to run",
+)
+def test_live_research_cheap_query():
+    """End-to-end against the real MARC27 platform.
+
+    Set `PRISM_LIVE_RESEARCH_TEST=1` to run. Uses depth=0 (local-only)
+    to keep cost minimal — typically <$0.05 per run.
+    """
+    result = _research(
+        question="What is the chemical composition of Inconel 718?",
+        depth=0,
+        timeout_seconds=120,
+    )
+    assert "error" not in result, f"live research failed: {result}"
+    assert result["answer"]
+    assert "Inconel" in result["answer"] or "nickel" in result["answer"].lower()
+    assert result["session_id"]
+    print(f"\n[live test] session={result['session_id']} cost=${result['cost_usd']:.4f}")


### PR DESCRIPTION
## Summary

Wires PRISM to the server-side Recursive Language Model at `POST /api/v1/knowledge/research/query`. **Real-money tool** — gated by `requires_approval=True` so every call needs user confirmation in the harness.

## Two LLMs at different abstraction levels

```
User
 ↓
PRISM CLI → [LLM #1: chat] decides "I'll call research(...)"
              ↓
              HTTP POST → server's RLM engine
                ↓
                [LLM #2: server-side] runs the recursive REPL loop
                  (graph_search, vector_search, web_search, llm_query)
              ↓
              SSE stream back
              ↓
PRISM CLI ← [LLM #1] receives ONE structured result
```

LLM #1 never recurses. Server-side recursion is hidden from the chat context. Two big wins:
- chat window doesn't blow up
- deep search can use a different / specialized model

## Server-side persistence (already exists, this PR consumes it)

Every completed session is written to the `research_sessions` Postgres table with full provenance (steps, tenant, cost, metrics) AND the answer is auto-embedded into the vector store under `doc_id = research-session-{uuid}`. Future agents — any session, any machine — can find this answer via `knowledge(action='semantic')` or `recall()` once the stateful memory branch lands.

## Safety

- `requires_approval=True` — harness must show "agent wants to call research(question='...', depth=N). Approve?" before each call
- Depth bounds enforced client-side (0..10) before hitting the server for clearer errors
- All SSE error paths return clean error dicts; no exceptions bubble up

## SSE protocol

12 server event types parsed: `started` / `decompose` / `reasoning` / `repl_exec` / `repl_result` / `repl_error` / `compacted` / `sub_session_start` / `sub_session_complete` / `answer` / `complete` / `error`. User-visible subset populates the `progress_log`. Keepalive lines and blank lines tolerated.

## Test plan

- [x] 23 unit tests pass (registration, schema, args, credentials, SSE parsing, happy path, error paths, keepalive tolerance, connection error handling)
- [x] 1 live integration test correctly skipped — gated by `PRISM_LIVE_RESEARCH_TEST=1` so CI never accidentally spends real money
- [x] 52/52 regression tests pass (test_bootstrap + test_capabilities + test_research_tool)
- [x] Bootstrap loads cleanly: 55 tools registered, `research` present, `requires_approval=True` enforced

## Composes with the stateful memory branch

When `round4/stateful-memory` lands, research results auto-record to `~/.prism/artifacts.db` like any other tool output. The expensive research call becomes recallable across sessions — pay once, reuse forever.

## Out of scope

- `knowledge(action='promote_artifact')` — push local artifact to KG (separate PR)
- SDK-side `client.knowledge.research()` (using BaseAPI directly for now)
- Background polling for long-running sessions
- Cancellation mid-stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added research tool enabling users to submit research questions with streaming progress updates, session tracking, and cost reporting. Tool execution requires approval.

* **Tests**
  * Added comprehensive test coverage for research tool including argument validation, credential handling, streaming behavior, and end-to-end integration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->