### PR TITLE
Round 7: search_materials dedupe + dataset I/O extension (34→31)

### DIFF
--- a/app/tools/data.py
+++ b/app/tools/data.py
@@ -150,85 +150,43 @@ def _export_results_csv(**kwargs) -> dict:
 
 
 def create_data_tools(registry: ToolRegistry) -> None:
-    registry.register(Tool(
-        name="search_materials",
-        description="Materials structure search across 20+ external federated databases (NOMAD, Materials Project, OQMD, COD, Alexandria, GNoME). Returns crystal structures, formulas, and metadata. NOT for searching the MARC27 internal knowledge graph (use knowledge_search) and NOT for searching scientific papers (use literature_search).",
-        input_schema={"type": "object", "properties": {
-            "elements": {"type": "array", "items": {"type": "string"}, "description": "Must contain ALL these elements (e.g., ['Fe', 'O'])"},
-            "formula": {"type": "string", "description": "Chemical formula (e.g., 'SiO2')"},
-            "n_elements_min": {"type": "integer", "description": "Minimum number of elements"},
-            "n_elements_max": {"type": "integer", "description": "Maximum number of elements"},
-            "band_gap_min": {"type": "number", "description": "Minimum band gap in eV"},
-            "band_gap_max": {"type": "number", "description": "Maximum band gap in eV"},
-            "space_group": {"type": "string", "description": "Space group symbol (e.g., 'Fm-3m')"},
-            "crystal_system": {"type": "string", "enum": ["cubic", "hexagonal", "tetragonal", "orthorhombic", "monoclinic", "triclinic", "trigonal"], "description": "Crystal system"},
-            "providers": {"type": "array", "items": {"type": "string"}, "description": "Optional: only query these provider IDs"},
-            "limit": {"type": "integer", "description": "Max results (default 20)", "default": 20}}},
-        func=_search_materials))
+    """Register data-shaped tools.
+
+    NOTE on Round 7 scope:
+      - `search_materials` registration was REMOVED. It duplicated
+        `materials_search` (in app/tools/search_engine/tools.py); both
+        called the same SearchEngine + ProviderRegistry. The richer
+        `materials_search` is the canonical entry point.
+      - `import_dataset` and `export_results_csv` registrations were
+        REMOVED. Both folded into the unified `dataset` Tool as
+        `dataset(action='import')` / `dataset(action='export')`.
+      - The underlying private helpers (_search_materials,
+        _import_dataset, _export_results_csv) are PRESERVED. They're
+        called by the dataset dispatcher, by Skills, and by tests.
+
+    What's still registered here:
+      - `query_materials_project` — different scope from materials_search.
+        It's the deep-property-detail path (uses mp_api.client.MPRester
+        with explicit field selection); materials_search is the
+        federated catalog-shaped query. Both are useful.
+    """
     registry.register(Tool(
         name="query_materials_project",
-        description="Query Materials Project for detailed material properties like band gap, formation energy, bulk modulus. Requires MP_API_KEY.",
-        input_schema={"type": "object", "properties": {
-            "formula": {"type": "string", "description": "Chemical formula, e.g. 'LiCoO2'"},
-            "material_id": {"type": "string", "description": "Materials Project ID, e.g. 'mp-1234'"},
-            "properties": {"type": "array", "items": {"type": "string"}, "description": "Properties to retrieve."}}},
-        func=_query_materials_project))
-    registry.register(Tool(
-        name="export_results_csv",
-        description="Export a list of result dictionaries to a CSV file. Use after gathering data to save results for the user.",
-        input_schema={"type": "object", "properties": {
-            "results": {"type": "array", "items": {"type": "object"}, "description": "List of result dictionaries to export"},
-            "filename": {"type": "string", "description": "Output CSV filename. Auto-generated if omitted."}},
-            "required": ["results"]},
-        func=_export_results_csv))
-    registry.register(Tool(
-        name="import_dataset",
         description=(
-            "Load a local CSV / JSON / Parquet file into the PRISM "
-            "DataStore so other tools (`validate_dataset`, "
-            "`plot_correlation_matrix`, training pipelines) can refer "
-            "to it by name. Use this whenever the user has data on "
-            "disk they want to analyse — 'I have a CSV with 500 alloy "
-            "compositions, can you check it?'. Format is auto-detected "
-            "from extension (.csv / .json / .parquet); pass file_format "
-            "explicitly only when the extension is wrong or missing. "
-            "Dataset name defaults to the file's stem (e.g. "
-            "`/tmp/alloys.csv` → `alloys`); override with dataset_name "
-            "to avoid clobbering an existing one. Returns the resolved "
-            "dataset_name + row/column counts so the agent can confirm "
-            "the load worked before piping into other tools."
+            "Query Materials Project for detailed material properties — "
+            "band gap, formation energy, bulk modulus, etc. Use this "
+            "when you have a specific material (formula or mp-ID) and "
+            "need rich property data. NOT a substitute for "
+            "materials_search (use that for federated catalog queries "
+            "across 20+ databases). Requires MP_API_KEY."
         ),
         input_schema={
             "type": "object",
             "properties": {
-                "file_path": {
-                    "type": "string",
-                    "description": (
-                        "Absolute or working-directory-relative path to "
-                        "the source file. Glob patterns NOT supported — "
-                        "one file per call."
-                    ),
-                },
-                "dataset_name": {
-                    "type": "string",
-                    "description": (
-                        "Name to register under in the DataStore. "
-                        "Defaults to the file's stem; override to avoid "
-                        "overwriting an existing dataset of that name."
-                    ),
-                },
-                "file_format": {
-                    "type": "string",
-                    "enum": ["csv", "json", "parquet"],
-                    "description": (
-                        "Format override — pass when the extension is "
-                        "wrong or absent. Default behaviour is to "
-                        "auto-detect from the extension."
-                    ),
-                },
+                "formula": {"type": "string", "description": "Chemical formula, e.g. 'LiCoO2'"},
+                "material_id": {"type": "string", "description": "Materials Project ID, e.g. 'mp-1234'"},
+                "properties": {"type": "array", "items": {"type": "string"}, "description": "Properties to retrieve."},
             },
-            "required": ["file_path"],
-            "additionalProperties": False,
         },
-        func=_import_dataset,
+        func=_query_materials_project,
     ))

--- a/app/tools/dataset.py
+++ b/app/tools/dataset.py
@@ -47,11 +47,32 @@ def _act_visualize(**kwargs) -> dict:
     return _visualize_dataset(**kwargs)
 
 
+def _act_import(**kwargs) -> dict:
+    """Round 7 addition: load a CSV/JSON/Parquet into the DataStore."""
+    from app.tools.data import _import_dataset
+    return _import_dataset(**kwargs)
+
+
+def _act_export(**kwargs) -> dict:
+    """Round 7 addition: write a list of result dicts to a CSV file."""
+    from app.tools.data import _export_results_csv
+    return _export_results_csv(**kwargs)
+
+
 _DISPATCH = {
     "validate":  _act_validate,
     "review":    _act_review,
     "visualize": _act_visualize,
+    "import":    _act_import,
+    "export":    _act_export,
 }
+
+
+# Actions that REQUIRE a `dataset_name` argument (the analysis ops).
+# import + export use different keys (file_path / results), so they're
+# excluded from this gate and validate themselves through the underlying
+# impls.
+_REQUIRES_DATASET_NAME = {"validate", "review", "visualize"}
 
 
 def _dataset(**kwargs) -> dict:
@@ -62,14 +83,20 @@ def _dataset(**kwargs) -> dict:
             "hint": (
                 "dataset(action='validate', dataset_name='...') / "
                 "dataset(action='review', dataset_name='...') / "
-                "dataset(action='visualize', dataset_name='...', kind='...')"
+                "dataset(action='visualize', dataset_name='...') / "
+                "dataset(action='import', file_path='./alloys.csv') / "
+                "dataset(action='export', results=[{...}, ...])"
             ),
         }
     handler = _DISPATCH.get(action)
     if not handler:
         return {"error": f"Unknown action '{action}'. Valid: {list(_DISPATCH.keys())}"}
-    if not kwargs.get("dataset_name"):
+    if action in _REQUIRES_DATASET_NAME and not kwargs.get("dataset_name"):
         return {"error": f"Action '{action}' requires `dataset_name`"}
+    if action == "import" and not kwargs.get("file_path"):
+        return {"error": "Action 'import' requires `file_path`"}
+    if action == "export" and "results" not in kwargs:
+        return {"error": "Action 'export' requires `results` (list of dicts)"}
     try:
         return handler(**kwargs)
     except Exception as e:
@@ -77,27 +104,36 @@ def _dataset(**kwargs) -> dict:
 
 
 _DESCRIPTION = (
-    "Operate on a stored dataset (in the PRISM DataStore — use "
-    "`import_dataset` first if your data lives in a CSV). ONE tool, "
-    "three actions:\n"
+    "Dataset I/O + analysis. ONE tool, five actions:\n"
+    "\n"
+    "I/O actions:\n"
+    "  • action='import' — load a local CSV / JSON / Parquet file into the "
+    "PRISM DataStore. Requires `file_path`. Optional: `dataset_name` "
+    "(default: file stem), `file_format` (default: auto-detect from "
+    "extension). Returns the resolved dataset_name + row/column counts.\n"
+    "  • action='export' — write a list of result dictionaries to a CSV "
+    "file. Requires `results` (list of dicts). Optional: `filename` "
+    "(default: auto-generated). Use after gathering data to save results.\n"
+    "\n"
+    "Analysis actions (require `dataset_name` — use action='import' first "
+    "if your data lives in a file):\n"
     "  • action='validate' — quality audit. Three checks combined: "
-    "(a) Z-score outlier flagging per column (threshold 3.0 default — "
+    "(a) Z-score outlier flagging per column (`z_threshold` default 3.0 — "
     "tighten to 2.0 for curated data, loosen to 4.0+ for wide-scan); "
-    "(b) physical-constraint checks (negative band gaps, density-out-"
-    "of-range, stoichiometric impossibilities); (c) per-column "
-    "completeness scoring. Returns a structured report + a human-"
-    "readable summary. Use before training a model or making a decision "
-    "off the data.\n"
+    "(b) physical-constraint checks (negative band gaps, density "
+    "out-of-range, stoichiometric impossibilities); (c) per-column "
+    "completeness scoring. Returns a structured report + human-readable "
+    "summary. Use before training a model or making a decision off the data.\n"
     "  • action='review' — peer-review-style assessment. Looks for "
-    "structural issues, missing metadata, statistical anomalies. "
-    "Heavier than 'validate'; use when the user asks 'is this dataset "
-    "publishable / ready for analysis?'.\n"
+    "structural issues, missing metadata, statistical anomalies. Heavier "
+    "than 'validate'; use when the user asks 'is this dataset publishable "
+    "/ ready for analysis?'.\n"
     "  • action='visualize' — generate visual summaries. See the "
-    "underlying skill for supported chart types. Use when the user "
+    "visualization skill for supported chart kinds. Use when the user "
     "wants 'show me this dataset's distribution / relationships'.\n"
-    "All three require `dataset_name`. NOT for ad-hoc plots of arbitrary "
-    "data (use `plot` for that) and NOT for searching materials databases "
-    "(use materials_search)."
+    "\n"
+    "NOT for ad-hoc plots of arbitrary data (use `plot` for that) and "
+    "NOT for searching materials databases (use `materials_search`)."
 )
 
 
@@ -109,21 +145,22 @@ _SCHEMA = {
             "enum": list(_DISPATCH.keys()),
             "description": "Which dataset operation to perform.",
         },
+        # Analysis actions
         "dataset_name": {
             "type": "string",
             "description": (
                 "Name of the dataset registered in the PRISM DataStore. "
-                "Use `import_dataset` first if it lives in a CSV. Required "
-                "for all actions."
+                "Required for action='validate'/'review'/'visualize'. "
+                "For action='import', this is the optional name to "
+                "register the file under (defaults to file stem)."
             ),
         },
         "z_threshold": {
             "type": "number",
             "description": (
                 "Z-score threshold for outlier flagging in action='validate'. "
-                "Default 3.0 (≈ outside 99.7%). Tighten to 2.0 for stricter "
-                "review of curated datasets; loosen to 4.0+ for wide-scan "
-                "exploration data."
+                "Default 3.0. Tighten to 2.0 for stricter review of curated "
+                "datasets; loosen to 4.0+ for wide-scan exploration data."
             ),
             "default": 3.0,
         },
@@ -134,8 +171,42 @@ _SCHEMA = {
                 "visualization skill for supported values."
             ),
         },
+        # Import action
+        "file_path": {
+            "type": "string",
+            "description": (
+                "Source file path for action='import'. Absolute or "
+                "working-directory-relative. Glob patterns NOT supported "
+                "— one file per call."
+            ),
+        },
+        "file_format": {
+            "type": "string",
+            "enum": ["csv", "json", "parquet"],
+            "description": (
+                "Format override for action='import'. Pass when the "
+                "extension is wrong or absent. Default: auto-detect."
+            ),
+        },
+        # Export action
+        "results": {
+            "type": "array",
+            "items": {"type": "object"},
+            "description": (
+                "List of result dictionaries to export for action='export'. "
+                "All dicts should share the same key shape; missing keys "
+                "become empty cells."
+            ),
+        },
+        "filename": {
+            "type": "string",
+            "description": (
+                "Output CSV path for action='export'. Auto-generated under "
+                "the working directory if omitted."
+            ),
+        },
     },
-    "required": ["action", "dataset_name"],
+    "required": ["action"],
     "additionalProperties": False,
 }
 

--- a/app/tools/skills/acquisition.py
+++ b/app/tools/skills/acquisition.py
@@ -102,7 +102,7 @@ ACQUIRE_SKILL = Skill(
         "normalize records, and save as a named dataset for downstream analysis."
     ),
     steps=[
-        SkillStep("collect_optimade", "Query materials databases", "search_materials"),
+        SkillStep("collect_optimade", "Query materials databases", "materials_search"),
         SkillStep(
             "collect_mp",
             "Query Materials Project",

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -11,12 +11,18 @@ class TestBuildFullRegistry:
         # Also verify we got 3 items from the full call
 
     def test_has_core_tools(self):
+        """After Round 7: search_materials was removed (duplicate of
+        materials_search); import_dataset and export_results_csv folded into
+        the unified `dataset` Tool as actions."""
         registry, _prov, _agents = build_full_registry(enable_mcp=False, enable_plugins=False)
         names = {t.name for t in registry.list_tools()}
-        assert "search_materials" in names
-        assert "query_materials_project" in names
-        assert "export_results_csv" in names
-        assert "import_dataset" in names
+        assert "materials_search" in names  # canonical federated search
+        assert "query_materials_project" in names  # MP-specific deep query
+        assert "dataset" in names  # absorbs import + export
+        # Old names must be gone
+        assert "search_materials" not in names
+        assert "import_dataset" not in names
+        assert "export_results_csv" not in names
 
     def test_has_system_tools(self):
         registry, _prov, _agents = build_full_registry(enable_mcp=False, enable_plugins=False)
@@ -82,10 +88,11 @@ class TestBuildFullRegistry:
         assert "validate_dataset" not in names
         assert "review_dataset" not in names
         assert "visualize_dataset" not in names
-        # The unified tool advertises all three actions
+        # The unified tool advertises all five actions (Round 7 added
+        # import + export by absorbing import_dataset + export_results_csv)
         ds = registry.get("dataset")
         actions = ds.input_schema["properties"]["action"]["enum"]
-        assert set(actions) == {"validate", "review", "visualize"}
+        assert set(actions) == {"validate", "review", "visualize", "import", "export"}
 
     def test_has_correlation_matrix_tool(self):
         """correlation_matrix is now a kind of the unified `plot` tool."""

--- a/tests/test_mcp_roundtrip.py
+++ b/tests/test_mcp_roundtrip.py
@@ -17,9 +17,11 @@ class TestMCPRoundTrip:
                 return [t.name for t in tools]
 
         tool_names = asyncio.run(run())
-        assert "search_materials" in tool_names
-        assert "predict_property" in tool_names
-        assert "export_results_csv" in tool_names
+        # After Round 4-7 collapses: predict_property → predict, export_results_csv
+        # → dataset(action='export'), search_materials → materials_search.
+        assert "materials_search" in tool_names
+        assert "predict" in tool_names
+        assert "dataset" in tool_names
         assert "list_models" in tool_names
         assert len(tool_names) >= 10
 
@@ -67,5 +69,5 @@ class TestMCPRoundTrip:
         text = asyncio.run(run())
         data = json.loads(text)
         tool_names = [t["name"] for t in data]
-        assert "search_materials" in tool_names
+        assert "materials_search" in tool_names  # was search_materials before Round 7
         assert "list_models" in tool_names

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -22,10 +22,13 @@ class TestMCPServer:
                 return [t.name for t in tools]
 
         tool_names = asyncio.run(run())
-        assert "search_materials" in tool_names
+        # After Round 4-7 collapses:
+        #   search_materials → materials_search (canonical federated)
+        #   export_results_csv → dataset(action='export')
+        #   predict_property → predict(target=...)
+        assert "materials_search" in tool_names
         assert "query_materials_project" in tool_names
-        assert "export_results_csv" in tool_names
-        # `predict_property` was collapsed into the unified `predict(target=...)` tool.
+        assert "dataset" in tool_names
         assert "predict" in tool_names
         assert "list_models" in tool_names
         assert len(tool_names) >= 10
@@ -54,11 +57,12 @@ class TestMCPServer:
                 return {t.name: t.inputSchema for t in tools}
 
         schemas = asyncio.run(run())
-        # search_materials has elements with a description
-        search_schema = schemas["search_materials"]
+        # materials_search has elements with a description (was search_materials
+        # pre-Round 7; canonical federated tool now)
+        search_schema = schemas["materials_search"]
         assert "elements" in search_schema["properties"]
         assert search_schema["properties"]["elements"]["type"] == "array"
-        # elements is optional (no required fields for search_materials)
+        # elements is optional (no required fields for materials_search)
         assert "elements" not in search_schema.get("required", [])
 
     def test_tool_schema_required_optional(self):
@@ -90,7 +94,7 @@ class TestMCPServer:
         result = asyncio.run(run())
         # Result should be parseable JSON with tool names
         text = str(result)
-        assert "search_materials" in text
+        assert "materials_search" in text  # was search_materials pre-Round 7
         assert "list_models" in text
 
     def test_server_has_dataset_and_model_resources(self):

--- a/tests/test_plugin_integration.py
+++ b/tests/test_plugin_integration.py
@@ -80,12 +80,15 @@ class TestPluginIntegration:
         assert records[0]["formula"] == "H2O"
 
     def test_build_full_registry_without_plugins(self):
-        """build_full_registry with plugins disabled still loads all built-in tools."""
+        """build_full_registry with plugins disabled still loads all built-in tools.
+
+        After Round 7 collapses: search_materials → materials_search,
+        import_dataset → dataset(action='import')."""
         registry, _prov, _agents = build_full_registry(enable_mcp=False, enable_plugins=False)
         names = {t.name for t in registry.list_tools()}
         # Core tools
-        assert "search_materials" in names
-        assert "import_dataset" in names
+        assert "materials_search" in names  # was search_materials pre-Round 7
+        assert "dataset" in names  # absorbed import_dataset as action='import'
         # Skills as tools
         assert "acquire_materials" in names
         assert "materials_discovery" in names

--- a/tests/test_tools_data.py
+++ b/tests/test_tools_data.py
@@ -1,32 +1,36 @@
-"""Tests for data tools."""
+"""Tests for data tools.
+
+After Round 7:
+  - search_materials Tool registration removed (duplicate of materials_search
+    in app/tools/search_engine/tools.py). The _search_materials private
+    helper is still importable for direct unit testing if needed.
+  - import_dataset / export_results_csv Tool registrations removed; both
+    folded into the unified `dataset` Tool as `dataset(action='import')` /
+    `dataset(action='export')`.
+  - query_materials_project remains — different scope (MP-specific deep
+    property query, not a federated catalog search).
+"""
 import os
 import sys
 import pytest
 from unittest.mock import patch, MagicMock
-from app.tools.data import create_data_tools
+from app.tools.data import create_data_tools, _search_materials, _export_results_csv, _import_dataset
 from app.tools.base import ToolRegistry
 
 
-class TestSearchMaterialsTool:
-    def test_tool_registered(self):
+class TestRegistration:
+    def test_only_query_mp_registered(self):
+        """Round 7: data.py now registers ONLY query_materials_project.
+        The other former data tools moved (search_materials → search_engine,
+        import/export → dataset Tool actions)."""
         registry = ToolRegistry()
         create_data_tools(registry)
         names = [t.name for t in registry.list_tools()]
-        assert "search_materials" in names
-
-    def test_search_by_elements(self):
-        registry = ToolRegistry()
-        create_data_tools(registry)
-        tool = registry.get("search_materials")
-        # The tool uses the federated search engine; verify it handles element args
-        result = tool.execute(elements=["Si"], limit=5)
-        assert "results" in result or "error" in result
-
-    def test_search_materials_schema(self):
-        registry = ToolRegistry()
-        create_data_tools(registry)
-        tool = registry.get("search_materials")
-        assert "elements" in tool.input_schema["properties"]
+        assert "query_materials_project" in names
+        # Removed in Round 7
+        assert "search_materials" not in names
+        assert "import_dataset" not in names
+        assert "export_results_csv" not in names
 
 
 class TestQueryMPTool:
@@ -36,21 +40,37 @@ class TestQueryMPTool:
         names = [t.name for t in registry.list_tools()]
         assert "query_materials_project" in names
 
-
-class TestExportResultsCSV:
-    def test_tool_registered(self):
+    def test_schema(self):
         registry = ToolRegistry()
         create_data_tools(registry)
-        names = [t.name for t in registry.list_tools()]
-        assert "export_results_csv" in names
+        tool = registry.get("query_materials_project")
+        # MP-specific schema fields
+        assert "formula" in tool.input_schema["properties"]
+        assert "material_id" in tool.input_schema["properties"]
 
-    def test_export_creates_file(self, tmp_path):
-        registry = ToolRegistry()
-        create_data_tools(registry)
-        tool = registry.get("export_results_csv")
+
+class TestSearchMaterialsImpl:
+    """The private _search_materials function is still used internally
+    (by Skills, by the dataset acquisition workflow). Verify it's
+    importable and has the expected signature."""
+
+    def test_callable_with_elements(self):
+        # Real call would hit the federated search engine; we just verify
+        # the function accepts the expected kwargs without error
+        # (it'll return either results or a network error).
+        result = _search_materials(elements=["Si"], limit=1)
+        assert isinstance(result, dict)
+        assert "results" in result or "error" in result
+
+
+class TestExportResultsCSVImpl:
+    """_export_results_csv is now dispatched via dataset(action='export'),
+    but the underlying impl remains testable directly."""
+
+    def test_creates_file(self, tmp_path):
         filepath = str(tmp_path / "test_export.csv")
         results = [{"id": "mp-1", "formula": "Si"}, {"id": "mp-2", "formula": "Ge"}]
-        out = tool.execute(results=results, filename=filepath)
+        out = _export_results_csv(results=results, filename=filepath)
         assert out["rows"] == 2
         assert os.path.exists(filepath)
         with open(filepath) as f:
@@ -58,18 +78,64 @@ class TestExportResultsCSV:
         assert "id,formula" in content
         assert "mp-1,Si" in content
 
-    def test_export_empty_results(self):
-        registry = ToolRegistry()
-        create_data_tools(registry)
-        tool = registry.get("export_results_csv")
-        out = tool.execute(results=[])
+    def test_empty_results(self):
+        out = _export_results_csv(results=[])
         assert "error" in out
 
-    def test_export_auto_filename(self, tmp_path, monkeypatch):
+    def test_auto_filename(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
-        registry = ToolRegistry()
-        create_data_tools(registry)
-        tool = registry.get("export_results_csv")
-        out = tool.execute(results=[{"a": 1}])
+        out = _export_results_csv(results=[{"a": 1}])
         assert "filename" in out
         assert out["filename"].startswith("prism_export_")
+
+
+class TestDatasetActionImportExport:
+    """Verify the new dataset(action='import') and dataset(action='export')
+    actions wire correctly through the dataset Tool."""
+
+    def test_import_via_dataset_tool(self, tmp_path):
+        from app.tools.dataset import create_dataset_tool
+
+        # Write a small CSV
+        csv_path = tmp_path / "alloys.csv"
+        csv_path.write_text("formula,band_gap\nSi,1.1\nGe,0.67\n")
+
+        registry = ToolRegistry()
+        create_dataset_tool(registry)
+        tool = registry.get("dataset")
+        result = tool.execute(action="import", file_path=str(csv_path))
+        assert "error" not in result, f"unexpected error: {result}"
+        assert result.get("rows") == 2 or "dataset_name" in result
+
+    def test_import_requires_file_path(self):
+        from app.tools.dataset import create_dataset_tool
+        registry = ToolRegistry()
+        create_dataset_tool(registry)
+        tool = registry.get("dataset")
+        result = tool.execute(action="import")
+        assert "error" in result
+        assert "file_path" in result["error"]
+
+    def test_export_via_dataset_tool(self, tmp_path):
+        from app.tools.dataset import create_dataset_tool
+
+        registry = ToolRegistry()
+        create_dataset_tool(registry)
+        tool = registry.get("dataset")
+        out_path = str(tmp_path / "export.csv")
+        result = tool.execute(
+            action="export",
+            results=[{"x": 1, "y": 2}, {"x": 3, "y": 4}],
+            filename=out_path,
+        )
+        assert "error" not in result
+        assert os.path.exists(out_path)
+
+    def test_export_requires_results(self):
+        from app.tools.dataset import create_dataset_tool
+        registry = ToolRegistry()
+        create_dataset_tool(registry)
+        tool = registry.get("dataset")
+        result = tool.execute(action="export")
+        assert "error" in result
+        assert "results" in result["error"]


### PR DESCRIPTION
## Summary

Two collapses. Net surface: **34 → 31 tools** (–3). Cumulative day total: **75 → 31 tools (–59%)**.

### (1) Dedupe: `search_materials` → `materials_search`

Both tools called the same `SearchEngine` + `ProviderRegistry`. `materials_search` (in `search_engine/tools.py`) is the richer canonical entry. The `data.py` `search_materials` registration is removed; the underlying `_search_materials` private function is preserved for internal Skill use.

The `ACQUIRE_SKILL` workflow step that referenced `search_materials` by name is updated to `materials_search`.

### (2) Dataset I/O extension

| Was | Now |
|---|---|
| `import_dataset(file_path=…)` | `dataset(action='import', file_path=…)` |
| `export_results_csv(results=…)` | `dataset(action='export', results=…)` |

Natural fit — these are the I/O endpoints of the dataset lifecycle (import → validate/review/visualize → export). The dataset Tool's action enum is now: `validate`, `review`, `visualize`, `import`, `export`.

Per-action arg validation lives in the dispatcher.

## What stays

`query_materials_project` is preserved — different scope from `materials_search`. It's the deep-property path (uses `mp_api.client.MPRester` with explicit field selection); `materials_search` is the federated catalog query. They don't overlap.

## Test plan

- [x] `test_bootstrap.py`, `test_mcp_roundtrip.py`, `test_mcp_server.py`, `test_plugin_integration.py` updated for new tool names
- [x] `test_tools_data.py` restructured: tests only-registered tools + direct impl tests for now-internal helpers + new dataset(action='import'/'export') tests
- [x] `test_import_dataset.py` preserved (uses impl directly, still importable)
- [x] **61/61 affected tests pass. Zero regression.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)