### PR TITLE
fix(compute): split submit out as approval-gated standalone tool

### DIFF
--- a/app/tools/compute.py
+++ b/app/tools/compute.py
@@ -1,15 +1,30 @@
-"""Compute Broker — UNIFIED tool collapsing 6 actions into one entry point.
+"""Compute Broker — unified read-only tool + standalone money-spending submit.
 
-DRAFT for Round 4 collapse work. Will replace app/tools/compute.py once PR #12 merges.
+Two tools:
 
-Replaces:
-  compute_gpus, compute_providers, compute_estimate, compute_submit,
-  compute_status, compute_cancel
-Discriminator: `action` (string enum)
+  - `compute(action=…)` — read-only and idempotent operations:
+    list_gpus, list_providers, estimate, status, cancel.
+    No approval required. Cheap to call repeatedly (estimate is FREE,
+    list_gpus/providers are catalog reads, status is a poll, cancel
+    is idempotent).
 
-Approval semantics: same as today (none). Flag for follow-up:
-  action='submit' is the money-spending one; should arguably set
-  requires_approval=True. Out of scope for the collapse PR.
+  - `compute_submit(...)` — STANDALONE money-spending action.
+    Dispatches a real GPU/CPU job to the MARC27 Compute Broker.
+    `requires_approval=True` — the harness MUST prompt the user before
+    each call. Cost is real, sometimes substantial (~$0.10–$10+ per job).
+
+WHY THE SPLIT
+
+Earlier collapse work folded all 6 compute_* tools into one
+`compute(action=…)` tool. That was clean for surface reduction, but
+collapsed the approval semantics: `requires_approval` is a per-tool
+boolean, not per-action. Either every compute call needed approval
+(annoying for list_gpus / estimate / status polling) or none did
+(unsafe for submit). Splitting submit back out preserves the original
+approval gate for money-spending while keeping the rest collapsed.
+
+Same architectural pattern as bash_task / stop_bash_task: destructive
+or money-spending actions stay isolated for approval.
 """
 import logging
 from app.tools.base import Tool, ToolRegistry
@@ -76,24 +91,40 @@ def _act_cancel(client, **kw) -> dict:
     return {"status": "cancelled", "job_id": kw["job_id"]}
 
 
-# (handler, list-of-required-args)
+# (handler, list-of-required-args) — read-only / idempotent actions ONLY.
+# The money-spending `submit` action is NOT in this dispatch; it lives as
+# a separate standalone tool with requires_approval=True (see below).
 _DISPATCH: dict[str, tuple] = {
     "list_gpus":      (_act_list_gpus,      []),
     "list_providers": (_act_list_providers, []),
     "estimate":       (_act_estimate,       ["image"]),
-    "submit":         (_act_submit,         ["image", "inputs"]),
     "status":         (_act_status,         ["job_id"]),
     "cancel":         (_act_cancel,         ["job_id"]),
 }
 
 
 def _compute(**kwargs) -> dict:
-    """Single entry point dispatched by `action`."""
+    """Read-only dispatcher. Money-spending `submit` is in `compute_submit`."""
     action = kwargs.pop("action", None)
     if not action:
         return {
             "error": f"Missing 'action'. Valid: {list(_DISPATCH.keys())}",
-            "hint": "Call as compute(action='list_gpus') or compute(action='submit', image=..., inputs=...)",
+            "hint": (
+                "compute(action='list_gpus') / compute(action='estimate', image='...') / "
+                "compute(action='status', job_id='...'). For dispatching a real job, "
+                "use the separate compute_submit tool (approval-gated)."
+            ),
+        }
+
+    if action == "submit":
+        # Hard-redirect callers who try the old interface
+        return {
+            "error": (
+                "action='submit' moved to a separate tool `compute_submit` for "
+                "safety. compute_submit requires user approval before each call "
+                "because it spends real money. Call compute_submit(image=..., "
+                "inputs=...) directly."
+            ),
         }
 
     if action not in _DISPATCH:
@@ -119,19 +150,60 @@ def _compute(**kwargs) -> dict:
         return {"error": str(e), "action": action}
 
 
+def _compute_submit(**kwargs) -> dict:
+    """Money-spending dispatcher for compute_submit (approval-gated)."""
+    if not kwargs.get("image"):
+        return {"error": "compute_submit requires `image`"}
+    if "inputs" not in kwargs:
+        return {"error": "compute_submit requires `inputs` (JSON payload, may be empty {})"}
+
+    client = _get_client()
+    if not client:
+        return {"error": "MARC27 platform not connected. Run `prism login` first."}
+
+    try:
+        return _act_submit(client, **kwargs)
+    except Exception as e:
+        return {"error": str(e)}
+
+
 _DESCRIPTION = (
-    "MARC27 Compute Broker — submit, monitor, and cancel containerized "
-    "GPU/CPU jobs across providers (PRISM mesh nodes, RunPod, Lambda). "
-    "ONE tool, six actions selected via `action`:\n"
+    "MARC27 Compute Broker — read-only and idempotent operations across "
+    "providers (PRISM mesh nodes, RunPod, Lambda). For dispatching real "
+    "GPU/CPU jobs, use the separate `compute_submit` tool (approval-gated, "
+    "money-spending).\n"
+    "\n"
+    "ONE tool, five read-only actions selected via `action`:\n"
     "  • action='list_gpus' — show available GPU types + pricing. No other args.\n"
     "  • action='list_providers' — show registered backends. No other args.\n"
     "  • action='estimate' — cost preview, FREE; requires `image`. Optional: `gpu_type`, `timeout_seconds`.\n"
-    "  • action='submit' — DISPATCHES A REAL JOB (money-spending); requires `image` + `inputs`. "
-    "Set `budget_max_usd` to cap spend.\n"
     "  • action='status' — poll one job; requires `job_id`. Cheap, no spend.\n"
     "  • action='cancel' — abort queued/running job; requires `job_id`. Idempotent.\n"
-    "Typical sequence: list_gpus → estimate → submit → status (loop) → [cancel if needed]. "
-    "NOT for listing LLM models (use models_list) and NOT for ML prediction (use predict)."
+    "Typical sequence: list_gpus → estimate → compute_submit → status (loop) → "
+    "[cancel if needed]. NOT for listing LLM models (use models_list) and NOT "
+    "for ML prediction (use predict)."
+)
+
+
+_SUBMIT_DESCRIPTION = (
+    "Dispatch a real containerized GPU/CPU job to the MARC27 Compute Broker. "
+    "MONEY-SPENDING ACTION — requires user approval before each call (the "
+    "harness will prompt you).\n"
+    "\n"
+    "Required args: `image` (Docker tag like 'vasp:6.5.0' or marketplace slug), "
+    "`inputs` (JSON payload for the container). Strongly recommended: "
+    "`budget_max_usd` to hard-cap spend (broker refuses dispatch if estimate "
+    "exceeds).\n"
+    "\n"
+    "Optional: `gpu_type` (A100-80GB, H100-80GB, ...; uses cheapest available "
+    "if omitted), `provider_preference` ('cheapest' default — prefers PRISM "
+    "mesh; 'fastest' = premium cloud; or specific provider name), "
+    "`timeout_seconds` (wall-time cap, default 3600), `env_vars` (API keys, "
+    "license tokens).\n"
+    "\n"
+    "Returns the job_id you can poll with compute(action='status', "
+    "job_id=...). Use compute(action='estimate') first if cost is a concern. "
+    "NOT for atomistic SLURM submission (that goes through pyiron sim_tools)."
 )
 
 
@@ -141,66 +213,33 @@ _SCHEMA = {
         "action": {
             "type": "string",
             "enum": list(_DISPATCH.keys()),
-            "description": "Which compute-broker operation to perform.",
+            "description": "Which read-only compute-broker operation to perform.",
         },
         "image": {
             "type": "string",
             "description": (
                 "Container image (e.g. 'vasp:6.5.0', 'quantum-espresso:7.4') "
-                "or marketplace slug. Required for action='estimate' and action='submit'."
-            ),
-        },
-        "inputs": {
-            "type": "object",
-            "description": (
-                "JSON input payload for the container. Shape depends on the image — "
-                "DFT runners want {structure, kpoints, encut, ...}, training jobs want "
-                "{dataset_uri, hyperparameters, ...}. Required for action='submit'."
+                "or marketplace slug. Required for action='estimate'."
             ),
         },
         "gpu_type": {
             "type": "string",
             "description": (
-                "GPU class (e.g. 'A100-80GB', 'H100-80GB'). Optional for "
-                "action='estimate'/'submit'; uses cheapest available if omitted."
+                "GPU class (e.g. 'A100-80GB', 'H100-80GB') for action='estimate'."
             ),
-        },
-        "budget_max_usd": {
-            "type": "number",
-            "description": (
-                "Hard cap on job cost in USD for action='submit'. The broker "
-                "refuses dispatch if estimated cost exceeds this. Strongly "
-                "recommended for non-trivial jobs."
-            ),
-        },
-        "provider_preference": {
-            "type": "string",
-            "description": (
-                "Routing strategy for action='submit': 'cheapest' (default — "
-                "prefers PRISM mesh nodes), 'fastest' (premium cloud), or an "
-                "explicit provider name."
-            ),
-            "default": "cheapest",
         },
         "timeout_seconds": {
             "type": "integer",
             "description": (
-                "Wall-time cap in seconds for action='estimate'/'submit'. "
+                "Wall-time cap in seconds for action='estimate'. "
                 "Default 3600 (1 hour). Cost = price-per-hour × timeout / 3600."
             ),
             "default": 3600,
         },
-        "env_vars": {
-            "type": "object",
-            "description": (
-                "Environment variables passed to the action='submit' container. "
-                "Use for API keys, license tokens, feature flags."
-            ),
-        },
         "job_id": {
             "type": "string",
             "description": (
-                "Job ID returned by action='submit' (format: 'job_<uuid>' or "
+                "Job ID returned by compute_submit (format: 'job_<uuid>' or "
                 "numeric SLURM ID). Required for action='status' and action='cancel'."
             ),
         },
@@ -210,11 +249,82 @@ _SCHEMA = {
 }
 
 
+_SUBMIT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "image": {
+            "type": "string",
+            "description": (
+                "Container image (Docker tag, e.g. 'vasp:6.5.0') or "
+                "marketplace slug registered with the broker."
+            ),
+        },
+        "inputs": {
+            "type": "object",
+            "description": (
+                "JSON input payload for the container. Shape depends on the "
+                "image — DFT runners want {structure, kpoints, encut, ...}; "
+                "training jobs want {dataset_uri, hyperparameters, ...}. "
+                "Pass {} if the image needs no inputs."
+            ),
+        },
+        "gpu_type": {
+            "type": "string",
+            "description": "GPU class (e.g. 'A100-80GB'). Use compute(action='list_gpus') first.",
+        },
+        "budget_max_usd": {
+            "type": "number",
+            "description": (
+                "Hard cap on this job's cost in USD. Broker refuses dispatch "
+                "if estimated cost exceeds this. STRONGLY recommended for "
+                "non-trivial jobs to prevent runaway charges."
+            ),
+        },
+        "provider_preference": {
+            "type": "string",
+            "description": (
+                "Routing strategy: 'cheapest' (default, prefers PRISM mesh "
+                "nodes), 'fastest' (premium cloud), or specific provider name."
+            ),
+            "default": "cheapest",
+        },
+        "timeout_seconds": {
+            "type": "integer",
+            "description": (
+                "Wall-time cap in seconds. Job is killed at the cap even if "
+                "not done. Default 3600 (1 hour)."
+            ),
+            "default": 3600,
+        },
+        "env_vars": {
+            "type": "object",
+            "description": (
+                "Environment variables passed to the container. Use for API "
+                "keys, license tokens, feature flags."
+            ),
+        },
+    },
+    "required": ["image", "inputs"],
+    "additionalProperties": False,
+}
+
+
 def create_compute_tools(registry: ToolRegistry) -> None:
-    """Register the unified `compute` tool (replaces 6 prior tools)."""
+    """Register the read-only `compute` tool + the approval-gated `compute_submit`.
+
+    The split mirrors the bash_task / stop_bash_task pattern: destructive
+    or money-spending actions stay isolated for per-tool approval gating.
+    """
     registry.register(Tool(
         name="compute",
         description=_DESCRIPTION,
         input_schema=_SCHEMA,
         func=_compute,
+    ))
+    registry.register(Tool(
+        name="compute_submit",
+        description=_SUBMIT_DESCRIPTION,
+        input_schema=_SUBMIT_SCHEMA,
+        func=_compute_submit,
+        requires_approval=True,
     ))

--- a/tests/test_compute_submit_approval.py
+++ b/tests/test_compute_submit_approval.py
@@ -1,0 +1,162 @@
+"""Tests for the compute / compute_submit split.
+
+After this PR: compute(action='submit') is removed from the unified
+compute tool; submit becomes a standalone `compute_submit` tool with
+`requires_approval=True`. The harness will prompt the user before each
+call. This test file verifies the split is correct end-to-end.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.tools.base import ToolRegistry
+from app.tools.compute import (
+    _compute,
+    _compute_submit,
+    create_compute_tools,
+)
+
+
+class TestRegistration:
+    def test_both_tools_registered(self):
+        reg = ToolRegistry()
+        create_compute_tools(reg)
+        names = [t.name for t in reg.list_tools()]
+        assert "compute" in names
+        assert "compute_submit" in names
+
+    def test_compute_submit_requires_approval(self):
+        reg = ToolRegistry()
+        create_compute_tools(reg)
+        cs = reg.get("compute_submit")
+        assert cs.requires_approval is True
+
+    def test_compute_does_not_require_approval(self):
+        """Read-only ops must NOT require approval — agent polls
+        compute(action='status') in tight loops; approving each one
+        would break the UX."""
+        reg = ToolRegistry()
+        create_compute_tools(reg)
+        c = reg.get("compute")
+        assert c.requires_approval is False
+
+    def test_submit_removed_from_compute_action_enum(self):
+        reg = ToolRegistry()
+        create_compute_tools(reg)
+        c = reg.get("compute")
+        actions = c.input_schema["properties"]["action"]["enum"]
+        assert "submit" not in actions
+        # The remaining 5 actions are read-only / idempotent
+        assert set(actions) == {"list_gpus", "list_providers", "estimate", "status", "cancel"}
+
+    def test_compute_submit_required_args(self):
+        reg = ToolRegistry()
+        create_compute_tools(reg)
+        cs = reg.get("compute_submit")
+        assert set(cs.input_schema["required"]) == {"image", "inputs"}
+
+
+class TestComputeReadOnlyDispatcher:
+    def test_missing_action(self):
+        r = _compute()
+        assert "error" in r
+        assert "Missing 'action'" in r["error"]
+
+    def test_unknown_action(self):
+        r = _compute(action="bogus")
+        assert "error" in r
+        assert "Unknown action" in r["error"]
+
+    def test_submit_action_redirects(self):
+        """Old code calling compute(action='submit') gets a clear redirect
+        to the new standalone tool, not a confusing 'unknown action' error."""
+        r = _compute(action="submit", image="x", inputs={})
+        assert "error" in r
+        assert "compute_submit" in r["error"]
+        assert "approval" in r["error"].lower() or "money" in r["error"].lower()
+
+    def test_estimate_requires_image(self):
+        with patch("app.tools.compute._get_client", return_value=MagicMock()):
+            r = _compute(action="estimate")
+        assert "error" in r
+        assert "image" in r["error"]
+
+    def test_status_requires_job_id(self):
+        with patch("app.tools.compute._get_client", return_value=MagicMock()):
+            r = _compute(action="status")
+        assert "error" in r
+        assert "job_id" in r["error"]
+
+    def test_cancel_requires_job_id(self):
+        with patch("app.tools.compute._get_client", return_value=MagicMock()):
+            r = _compute(action="cancel")
+        assert "error" in r
+        assert "job_id" in r["error"]
+
+    def test_list_gpus_dispatches(self):
+        client = MagicMock()
+        client.compute.list_gpus.return_value = [{"type": "A100"}]
+        with patch("app.tools.compute._get_client", return_value=client):
+            r = _compute(action="list_gpus")
+        assert "error" not in r
+        assert r["count"] == 1
+        assert r["source"] == "marc27_compute_broker"
+
+    def test_no_client_returns_clean_error(self):
+        with patch("app.tools.compute._get_client", return_value=None):
+            r = _compute(action="list_gpus")
+        assert "error" in r
+        assert "MARC27 platform not connected" in r["error"]
+
+
+class TestComputeSubmit:
+    def test_missing_image(self):
+        r = _compute_submit()
+        assert "error" in r
+        assert "image" in r["error"]
+
+    def test_missing_inputs(self):
+        r = _compute_submit(image="vasp:6.5.0")
+        assert "error" in r
+        assert "inputs" in r["error"]
+
+    def test_empty_inputs_dict_is_valid(self):
+        """`inputs={}` is a valid value (some images need no inputs).
+        We require the KEY to be present, not non-empty."""
+        client = MagicMock()
+        client.compute.submit.return_value = {"job_id": "job_123"}
+        with patch("app.tools.compute._get_client", return_value=client):
+            r = _compute_submit(image="x", inputs={})
+        assert "error" not in r
+        assert r["job"]["job_id"] == "job_123"
+
+    def test_no_client(self):
+        with patch("app.tools.compute._get_client", return_value=None):
+            r = _compute_submit(image="x", inputs={})
+        assert "error" in r
+        assert "MARC27 platform not connected" in r["error"]
+
+    def test_happy_path(self):
+        client = MagicMock()
+        client.compute.submit.return_value = {
+            "job_id": "job_xyz",
+            "status": "queued",
+        }
+        with patch("app.tools.compute._get_client", return_value=client):
+            r = _compute_submit(
+                image="vasp:6.5.0",
+                inputs={"structure": "..."},
+                gpu_type="A100-80GB",
+                budget_max_usd=5.0,
+                provider_preference="cheapest",
+                timeout_seconds=7200,
+                env_vars={"VASP_LICENSE": "..."},
+            )
+        assert "error" not in r
+        # Verify all kwargs were forwarded to the SDK
+        client.compute.submit.assert_called_once()
+        call_kwargs = client.compute.submit.call_args.kwargs
+        assert call_kwargs["image"] == "vasp:6.5.0"
+        assert call_kwargs["budget_max_usd"] == 5.0
+        assert call_kwargs["timeout_seconds"] == 7200
+        assert call_kwargs["env_vars"] == {"VASP_LICENSE": "..."}


### PR DESCRIPTION
## Summary

PR #13's collapse folded six `compute_*` tools into one `compute(action=…)`. Clean for surface, but it dropped the approval gate on the money-spending `submit` action — `requires_approval` is per-tool, not per-action.

This PR splits `compute_submit` back out as a standalone tool with `requires_approval=True`. The harness now prompts the user before each real-money dispatch. Read-only / idempotent ops stay unified.

| Tool | Actions | Approval |
|---|---|---|
| `compute(action=…)` | list_gpus, list_providers, estimate, status, cancel | ❌ no (cheap polling) |
| `compute_submit(image=…, inputs=…)` | (single tool) | ✅ yes |

## Same pattern as bash_task / stop_bash_task

Destructive or money-spending actions stay isolated for per-tool approval gating. The proper long-term fix is per-action `requires_approval` at the `Tool.execute` level — that needs harness coordination (changes the JSON protocol the Rust side reads), so it's tracked as a separate follow-up. When it lands, `compute_submit` rejoins `compute` as `action='submit'` with the gate moving down.

## Backwards-compat

Old code calling `compute(action='submit')` gets a clear redirect message pointing to `compute_submit`, not a confusing "Unknown action" error. The agent sees the redirect on one turn and retries correctly on the next.

## Test plan

- [x] `tests/test_compute_submit_approval.py` — 18 tests
- [x] Registration: both tools present, approval flags correct, submit removed from compute action enum
- [x] Dispatch: missing/unknown action, redirect for old `action='submit'`, per-action arg validation, list_gpus happy path
- [x] compute_submit: image/inputs validation, empty inputs dict valid, full happy path with all kwargs forwarded
- [x] 47/47 regression tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)