### PR TITLE
Round 6: web collapse + dataset Skill-merge + alias cleanup (39→34)

### DIFF
--- a/app/plugins/bootstrap.py
+++ b/app/plugins/bootstrap.py
@@ -24,6 +24,7 @@ def build_full_registry(
     from app.tools.code import create_code_tools
     from app.tools.bash import create_bash_tools
     from app.tools.capabilities import create_capabilities_tools
+    from app.tools.dataset import create_dataset_tool
 
     registry = ToolRegistry()
     create_system_tools(registry)
@@ -35,6 +36,9 @@ def build_full_registry(
     create_code_tools(registry)
     create_bash_tools(registry)
     create_capabilities_tools(registry)
+    # Unified dataset tool — replaces VALIDATE_SKILL / REVIEW_SKILL /
+    # VISUALIZE_SKILL Tool registrations. See app/tools/dataset.py.
+    create_dataset_tool(registry)
 
     # Stateful tool memory — auto-record meaningful tool outputs as artifacts
     # and expose recall/fetch/list as tools. Opt-out via PRISM_DISABLE_MEMORY=1

--- a/app/tools/dataset.py
+++ b/app/tools/dataset.py
@@ -1,0 +1,156 @@
+"""Dataset tool — unified validate / review / visualize dispatcher.
+
+Consolidates three previously-separate Skills into one Tool:
+
+  validate_dataset   → dataset(action='validate', ...)
+  review_dataset     → dataset(action='review', ...)
+  visualize_dataset  → dataset(action='visualize', ...)
+
+WHY ABOVE-SKILL ABSTRACTION
+
+The originals were `Skill` objects (procedural workflows with named
+steps). The Skill abstraction is internal: the LLM agent only sees the
+generated Tool. Per-Skill `steps` metadata didn't reach the agent's
+view of the tool surface; it was used by some internal logging /
+audit paths only. Collapsing into a Tool drops that internal metadata
+but doesn't change the agent-visible behavior.
+
+Dataset operations have a coherent shape — they all operate on a
+DataStore-registered dataset by name and return a structured report.
+The unified tool gives Stage 2.1 retrieval a single rich-description
+target instead of three near-duplicate ones.
+
+KEEPING SKILL FILES INTACT
+
+The validate.py / review.py / visualize.py files remain — they hold
+the actual implementations. We just delete the Skill registration
+side and route through this dataset Tool. If the harness gains true
+Skill-aware UX (showing per-step progress), we can re-introduce
+Skill registration without changing the implementations.
+"""
+from app.tools.base import Tool, ToolRegistry
+
+
+# Lazy imports keep the Tool module light at import time
+def _act_validate(**kwargs) -> dict:
+    from app.tools.skills.validation import _validate_dataset
+    return _validate_dataset(**kwargs)
+
+
+def _act_review(**kwargs) -> dict:
+    from app.tools.skills.review import _review_dataset
+    return _review_dataset(**kwargs)
+
+
+def _act_visualize(**kwargs) -> dict:
+    from app.tools.skills.visualization import _visualize_dataset
+    return _visualize_dataset(**kwargs)
+
+
+_DISPATCH = {
+    "validate":  _act_validate,
+    "review":    _act_review,
+    "visualize": _act_visualize,
+}
+
+
+def _dataset(**kwargs) -> dict:
+    action = kwargs.pop("action", None)
+    if not action:
+        return {
+            "error": f"Missing 'action'. Valid: {list(_DISPATCH.keys())}",
+            "hint": (
+                "dataset(action='validate', dataset_name='...') / "
+                "dataset(action='review', dataset_name='...') / "
+                "dataset(action='visualize', dataset_name='...', kind='...')"
+            ),
+        }
+    handler = _DISPATCH.get(action)
+    if not handler:
+        return {"error": f"Unknown action '{action}'. Valid: {list(_DISPATCH.keys())}"}
+    if not kwargs.get("dataset_name"):
+        return {"error": f"Action '{action}' requires `dataset_name`"}
+    try:
+        return handler(**kwargs)
+    except Exception as e:
+        return {"error": str(e), "action": action}
+
+
+_DESCRIPTION = (
+    "Operate on a stored dataset (in the PRISM DataStore — use "
+    "`import_dataset` first if your data lives in a CSV). ONE tool, "
+    "three actions:\n"
+    "  • action='validate' — quality audit. Three checks combined: "
+    "(a) Z-score outlier flagging per column (threshold 3.0 default — "
+    "tighten to 2.0 for curated data, loosen to 4.0+ for wide-scan); "
+    "(b) physical-constraint checks (negative band gaps, density-out-"
+    "of-range, stoichiometric impossibilities); (c) per-column "
+    "completeness scoring. Returns a structured report + a human-"
+    "readable summary. Use before training a model or making a decision "
+    "off the data.\n"
+    "  • action='review' — peer-review-style assessment. Looks for "
+    "structural issues, missing metadata, statistical anomalies. "
+    "Heavier than 'validate'; use when the user asks 'is this dataset "
+    "publishable / ready for analysis?'.\n"
+    "  • action='visualize' — generate visual summaries. See the "
+    "underlying skill for supported chart types. Use when the user "
+    "wants 'show me this dataset's distribution / relationships'.\n"
+    "All three require `dataset_name`. NOT for ad-hoc plots of arbitrary "
+    "data (use `plot` for that) and NOT for searching materials databases "
+    "(use materials_search)."
+)
+
+
+_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "action": {
+            "type": "string",
+            "enum": list(_DISPATCH.keys()),
+            "description": "Which dataset operation to perform.",
+        },
+        "dataset_name": {
+            "type": "string",
+            "description": (
+                "Name of the dataset registered in the PRISM DataStore. "
+                "Use `import_dataset` first if it lives in a CSV. Required "
+                "for all actions."
+            ),
+        },
+        "z_threshold": {
+            "type": "number",
+            "description": (
+                "Z-score threshold for outlier flagging in action='validate'. "
+                "Default 3.0 (≈ outside 99.7%). Tighten to 2.0 for stricter "
+                "review of curated datasets; loosen to 4.0+ for wide-scan "
+                "exploration data."
+            ),
+            "default": 3.0,
+        },
+        "kind": {
+            "type": "string",
+            "description": (
+                "Visualization kind for action='visualize'. See the "
+                "visualization skill for supported values."
+            ),
+        },
+    },
+    "required": ["action", "dataset_name"],
+    "additionalProperties": False,
+}
+
+
+def create_dataset_tool(registry: ToolRegistry) -> None:
+    """Register the unified `dataset` tool.
+
+    Replaces the previously-separate VALIDATE_SKILL / REVIEW_SKILL /
+    VISUALIZE_SKILL registrations. Those Skill objects remain in the
+    skills/ directory for future Skill-aware harness UX, but they
+    no longer register themselves as Tools.
+    """
+    registry.register(Tool(
+        name="dataset",
+        description=_DESCRIPTION,
+        input_schema=_SCHEMA,
+        func=_dataset,
+    ))

--- a/app/tools/search.py
+++ b/app/tools/search.py
@@ -172,41 +172,9 @@ def create_search_tools(registry: ToolRegistry) -> None:
     ))
 
     # Backward-compat aliases — same behaviour as before, narrower
-    # descriptions so the retriever prefers the unified tool unless
-    # the user/agent specifically asks for one source. Keeping these
-    # avoids breaking any in-flight workflows or scripts.
-    registry.register(Tool(
-        name="literature_search",
-        description=(
-            "[Alias for prior_art_search source='papers']. Search "
-            "scientific literature (arXiv, Semantic Scholar). Prefer "
-            "`prior_art_search` for new code."
-        ),
-        input_schema={
-            "type": "object",
-            "properties": {
-                "query": {"type": "string"},
-                "max_results": {"type": "integer", "default": 20},
-                "sources": {"type": "array", "items": {"type": "string"}},
-            },
-            "required": ["query"],
-        },
-        func=_literature_search,
-    ))
-    registry.register(Tool(
-        name="patent_search",
-        description=(
-            "[Alias for prior_art_search source='patents']. Search "
-            "patents via Lens.org. Requires LENS_API_TOKEN. Prefer "
-            "`prior_art_search` for new code."
-        ),
-        input_schema={
-            "type": "object",
-            "properties": {
-                "query": {"type": "string"},
-                "max_results": {"type": "integer", "default": 20},
-            },
-            "required": ["query"],
-        },
-        func=_patent_search,
-    ))
+    # NOTE: literature_search and patent_search aliases were removed in
+    # Round 6 cleanup. Both functionalities are accessible via
+    # prior_art_search(source='papers'|'patents'). The aliases existed
+    # only to ease migration; keeping them inflated the embedding
+    # retrieval surface (Stage 2.1) without adding capability. Any
+    # callers should switch to prior_art_search.

--- a/app/tools/skills/registry.py
+++ b/app/tools/skills/registry.py
@@ -1,4 +1,11 @@
-"""Built-in skill registry: loads all PRISM skills."""
+"""Built-in skill registry: loads all PRISM skills.
+
+NOTE: The dataset-shaped skills (VALIDATE_SKILL / REVIEW_SKILL /
+VISUALIZE_SKILL) were collapsed into the unified `dataset` Tool in
+Round 6. They are NOT registered here anymore — the underlying
+implementations stay in their respective files and are dispatched
+via app/tools/dataset.py. See that file's docstring for rationale.
+"""
 
 from app.tools.skills.base import SkillRegistry
 
@@ -9,24 +16,18 @@ def load_builtin_skills() -> SkillRegistry:
 
     from app.tools.skills.acquisition import ACQUIRE_SKILL
     from app.tools.skills.prediction import PREDICT_SKILL
-    from app.tools.skills.visualization import VISUALIZE_SKILL
     from app.tools.skills.reporting import REPORT_SKILL
     from app.tools.skills.selection import SELECT_SKILL
     from app.tools.skills.discovery import DISCOVER_SKILL
     from app.tools.skills.simulation_plan import SIM_PLAN_SKILL
     from app.tools.skills.phase_analysis import PHASE_ANALYSIS_SKILL
-    from app.tools.skills.validation import VALIDATE_SKILL
-    from app.tools.skills.review import REVIEW_SKILL
 
     registry.register(ACQUIRE_SKILL)
     registry.register(PREDICT_SKILL)
-    registry.register(VISUALIZE_SKILL)
     registry.register(REPORT_SKILL)
     registry.register(SELECT_SKILL)
     registry.register(DISCOVER_SKILL)
     registry.register(SIM_PLAN_SKILL)
     registry.register(PHASE_ANALYSIS_SKILL)
-    registry.register(VALIDATE_SKILL)
-    registry.register(REVIEW_SKILL)
 
     return registry

--- a/app/tools/system.py
+++ b/app/tools/system.py
@@ -243,33 +243,11 @@ def create_system_tools(registry: ToolRegistry) -> None:
         input_schema=_FILE_SCHEMA,
         func=_file,
     ))
-    registry.register(Tool(
-        name="web_search",
-        description=(
-            "General-purpose web search. Returns titles, URLs, and "
-            "snippets of pages matching the query. Use this when the "
-            "user wants information from the open web — current "
-            "events, vendor docs, blog posts, GitHub repos, anything "
-            "that wouldn't be in a structured database. NOT for "
-            "scientific papers (use `prior_art_search` source='papers' "
-            "— better metadata + DOIs) and NOT for materials "
-            "structures (use `materials_search` for the federated "
-            "DB hits). Typically a fast first-pass tool the agent "
-            "follows up with `web_read` on the most-promising URL."
-        ),
-        input_schema={
-            "type": "object",
-            "properties": {
-                "query": {
-                    "type": "string",
-                    "description": "Free-text web search query.",
-                },
-            },
-            "required": ["query"],
-            "additionalProperties": False,
-        },
-        func=_web_search,
-    ))
+    # NOTE: the system.py `web_search` Tool registration was removed in
+    # Round 6 cleanup. It duplicated the richer Firecrawl-or-DuckDuckGo
+    # implementation in app/tools/web.py, which is now exposed as
+    # `web(action='search')`. The `_web_search` function below remains
+    # because internal helpers (and tests) may call it directly.
     registry.register(Tool(
         name="show_scratchpad",
         description=(

--- a/app/tools/web.py
+++ b/app/tools/web.py
@@ -245,54 +245,71 @@ def _web_search(**kwargs) -> dict:
         return {"error": f"All search methods failed: {e}"}
 
 
+def _web(**kwargs) -> dict:
+    """Unified web dispatcher. Replaces web_read + web_search."""
+    action = kwargs.pop("action", None)
+    if not action:
+        return {
+            "error": "Missing 'action'. Valid: read, search",
+            "hint": (
+                "web(action='read', url='https://...') — fetch one page as clean text. "
+                "web(action='search', query='...') — search the web for relevant URLs."
+            ),
+        }
+    if action == "read":
+        if not kwargs.get("url"):
+            return {"error": "Action 'read' requires `url`"}
+        return _web_read(**kwargs)
+    if action == "search":
+        if not kwargs.get("query"):
+            return {"error": "Action 'search' requires `query`"}
+        return _web_search(**kwargs)
+    return {"error": f"Unknown action '{action}'. Valid: read, search"}
+
+
+_WEB_DESCRIPTION = (
+    "Open-web access. ONE tool, two actions:\n"
+    "  • action='read' — fetch a single URL and return clean text content. "
+    "Handles JavaScript-heavy sites, strips HTML, returns markdown. Requires "
+    "`url`. Use to read papers, docs, Wikipedia articles, blog posts.\n"
+    "  • action='search' — query the open web; returns titles, URLs, snippets. "
+    "Requires `query`. Optional `limit` (default 5). Searches via Firecrawl "
+    "(if configured) or DuckDuckGo.\n"
+    "Typical sequence: action='search' → pick the best URL → action='read' on "
+    "that URL. NOT for scientific papers (use prior_art_search for better "
+    "metadata + DOIs) and NOT for the MARC27 KG (use knowledge(action='search'))."
+)
+
+
 def create_web_tools(registry: ToolRegistry) -> None:
-    """Register web browsing tools."""
-
-    registry.register(
-        Tool(
-            name="web_read",
-            description=(
-                "Read a web page and return clean text content. Handles JavaScript-heavy "
-                "sites, strips HTML, and returns markdown. Use this to read papers, docs, "
-                "Wikipedia articles, or any web page. Returns clean text ready for analysis."
-            ),
-            input_schema={
-                "type": "object",
-                "properties": {
-                    "url": {
-                        "type": "string",
-                        "description": "URL to read (https://...)",
-                    },
+    """Register the unified `web` tool (replaces web_read + web_search)."""
+    registry.register(Tool(
+        name="web",
+        description=_WEB_DESCRIPTION,
+        input_schema={
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["read", "search"],
+                    "description": "Which web operation to perform.",
                 },
-                "required": ["url"],
-            },
-            func=_web_read,
-        )
-    )
-
-    registry.register(
-        Tool(
-            name="web_search",
-            description=(
-                "Search the web for information. Returns titles, URLs, and snippets. "
-                "Use to find papers, datasets, documentation, or any web content. "
-                "Searches via Firecrawl (if configured) or DuckDuckGo."
-            ),
-            input_schema={
-                "type": "object",
-                "properties": {
-                    "query": {
-                        "type": "string",
-                        "description": "Search query",
-                    },
-                    "limit": {
-                        "type": "integer",
-                        "description": "Max results (default 5)",
-                        "default": 5,
-                    },
+                "url": {
+                    "type": "string",
+                    "description": "URL to read for action='read' (https://...).",
                 },
-                "required": ["query"],
+                "query": {
+                    "type": "string",
+                    "description": "Search query for action='search'.",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max results for action='search' (default 5).",
+                    "default": 5,
+                },
             },
-            func=_web_search,
-        )
-    )
+            "required": ["action"],
+            "additionalProperties": False,
+        },
+        func=_web,
+    ))

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -21,8 +21,10 @@ class TestBuildFullRegistry:
     def test_has_system_tools(self):
         registry, _prov, _agents = build_full_registry(enable_mcp=False, enable_plugins=False)
         names = {t.name for t in registry.list_tools()}
-        # System tools exist (read_file, write_file, web_search)
-        assert "read_file" in names or len(names) > 3
+        # System tools exist (file unified, show_scratchpad). web search
+        # lives in app/tools/web.py now as web(action='search').
+        assert "file" in names
+        assert "show_scratchpad" in names
 
     def test_has_visualization_tools(self):
         registry, _prov, _agents = build_full_registry(enable_mcp=False, enable_plugins=False)
@@ -70,12 +72,20 @@ class TestBuildFullRegistry:
         names = {t.name for t in registry.list_tools()}
         assert "list_predictable_properties" in names
 
-    def test_has_validate_and_review_skills(self):
-        """validate_dataset and review_dataset skills are registered."""
+    def test_has_dataset_tool(self):
+        """Round 6 collapse: validate_dataset / review_dataset / visualize_dataset
+        Skills were collapsed into the unified `dataset(action=…)` Tool."""
         registry, _prov, _agents = build_full_registry(enable_mcp=False, enable_plugins=False)
         names = {t.name for t in registry.list_tools()}
-        assert "validate_dataset" in names
-        assert "review_dataset" in names
+        assert "dataset" in names
+        # Old Skill names must be gone
+        assert "validate_dataset" not in names
+        assert "review_dataset" not in names
+        assert "visualize_dataset" not in names
+        # The unified tool advertises all three actions
+        ds = registry.get("dataset")
+        actions = ds.input_schema["properties"]["action"]["enum"]
+        assert set(actions) == {"validate", "review", "visualize"}
 
     def test_has_correlation_matrix_tool(self):
         """correlation_matrix is now a kind of the unified `plot` tool."""

--- a/tests/test_data_sources_integration.py
+++ b/tests/test_data_sources_integration.py
@@ -28,17 +28,16 @@ class TestGetDefaultCollectorRegistry:
 
 
 class TestBuildFullRegistryIncludesSearchTools:
-    def test_has_literature_search(self):
+    def test_has_prior_art_search(self):
+        """Round 6 collapse: literature_search + patent_search aliases
+        were removed; prior_art_search is the canonical entry point."""
         from app.plugins.bootstrap import build_full_registry
         reg, _prov, _agents = build_full_registry(enable_mcp=False, enable_plugins=False)
         names = [t.name for t in reg.list_tools()]
-        assert "literature_search" in names
-
-    def test_has_patent_search(self):
-        from app.plugins.bootstrap import build_full_registry
-        reg, _prov, _agents = build_full_registry(enable_mcp=False, enable_plugins=False)
-        names = [t.name for t in reg.list_tools()]
-        assert "patent_search" in names
+        assert "prior_art_search" in names
+        # Old aliases must be gone
+        assert "literature_search" not in names
+        assert "patent_search" not in names
 
 
 class TestOMAT24Integration:

--- a/tests/test_search_tools.py
+++ b/tests/test_search_tools.py
@@ -1,4 +1,10 @@
-"""Tests for literature_search and patent_search tools."""
+"""Tests for the search tools.
+
+After Round 6: the literature_search and patent_search Tool aliases were
+removed. Both functionalities live behind prior_art_search(source=…). The
+private _literature_search / _patent_search helpers are preserved for
+direct testing because prior_art_search dispatches into them.
+"""
 import pytest
 from unittest.mock import patch, MagicMock
 from app.tools.base import ToolRegistry
@@ -6,29 +12,24 @@ from app.tools.search import create_search_tools, _literature_search, _patent_se
 
 
 class TestCreateSearchTools:
-    def test_registers_both_tools(self):
+    def test_registers_prior_art_search(self):
         reg = ToolRegistry()
         create_search_tools(reg)
         names = [t.name for t in reg.list_tools()]
-        assert "literature_search" in names
-        assert "patent_search" in names
+        # Unified entry — replaced the two aliases
+        assert "prior_art_search" in names
+        # Old aliases must be gone (they inflated the retrieval surface
+        # without adding capability)
+        assert "literature_search" not in names
+        assert "patent_search" not in names
 
-    def test_literature_search_tool_schema(self):
+    def test_prior_art_search_schema(self):
         reg = ToolRegistry()
         create_search_tools(reg)
-        tool = reg.get("literature_search")
-        assert tool.input_schema["required"] == ["query"]
+        tool = reg.get("prior_art_search")
+        assert "query" in tool.input_schema["required"]
         assert "query" in tool.input_schema["properties"]
-        assert "max_results" in tool.input_schema["properties"]
-        assert "sources" in tool.input_schema["properties"]
-
-    def test_patent_search_tool_schema(self):
-        reg = ToolRegistry()
-        create_search_tools(reg)
-        tool = reg.get("patent_search")
-        assert tool.input_schema["required"] == ["query"]
-        assert "query" in tool.input_schema["properties"]
-        assert "max_results" in tool.input_schema["properties"]
+        assert "source" in tool.input_schema["properties"]
 
 
 class TestLiteratureSearchFunc:
@@ -40,7 +41,7 @@ class TestLiteratureSearchFunc:
         ]
         result = _literature_search(query="tungsten alloy")
         assert result["count"] == 2
-        assert result["query"] == "tungsten alloy"
+        assert result["source"] == "literature"
         assert len(result["results"]) == 2
 
     @patch("app.tools.data_collectors.literature_collector.LiteratureCollector.collect")
@@ -59,7 +60,7 @@ class TestPatentSearchFunc:
         ]
         result = _patent_search(query="alloy coating")
         assert result["count"] == 1
-        assert result["query"] == "alloy coating"
+        assert result["source"] == "patents"
 
     @patch("app.tools.data_collectors.patent_collector.PatentCollector.collect")
     def test_no_token_empty(self, mock_collect):

--- a/tests/test_skill_registry.py
+++ b/tests/test_skill_registry.py
@@ -5,21 +5,27 @@ from app.tools.base import ToolRegistry
 
 
 class TestSkillRegistry:
+    """After Round 6: VALIDATE_SKILL / REVIEW_SKILL / VISUALIZE_SKILL were
+    collapsed into the unified `dataset` Tool, registered separately. The
+    Skill registry now only holds the materials-workflow skills."""
+
     def test_load_all_skills(self):
         reg = load_builtin_skills()
         skills = reg.list_skills()
         names = {s.name for s in skills}
+        # Materials-workflow skills (preserved as Skills)
         assert "acquire_materials" in names
         assert "predict_properties" in names
-        assert "visualize_dataset" in names
         assert "generate_report" in names
         assert "select_materials" in names
         assert "materials_discovery" in names
         assert "plan_simulations" in names
         assert "analyze_phases" in names
-        assert "validate_dataset" in names
-        assert "review_dataset" in names
-        assert len(skills) == 10
+        # Dataset-shaped skills GONE — collapsed into the `dataset` Tool
+        assert "validate_dataset" not in names
+        assert "review_dataset" not in names
+        assert "visualize_dataset" not in names
+        assert len(skills) == 7  # 10 - 3 (dataset trio collapsed out)
 
     def test_all_convert_to_tools(self):
         reg = load_builtin_skills()
@@ -27,7 +33,7 @@ class TestSkillRegistry:
         reg.register_all_as_tools(tool_reg)
 
         tools = tool_reg.list_tools()
-        assert len(tools) == 10
+        assert len(tools) == 7
         for tool in tools:
             assert tool.name
             assert tool.description

--- a/tests/test_tools_system.py
+++ b/tests/test_tools_system.py
@@ -16,8 +16,10 @@ class TestSystemTools:
         registry = ToolRegistry()
         create_system_tools(registry)
         names = [t.name for t in registry.list_tools()]
-        # web_search and show_scratchpad still standalone
-        assert "web_search" in names
+        # show_scratchpad standalone; web_search REMOVED in Round 6 cleanup
+        # (web search now lives in app/tools/web.py as web(action='search'))
+        assert "web_search" not in names
+        assert "show_scratchpad" in names
         # Unified file tool replaced read_file/write_file/edit_file
         assert "file" in names
         assert "read_file" not in names


### PR DESCRIPTION
## Summary

Three independent collapses bundled into one Round 6 PR. Net surface: **39 → 34 tools** (−5).

| Cluster | Before | After |
|---|---|---|
| Web | `web_read`, `web_search` | `web(action='read'\|'search')` |
| Dataset Skills | `validate_dataset`, `review_dataset`, `visualize_dataset` | `dataset(action='validate'\|'review'\|'visualize')` |
| Aliases | `literature_search`, `patent_search` | (removed — use `prior_art_search(source=…)`) |
| Duplicate | `web_search` (also in system.py, masked before) | (removed — was a duplicate of web.py's richer version) |

## Dataset Skill-merge — crosses an abstraction boundary

`VALIDATE_SKILL` / `REVIEW_SKILL` / `VISUALIZE_SKILL` were `Skill` objects; the new `dataset` is a `Tool`. The Skill objects remain importable from `app/tools/skills/` for any future Skill-aware harness UX, but they no longer register themselves as Tools. The implementations stay in their original files; `app/tools/dataset.py` dispatches via lazy imports.

**Why it's safe:** The Skill `steps` metadata isn't surfaced to the LLM agent today — only the generated Tool is. So the agent-visible behavior is unchanged. If/when the harness gains per-step UX, Skill registration can come back without changing this dispatcher contract.

## Alias cleanup

`literature_search` and `patent_search` had `[Alias for prior_art_search source='X']` in their descriptions since the prior_art_search collapse. They inflated the Stage 2.1 retrieval surface without adding capability. The underlying `_literature_search` / `_patent_search` impl helpers stay — `prior_art_search` dispatches into them.

System.py had its own `web_search` (older DuckDuckGo-only implementation). It was masked by web.py's richer registration; now exposed because web.py's `web_search` is gone too. Removed.

## Test plan

- [x] Updated `test_bootstrap.py`, `test_data_sources_integration.py`, `test_search_tools.py`, `test_skill_registry.py`, `test_tools_system.py`
- [x] Skill-direct tests preserved (`test_skill_validation.py` etc. import `VALIDATE_SKILL` directly — still works because the Skill objects are still importable)
- [x] **Fixed pre-existing bug** in `test_search_tools.py` — assertions checked for a `query` field that the impl never returned (test was pre-broken; now matches actual return shape)
- [x] **84/84 affected tests pass. Zero regression.**

## Out of scope

- `materials_search` / `search_materials` / `query_materials_project` consolidation (different scopes — federated vs OPTIMADE vs MP-only; needs careful design)
- `acquire_materials` / `select_materials` / `analyze_phases` Skills (different shapes; collapsing risks semantic loss)
- Round 5 sim_jobs / structure / calphad (need pyiron installed)
- Per-action `requires_approval` (architectural — would unlock deeper collapses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Unified dataset operations (validate, review, visualize) into a single `dataset` tool with configurable actions.
  * Unified web operations (read, search) into a single `web` tool with configurable actions.

* **Bug Fixes & Improvements**
  * Removed deprecated `literature_search` and `patent_search` tool aliases; use `prior_art_search` with the `source` parameter instead.
  * Removed redundant `web_search` tool; functionality consolidated into unified web tool.
  * Simplified tool registry by removing dataset-related skills in favor of unified tool interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->