### PR TITLE
Round 5 batch A: collapse bash inspection (3→2, –1 surface)

### DIFF
--- a/app/tools/bash.py
+++ b/app/tools/bash.py
@@ -314,6 +314,27 @@ def _list_bash_tasks() -> dict:
     return {"tasks": tasks, "count": len(tasks)}
 
 
+def _bash_task(**kwargs) -> dict:
+    """Unified read-only dispatcher for bash task inspection.
+
+    Replaces `list_bash_tasks` + `read_bash_task`. The destructive
+    `stop_bash_task` stays separate because it's approval-gated; collapsing
+    it under this dispatcher would force per-action approval support in
+    the harness, which we don't have yet.
+    """
+    action = kwargs.get("action")
+    if not action:
+        return {"error": "Missing 'action'. Valid: list, read"}
+    if action == "list":
+        return _list_bash_tasks()
+    if action == "read":
+        task_id = kwargs.get("task_id")
+        if not task_id:
+            return {"error": "Action 'read' requires `task_id`"}
+        return _read_bash_task(task_id)
+    return {"error": f"Unknown action '{action}'. Valid: list, read"}
+
+
 def _read_bash_task(task_id: str) -> dict:
     with _BASH_TASKS_LOCK:
         task = _BASH_TASKS.get(task_id)
@@ -828,57 +849,45 @@ def create_bash_tools(registry: ToolRegistry) -> None:
         requires_approval=True,
     ))
     registry.register(Tool(
-        name="list_bash_tasks",
+        name="bash_task",
         description=(
-            "List every session-local background bash task — created "
-            "by `execute_bash` with `run_in_background=true` — that "
-            "is currently in this chat session's task table. Returns "
-            "each task's id, original command, status (`running` / "
-            "`completed` / `failed` / `timed_out` / `stopped`), and "
-            "exit code if terminal. Use when the agent has lost "
-            "track of a task id, when the user asks 'what's still "
-            "running?', or as the first step before "
-            "`read_bash_task` / `stop_bash_task`. Tasks are "
-            "session-scoped: ending the chat ends the tasks."
-        ),
-        input_schema={
-            "type": "object",
-            "properties": {},
-            "additionalProperties": False,
-        },
-        func=_list_bash_tasks,
-    ))
-    registry.register(Tool(
-        name="read_bash_task",
-        description=(
-            "Pull the latest stdout / stderr buffer from a "
-            "background bash task started with `execute_bash "
-            "run_in_background=true`. Returns whatever has been "
-            "written since the previous read (or since launch) plus "
-            "the current status. The right pattern is a polling "
-            "loop: call this every few seconds until status flips "
-            "to `completed` / `failed` / `timed_out` / `stopped`. "
-            "NOT a substitute for `compute_status` (that's for "
-            "MARC27 broker jobs, not local bash); NOT for stopping "
-            "a task (use `stop_bash_task`). Read-only — does not "
-            "consume the buffer; safe to call repeatedly."
+            "Inspect background bash tasks (started by `execute_bash` with "
+            "`run_in_background=true`). ONE tool, two read-only actions:\n"
+            "  • action='list' — list every session-local background bash "
+            "task. No args. Returns each task's id, command, status "
+            "(running / completed / failed / timed_out / stopped), and "
+            "exit code if terminal. Use when the agent lost track of a "
+            "task_id or when the user asks 'what's still running?'.\n"
+            "  • action='read' — pull the latest stdout/stderr buffer "
+            "from one task. Requires `task_id`. Use in a polling loop "
+            "every few seconds until status flips to terminal. Read-only — "
+            "does not consume the buffer; safe to call repeatedly.\n"
+            "Tasks are session-scoped: ending the chat ends the tasks. "
+            "NOT a substitute for compute_status (that's for MARC27 broker "
+            "jobs, not local bash). For STOPPING a task, use the separate "
+            "`stop_bash_task` tool — destructive ops stay isolated for "
+            "approval gating."
         ),
         input_schema={
             "type": "object",
             "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["list", "read"],
+                    "description": "Which inspection operation to perform.",
+                },
                 "task_id": {
                     "type": "string",
                     "description": (
-                        "Background bash task ID — returned by "
-                        "`execute_bash` when `run_in_background=true`, "
-                        "or rediscovered via `list_bash_tasks`."
+                        "Background bash task ID. Required for action='read'; "
+                        "ignored for action='list'."
                     ),
                 },
             },
-            "required": ["task_id"],
+            "required": ["action"],
             "additionalProperties": False,
         },
-        func=_read_bash_task,
+        func=_bash_task,
     ))
     registry.register(Tool(
         name="stop_bash_task",

--- a/tests/test_bash_task_unified.py
+++ b/tests/test_bash_task_unified.py
@@ -1,0 +1,85 @@
+"""Tests for the unified `bash_task` tool.
+
+After Round 5 batch A: list_bash_tasks + read_bash_task collapsed into
+bash_task(action='list'|'read'). stop_bash_task stays standalone because
+it's destructive (requires_approval=True) and per-action approval gating
+isn't supported in the harness yet.
+"""
+import pytest
+from unittest.mock import patch
+
+from app.tools.base import ToolRegistry
+from app.tools.bash import _bash_task, create_bash_tools
+
+
+class TestRegistration:
+    def test_bash_task_registered(self):
+        reg = ToolRegistry()
+        create_bash_tools(reg)
+        names = [t.name for t in reg.list_tools()]
+        assert "bash_task" in names
+
+    def test_old_names_removed(self):
+        reg = ToolRegistry()
+        create_bash_tools(reg)
+        names = [t.name for t in reg.list_tools()]
+        assert "list_bash_tasks" not in names
+        assert "read_bash_task" not in names
+
+    def test_destructive_op_isolated(self):
+        """stop_bash_task stays separate (destructive, approval-gated)."""
+        reg = ToolRegistry()
+        create_bash_tools(reg)
+        names = [t.name for t in reg.list_tools()]
+        assert "stop_bash_task" in names
+        assert reg.get("stop_bash_task").requires_approval is True
+
+    def test_execute_bash_kept(self):
+        """execute_bash is a different concept (runner) — stays standalone."""
+        reg = ToolRegistry()
+        create_bash_tools(reg)
+        names = [t.name for t in reg.list_tools()]
+        assert "execute_bash" in names
+
+    def test_action_enum(self):
+        reg = ToolRegistry()
+        create_bash_tools(reg)
+        tool = reg.get("bash_task")
+        actions = tool.input_schema["properties"]["action"]["enum"]
+        assert set(actions) == {"list", "read"}
+
+    def test_no_approval_required_for_read_only(self):
+        reg = ToolRegistry()
+        create_bash_tools(reg)
+        # bash_task is read-only — approval would defeat the polling-loop UX
+        assert reg.get("bash_task").requires_approval is False
+
+
+class TestDispatch:
+    def test_missing_action(self):
+        result = _bash_task()
+        assert "error" in result
+        assert "Missing 'action'" in result["error"]
+
+    def test_unknown_action(self):
+        result = _bash_task(action="bogus")
+        assert "error" in result
+        assert "Unknown action" in result["error"]
+
+    def test_action_list_no_args(self):
+        result = _bash_task(action="list")
+        assert "tasks" in result
+        assert "count" in result
+        assert isinstance(result["tasks"], list)
+
+    def test_action_read_requires_task_id(self):
+        result = _bash_task(action="read")
+        assert "error" in result
+        assert "task_id" in result["error"]
+
+    def test_action_read_unknown_task(self):
+        """When task_id doesn't exist, the underlying _read_bash_task
+        returns its own error shape (success=False), not the dispatcher's."""
+        result = _bash_task(action="read", task_id="nonexistent_xyz")
+        assert result.get("success") is False
+        assert "Unknown bash task" in result.get("error", "")

--- a/tests/test_execute_bash.py
+++ b/tests/test_execute_bash.py
@@ -1,0 +1,139 @@
+"""Tests for the execute_bash tool."""
+
+import time
+from unittest.mock import patch
+
+from app.tools import bash as bash_module
+from app.tools.base import ToolRegistry
+from app.tools.bash import (
+    _execute_bash,
+    _list_bash_tasks,
+    _read_bash_task,
+    _stop_bash_task,
+    create_bash_tools,
+)
+
+
+class TestExecuteBash:
+    def setup_method(self):
+        with bash_module._BASH_TASKS_LOCK:
+            for task in bash_module._BASH_TASKS.values():
+                process = task.get("process")
+                if process is not None:
+                    try:
+                        bash_module._terminate_process(process)
+                        process.wait(timeout=1)
+                    except Exception:
+                        pass
+            bash_module._BASH_TASKS.clear()
+
+    def test_simple_command(self):
+        result = _execute_bash(command='printf "hello"')
+        assert result["success"] is True
+        assert result["exit_code"] == 0
+        assert result["stdout"] == "hello"
+
+    def test_semantic_no_matches_is_not_error(self, tmp_path):
+        sample = tmp_path / "sample.txt"
+        sample.write_text("alpha\nbeta\n")
+        with patch("app.tools.bash._ALLOWED_BASE", tmp_path.resolve()):
+            result = _execute_bash(command='grep "gamma" sample.txt')
+        assert result["success"] is True
+        assert result["exit_code"] == 1
+        assert result["return_code_interpretation"] == "No matches found"
+
+    def test_blocks_command_substitution(self):
+        result = _execute_bash(command='echo $(pwd)')
+        assert result["success"] is False
+        assert "not supported" in result["error"]
+
+    def test_blocks_network_commands(self):
+        result = _execute_bash(command="curl -I https://example.com")
+        assert result["success"] is False
+        assert "Network command" in result["error"]
+
+    def test_blocks_paths_outside_project(self, tmp_path):
+        with patch("app.tools.bash._ALLOWED_BASE", tmp_path.resolve()):
+            result = _execute_bash(command="cat /etc/hosts")
+        assert result["success"] is False
+        assert "must stay within" in result["error"]
+
+    def test_write_inside_project(self, tmp_path):
+        output = tmp_path / "note.txt"
+        with patch("app.tools.bash._ALLOWED_BASE", tmp_path.resolve()):
+            result = _execute_bash(command='printf "ok" > note.txt')
+        assert result["success"] is True
+        assert output.read_text() == "ok"
+
+    def test_timeout(self):
+        result = _execute_bash(command="sleep 5", timeout=1)
+        assert result["success"] is False
+        assert result["exit_code"] == 124
+
+    def test_blocks_unsupported_git_subcommands(self):
+        result = _execute_bash(command="git commit -m test")
+        assert result["success"] is False
+        assert "git subcommand" in result["error"]
+
+    def test_background_task_lifecycle(self, tmp_path):
+        with patch("app.tools.bash._ALLOWED_BASE", tmp_path.resolve()):
+            started = _execute_bash(
+                command='printf "hello from background"',
+                description="Write a greeting",
+                run_in_background=True,
+            )
+            assert started["success"] is True
+            task_id = started["task"]["task_id"]
+
+            for _ in range(20):
+                task = _read_bash_task(task_id)
+                if task["task"]["status"] != "running":
+                    break
+                time.sleep(0.05)
+
+            assert task["task"]["status"] == "completed"
+            assert "hello from background" in task["task"]["stdout_tail"]
+
+            listed = _list_bash_tasks()
+            assert listed["count"] == 1
+            assert listed["tasks"][0]["task_id"] == task_id
+
+    def test_stop_background_task(self, tmp_path):
+        with patch("app.tools.bash._ALLOWED_BASE", tmp_path.resolve()):
+            started = _execute_bash(
+                command="sleep 30",
+                description="Long running sleep",
+                run_in_background=True,
+            )
+            task_id = started["task"]["task_id"]
+
+            stopped = _stop_bash_task(task_id)
+            assert stopped["success"] is True
+            assert stopped["task"]["status"] == "stopped"
+
+
+class TestBashToolRegistration:
+    """After Round 5 batch A: list_bash_tasks + read_bash_task collapsed
+    into bash_task(action='list'|'read'). stop_bash_task stays standalone."""
+
+    def test_tool_registered(self):
+        registry = ToolRegistry()
+        create_bash_tools(registry)
+        tool = registry.get("execute_bash")
+        assert tool.name == "execute_bash"
+        assert tool.requires_approval is True
+        # Read-only inspection — no approval (would break polling-loop UX)
+        assert registry.get("bash_task").requires_approval is False
+        # Destructive op stays separate, approval-gated
+        assert registry.get("stop_bash_task").requires_approval is True
+
+    def test_tool_in_bootstrap(self):
+        from app.plugins.bootstrap import build_full_registry
+
+        tool_reg, _, _ = build_full_registry(enable_mcp=False, enable_plugins=False)
+        names = {t.name for t in tool_reg.list_tools()}
+        assert "execute_bash" in names
+        assert "bash_task" in names
+        # Old names must be gone
+        assert "list_bash_tasks" not in names
+        assert "read_bash_task" not in names


### PR DESCRIPTION
## Summary

`list_bash_tasks` + `read_bash_task` → `bash_task(action='list'|'read')`.

`stop_bash_task` stays standalone — destructive op needs its own approval gate, harness doesn't support per-action `requires_approval` yet. Net surface for this cluster: **3 → 2** (–1).

## Why this batch is smaller than originally planned

Round 5 queued five clusters: dataset (5→1), bash_task (3→1), structure (3→1), sim_jobs (4→1), calphad (6→1). After scoping:

- **`structure` / `sim_jobs` / `calphad`** require pyiron / pycalphad to be installed. They're optional deps not loaded in the default dev environment. Collapsing without testing the dispatcher path through the actual handlers would be reckless. **Queued for a follow-up PR run in an environment with the optional deps installed.**
- **`dataset` cluster** spans the Tool/Skill abstraction (`import_dataset` + `export_results_csv` are `Tool` objects; `validate_dataset` + `review_dataset` + `visualize_dataset` are `Skill` objects with a different registration path and per-skill `requires_approval` flags). **Needs a deliberate Skill-merge design — queued.**
- **`bash_task` inspection** — clean, fully testable, ships as-is.

## Design note: read-only vs destructive

Two read-only ops (`list`, `read`) collapse cleanly with no approval gate — necessary because the polling-loop UX (call `read` every few seconds until status flips to terminal) breaks if every poll prompts the user.

Folding `stop_bash_task` in would force the unified tool to require approval, breaking that loop. Or it would require per-action approval support in `Tool.execute` — a real architectural change.

Clean answer: **destructive ops stay standalone.** Same pattern `compute_submit` needs (flagged earlier as a separate follow-up).

## Test plan

- [x] `tests/test_bash_task_unified.py` — 11 new tests (registration, old-names-removed, action enum, no-approval-on-read-only, dispatcher errors)
- [x] `tests/test_execute_bash.py` — updated registration assertions to use `bash_task` instead of the old names
- [x] 36/36 affected tests pass (test_execute_bash + test_bash_task_unified + test_bootstrap)

## Out of scope

- Dataset cluster (Tool/Skill merge design needed)
- sim_jobs / structure / calphad (need pyiron/pycalphad environment)
- Per-action `requires_approval` in `Tool.execute` (would unlock collapsing `stop_bash_task` into `bash_task`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)