### PR TITLE
pyiron boundary: unblock Python 3.14 + document architectural split

### DIFF
--- a/app/tools/simulation/bridge.py
+++ b/app/tools/simulation/bridge.py
@@ -1,4 +1,53 @@
-"""Pyiron bridge layer — lazy init, config management, structure/job stores."""
+"""Pyiron bridge — thin wrapper between PRISM tools and the pyiron stack.
+
+ARCHITECTURAL BOUNDARY (do not violate without discussion)
+==========================================================
+
+This module is the ONLY place PRISM imports from pyiron. Everything else
+goes through `get_bridge()` and the {Structure,Job}Store helpers exposed
+here. That's deliberate. See docs/pyiron_integration.md for the full
+rationale; the short version:
+
+  PRISM is an AI-native research workspace.
+  pyiron is an atomistic-simulation IDE / orchestrator.
+
+They sit at DIFFERENT levels of the stack. pyiron is a tool inside
+PRISM, not a competitor. To keep the boundary clean:
+
+  WE USE
+    - pyiron_atomistics    (LAMMPS / VASP / GPAW / SPHInX wrappers + ASE compat)
+    - pyiron_base          (Project, Job, HDF5/SQL storage, queue submission)
+    - executorlib          (HPC dispatch via SLURM, transitive)
+
+  WE DO NOT USE
+    - pyiron_workflow      (graph-based workflow framework — overlaps with our
+                            skills + YAML workflows; different abstraction)
+    - pyiron_core          (visual GUI for graph workflows — pure UI, irrelevant)
+
+  WE DO NOT DUPLICATE
+    - HDF5 storage of simulation results (pyiron owns this; our artifact
+      store records pointers/summaries, not the bulk data)
+    - The pyiron job database (SQL) — we keep our own JobStore as a
+      session-local cache of references, not a parallel database
+    - SLURM submission for atomistic codes (always go through
+      `pyiron job.server.queue` / executorlib; our compute broker is for
+      generic GPU work — training, inference, container jobs — NOT
+      atomistic sim)
+    - ASE-compatible structure objects (always use pyiron's, never roll
+      our own)
+
+  RESULT-LAYER POSITIONING
+    - pyiron's HDF5 = source of truth for simulation outputs
+    - PRISM's artifact store (Memex layer) = high-level summaries + the
+      pyiron job_id as provenance pointer; the agent recalls the
+      pointer, then dereferences via this bridge if it needs the full
+      HDF5 data
+
+If you find yourself reaching for pyiron_workflow's graph nodes or
+duplicating HDF5 storage, stop and re-read this docstring. The whole
+point of having pyiron as a backend is to NOT solve problems they've
+already solved well.
+"""
 import json
 import uuid
 from pathlib import Path
@@ -6,7 +55,12 @@ from typing import Any, Dict, List, Optional
 
 
 def check_pyiron_available() -> bool:
-    """Return True if pyiron_atomistics is importable."""
+    """Return True if pyiron_atomistics is importable.
+
+    pyiron_atomistics 0.6+ supports Python 3.9–3.14 (atomistics 0.3.6+).
+    Earlier PRISM versions gated this at python_version<'3.14' which
+    excluded macOS arm64 default Python; the gate is now <'3.15'.
+    """
     try:
         import pyiron_atomistics  # noqa: F401
         return True

--- a/docs/pyiron_integration.md
+++ b/docs/pyiron_integration.md
@@ -1,0 +1,152 @@
+# PRISM ↔ pyiron Integration
+
+**Status:** Active boundary  
+**Owner:** `app/tools/simulation/bridge.py`  
+**Authors:** Sid + Claude (2026-05-08)  
+**Audience:** PRISM contributors who need to add or modify simulation tools
+
+## TL;DR
+
+> **PRISM is an AI-native research workspace.**  
+> **pyiron is an atomistic-simulation IDE / orchestrator.**  
+> They sit at different levels of the stack. pyiron is a tool inside PRISM, not a competitor.
+
+Use `pyiron_atomistics` + `pyiron_base` + transitively `executorlib`. **Do not** use `pyiron_workflow` or `pyiron_core`. **Do not** duplicate HDF5 storage, the pyiron job database, atomistic SLURM submission, or ASE-compatible structure objects. Always go through `app/tools/simulation/bridge.py`.
+
+## What pyiron is (and isn't)
+
+pyiron is a modular ecosystem of ~10 packages on the [pyiron GitHub org](https://github.com/pyiron). The relevant ones:
+
+| Package | Role | We use it? |
+|---|---|---|
+| `pyiron_base` | Workflow + job mgmt + HDF5/SQL data storage. The orchestration layer. | ✅ via pyiron_atomistics |
+| `pyiron_atomistics` | LAMMPS / VASP / GPAW / S/PHI/nX wrappers + ASE compatibility. The atomistic layer. | ✅ this is our integration point |
+| `executorlib` | HPC executor (SLURM dispatch) | ✅ pulled in transitively |
+| `atomistics` | Lower-level wrapper, pure-python | ✅ transitive |
+| `pylammpsmpi`, `vaspparser`, `lammpsparser` | Code/parser bindings | ✅ transitive when running specific codes |
+| `pyiron_workflow` | Graph-based workflow framework | ❌ overlaps with our skills/workflows |
+| `pyiron_core` | Visual GUI for graph workflows | ❌ pure GUI |
+
+What pyiron *does*:
+
+1. Wraps simulation codes (LAMMPS, VASP, etc.) with one Python interface
+2. Manages atomistic *jobs* (create → run → store output → query results)
+3. HDF5-backed hierarchical storage of simulation outputs
+4. SQL job database (job_id, status, metadata)
+5. HPC submission via `executorlib` (SLURM/PBS/SGE)
+6. ASE-compatible structure objects
+7. Hash-based caching for parameter sweeps
+
+What pyiron is *evolving toward* (per the lead developer at the 2026 symposium): LLM-orchestrated atomistic workflows, smarter conversational sim setup, more "intelligent" parameter sweep navigation. This is good news for us — we'll inherit those features through the integration. It does **not** change PRISM's positioning.
+
+## Where PRISM and pyiron sit
+
+| Layer | Owner |
+|---|---|
+| Chat LLM, agent loop, tool selection | **PRISM** |
+| Embedding-based tool retrieval (Stage 2.1 EmbeddingGemma) | **PRISM** |
+| Stateful artifact memory + recall across sessions | **PRISM** |
+| Knowledge graph reasoning (MARC27 KG) | **PRISM** |
+| Federated DB search (NOMAD, Materials Project, OQMD, ...) | **PRISM** |
+| Generic compute broker (RunPod, Lambda, PRISM mesh — training, inference, generic GPU) | **PRISM** |
+| Code-writing agent (JAX, custom kernels) | **PRISM** |
+| The Fabric (multi-site federated AI compute mesh with RBAC) | **PRISM** |
+| Atomistic simulation orchestration (LAMMPS/VASP/GPAW jobs) | **pyiron** |
+| HDF5 storage of simulation outputs | **pyiron** |
+| Atomistic SLURM/PBS submission | **pyiron** (via executorlib) |
+| ASE-compatible structure objects | **pyiron / ASE** |
+| Parameter-sweep result aggregation (`pyiron_table`) | **pyiron** |
+
+The crisp test: *"Does this involve actually running LAMMPS / VASP / a DFT code?"* If yes, it's pyiron's turf. If no, it's PRISM's.
+
+## Integration architecture
+
+```
+PRISM agent loop
+    │
+    ▼
+sim_tools (app/tools/sim_tools.py)
+    │   create_structure, run_simulation, get_job_results, ...
+    ▼
+PyironBridge  (app/tools/simulation/bridge.py)  ← only place PRISM imports pyiron
+    │
+    ├── get_project()       → pyiron_atomistics.Project (lazy)
+    ├── StructureStore      → in-memory map of struct_id → ASE Atoms
+    ├── JobStore            → in-memory map of job_id → pyiron job ref
+    └── HPC config          → ~/.prism/hpc_config.json
+                                ↓
+                              applied to job.server.queue / cores / walltime
+                                ↓
+                              executorlib submits to SLURM
+                                ↓
+                              actual LAMMPS / VASP run
+                                ↓
+                              pyiron writes HDF5 + SQL row (its turf)
+                                ↓
+                              we read summaries through bridge.jobs.get(job_id)
+```
+
+The bridge is **thin**. It holds *references* to pyiron objects, not duplicate data. HDF5 is owned by pyiron. The PRISM artifact store records summary + provenance pointer; if the agent needs the full result, it fetches through the bridge, which reads from pyiron.
+
+## What goes where (decision table)
+
+| Question | Answer |
+|---|---|
+| "Where does the simulation result actually live?" | pyiron HDF5 file (under the pyiron Project directory) |
+| "Where does PRISM remember that the result exists?" | Local artifact store (`~/.prism/artifacts.db`) — stores `job_id` as provenance, plus the summary the LLM saw |
+| "How does the agent re-fetch the result later?" | `recall("...")` returns the artifact → `bridge.jobs.get(job_id)` → pyiron reads HDF5 |
+| "Where does the SLURM submission happen?" | `executorlib.SlurmClusterExecutor`, configured by `bridge.apply_hpc_config()` |
+| "What if I want to run a non-atomistic GPU job (training, ML inference)?" | PRISM compute broker (`compute(action='submit')`), NOT pyiron |
+| "What about a parameter sweep DataFrame?" | Use `pyiron_table` — it's the right tool. Don't roll our own aggregator. |
+| "Can I write a graph-based workflow?" | If you need atomistic-specific node-graph orchestration, YES, but at the SIM-level (rare, advanced). For PRISM-level workflows, use our YAML skills system. **Do not import `pyiron_workflow` into PRISM tools.** |
+| "Which Python versions support pyiron?" | 3.9–3.14 as of pyiron_atomistics 0.6+ / atomistics 0.3.6+ (April 2026) |
+
+## Dependency notes
+
+pyiron's pinned core deps:
+
+```
+ase==3.27.0      numpy==2.3.5      scipy==1.17.0      spglib==2.7.0
++ pandas, h5py, pyfileindex, executorlib, structuretoolkit, sqlalchemy
+```
+
+Three real risks:
+
+1. **Numpy pin conflict.** pyiron pins `numpy==2.3.5`. If any other PRISM dep needs `numpy>=2.4`, install fails. *Mitigation:* pyiron is in the `[simulation]` extra (opt-in), not core. Users who don't need atomistic sim avoid the conflict entirely.
+
+2. **Heavy install.** Full pyiron + LAMMPS/VASP wrappers + h5py + pandas + scipy + sqlalchemy = several hundred MB. Conda-forge has prebuilt binaries; pip install can hit native-extension compilation hell on macOS / Windows.  
+   *Recommendation:* document conda-forge as the supported install path:  
+   ```bash
+   conda install -c conda-forge pyiron_atomistics
+   ```  
+   The `pip install prism-platform[simulation]` path works on Linux but is brittle elsewhere.
+
+3. **Native simulation binaries.** LAMMPS / VASP / etc. are separate executables. pyiron's docs cover the resource-directory layout and how to wire your own builds. We don't need to repeat that here, but in PRISM's `prism configure` UX we should at least *check* whether a usable LAMMPS is on `PATH` and warn if not.
+
+## Anti-patterns to flag in code review
+
+- `from pyiron_workflow import ...` anywhere in PRISM → **reject in review**
+- `from pyiron_core import ...` → **reject in review**
+- A new HDF5 storage layer on the PRISM side that mirrors pyiron's — **reject**, use `bridge.jobs.get(job_id)` and read from pyiron
+- A parallel SLURM submitter for atomistic jobs — **reject**, use `bridge.apply_hpc_config(job)` + `executorlib`
+- A custom ASE-Atoms-equivalent class — **reject**, use pyiron's
+
+## When pyiron grows LLM features
+
+The pyiron team is moving toward LLM-orchestrated atomistic workflows. When that lands:
+
+- Their LLM features will be **better than what we'd build for atomistic-specific work** because they're solving a narrower problem with deeper domain context.
+- We **inherit** those features through the integration with no extra work.
+- PRISM's positioning is unchanged — we're a different, broader research workspace (federated DB search, paper reasoning, code-writing agent, multi-site Fabric, KG-grown-from-research, stateful memory across heterogeneous tool outputs).
+
+In other words: pyiron getting smart is a non-event for PRISM strategy. Stay in our lane; let theirs improve under us.
+
+## See also
+
+- `app/tools/simulation/bridge.py` — the only place PRISM imports pyiron
+- `app/tools/sim_tools.py` — the user-visible simulation tool surface
+- `docs/stateful_tools_2026.md` — how pyiron job results flow into the artifact store
+- [pyiron.org](https://pyiron.org/) — main IDE site
+- [pyiron_atomistics docs](https://pyiron-atomistics.readthedocs.io/en/latest/README.html)
+- [pyiron_base docs](https://pyiron-base.readthedocs.io/en/latest/README.html)
+- [pyiron 2019 paper — original architecture](https://pyiron.org/publications/2019/06/01/pyiron.html)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,11 +67,18 @@ ml = [
     "joblib>=1.3.0",
 ]
 simulation = [
-    "pyiron-base>=0.9; python_version<'3.14'",
-    "pyiron-atomistics>=0.6; python_version<'3.14'",
+    # pyiron officially supports Python 3.9–3.14 as of pyiron_atomistics /
+    # atomistics 0.3.6 (released 2026-04-28); requires-python in their
+    # pyproject.toml is `>=3.9, <3.15`. We mirror that window so users on
+    # Python 3.14 (the current default on macOS arm64) get simulation
+    # extras instead of being silently excluded. See docs/pyiron_integration.md
+    # for the architectural boundary between PRISM and pyiron.
+    "pyiron-base>=0.9; python_version<'3.15'",
+    "pyiron-atomistics>=0.6; python_version<'3.15'",
 ]
 calphad = [
-    "pycalphad>=0.10,<0.12; python_version<'3.14'",
+    # pycalphad supports Python 3.9–3.14; same window as pyiron.
+    "pycalphad>=0.10,<0.12; python_version<'3.15'",
 ]
 data = [
     "datasets>=3.0.0",


### PR DESCRIPTION
## Summary

Three small surgical changes that close out the pyiron boundary question. No behavior change for users on Python <3.14; users on 3.14 (the macOS arm64 default) get their sim_tools cluster back from being silently dead.

## Changes

**`pyproject.toml`** — lift simulation/calphad extras from `python_version<'3.14'` to `<'3.15'`. pyiron_atomistics 0.6+ / atomistics 0.3.6+ (April 2026) officially supports Python 3.9–3.14 with `requires-python = ">=3.9, <3.15"`.

**`app/tools/simulation/bridge.py`** — module docstring now explicitly documents the architectural boundary: PRISM uses `pyiron_atomistics` + `pyiron_base` only, NEVER `pyiron_workflow` or `pyiron_core`, and NEVER duplicates HDF5 storage / atomistic SLURM submission / ASE structures.

**`docs/pyiron_integration.md`** (NEW) — full architectural boundary doc with decision table, anti-patterns to flag in review, dependency notes, and the rationale for why pyiron getting LLM features is a non-event for PRISM strategy.

## Architectural positioning

> PRISM is the AI-native research workspace.  
> pyiron is the atomistic-simulation IDE / orchestrator.

| PRISM owns | pyiron owns |
|---|---|
| Chat LLM, agent loop, tool retrieval | Atomistic sim orchestration (LAMMPS/VASP/GPAW) |
| Stateful artifact memory + recall | HDF5 storage of simulation outputs |
| Knowledge graph reasoning (MARC27 KG) | Atomistic SLURM via executorlib |
| Federated DB search | ASE-compatible structures |
| Generic GPU compute (training/inference) | `pyiron_table` parameter sweeps |
| Code-writing agent (JAX, custom kernels) | |
| The Fabric (multi-site federated mesh) | |

**Crisp test:** *Does this involve actually running LAMMPS / VASP / a DFT code?* → pyiron's turf. Otherwise → PRISM's.

When pyiron grows LLM features (the lead dev's stated direction at the 2026 symposium), we **inherit them through the integration**. PRISM's positioning is unchanged because we're solving a fundamentally broader problem (federated research workspace, code-writing agent, multi-site Fabric).

## Test plan

- [x] `pyproject.toml` syntax preserved; no new dependencies added
- [x] Bridge module change is comment/docstring only — zero behavior change
- [x] 29/29 regression tests pass (test_bootstrap + test_capabilities)
- [x] `docs/pyiron_integration.md` added via `git add -f` (docs/ is gitignored per project convention)

## Out of scope

- Round 5 sim_jobs / structure / calphad collapses — now unblocked on Python 3.14 once pyiron_atomistics is installed in a dev env, queued for a follow-up PR
- The optional `[simulation]` extras pip install path is documented in the new doc as brittle on macOS/Windows — conda-forge is the supported path

🤖 Generated with [Claude Code](https://claude.com/claude-code)