### PR TITLE
Round 5: sim_tools + calphad collapse (19→9, –10 surface when deps installed)

### DIFF
--- a/app/tools/calphad.py
+++ b/app/tools/calphad.py
@@ -149,92 +149,213 @@ def _import_database(**kwargs) -> dict:
 # Registration
 # ===========================================================================
 
+# ---------------------------------------------------------------------------
+# Round 5 unified dispatchers
+# ---------------------------------------------------------------------------
+
+def _calphad(**kwargs) -> dict:
+    """Read-only CALPHAD dispatcher: catalog + import. No approval gate.
+
+    Replaces list_calphad_databases / list_phases / import_calphad_database.
+    Compute actions (phase_diagram / equilibrium / gibbs) live in the
+    separate `calphad_compute` tool which is approval-gated.
+    """
+    action = kwargs.pop("action", None)
+    if not action:
+        return {
+            "error": "Missing 'action'. Valid: list_databases, list_phases, import",
+            "hint": (
+                "calphad(action='list_databases') / "
+                "calphad(action='list_phases', database_name='...') / "
+                "calphad(action='import', source_path='...')"
+            ),
+        }
+    if action == "list_databases":
+        return _list_databases(**kwargs)
+    if action == "list_phases":
+        if not kwargs.get("database_name"):
+            return {"error": "Action 'list_phases' requires `database_name`"}
+        return _list_phases(**kwargs)
+    if action == "import":
+        if not kwargs.get("source_path"):
+            return {"error": "Action 'import' requires `source_path`"}
+        return _import_database(**kwargs)
+    return {"error": f"Unknown action '{action}'. Valid: list_databases, list_phases, import"}
+
+
+def _calphad_compute(**kwargs) -> dict:
+    """Money/compute-spending CALPHAD dispatcher. Approval-gated.
+
+    Replaces calculate_phase_diagram / calculate_equilibrium /
+    calculate_gibbs_energy. All three are real CALPHAD calculations
+    that take seconds to minutes and produce structured results.
+    """
+    action = kwargs.pop("action", None)
+    if not action:
+        return {
+            "error": "Missing 'action'. Valid: phase_diagram, equilibrium, gibbs",
+            "hint": (
+                "calphad_compute(action='phase_diagram', database_name='...', components=[...]) / "
+                "calphad_compute(action='equilibrium', database_name='...', components=[...], conditions={...}) / "
+                "calphad_compute(action='gibbs', database_name='...', components=[...], phases=[...], temperature=...)"
+            ),
+        }
+
+    if not kwargs.get("database_name"):
+        return {"error": f"Action '{action}' requires `database_name`"}
+    if not kwargs.get("components"):
+        return {"error": f"Action '{action}' requires `components` (list)"}
+
+    if action == "phase_diagram":
+        return _calculate_phase_diagram(**kwargs)
+    if action == "equilibrium":
+        if not kwargs.get("conditions"):
+            return {"error": "Action 'equilibrium' requires `conditions` dict"}
+        return _calculate_equilibrium(**kwargs)
+    if action == "gibbs":
+        if not kwargs.get("phases"):
+            return {"error": "Action 'gibbs' requires `phases` list"}
+        if "temperature" not in kwargs:
+            return {"error": "Action 'gibbs' requires `temperature`"}
+        return _calculate_gibbs_energy(**kwargs)
+    return {"error": f"Unknown action '{action}'. Valid: phase_diagram, equilibrium, gibbs"}
+
+
+# ---------------------------------------------------------------------------
+# Tool descriptions
+# ---------------------------------------------------------------------------
+
+_CALPHAD_DESCRIPTION = (
+    "CALPHAD database catalog + IO operations (read-only / no compute). "
+    "ONE tool, three actions:\n"
+    "  • action='list_databases' — show available TDB thermodynamic database "
+    "files in the PRISM-managed directory. No args.\n"
+    "  • action='list_phases' — list phases available in a database, "
+    "optionally filtered by components. Required: `database_name`. "
+    "Optional: `components` to filter.\n"
+    "  • action='import' — import a TDB database file into PRISM's managed "
+    "directory. Required: `source_path`. Optional: `name` (default: file "
+    "stem).\n"
+    "For actual CALPHAD calculations (phase diagrams, equilibrium, Gibbs "
+    "energy), use the separate `calphad_compute` tool — those are "
+    "approval-gated because they spend compute budget."
+)
+
+
+_CALPHAD_COMPUTE_DESCRIPTION = (
+    "CALPHAD thermodynamic calculations. ONE tool, three actions. "
+    "MONEY/COMPUTE-SPENDING — requires_approval=True; the harness will "
+    "prompt before each call.\n"
+    "  • action='phase_diagram' — calculate a binary/ternary phase diagram. "
+    "Required: `database_name`, `components` (e.g. ['Al', 'Ni']). "
+    "Optional: `phases`, `temperature_range` (default [300, 2000, 50]), "
+    "`pressure` (default 101325 Pa).\n"
+    "  • action='equilibrium' — calculate equilibrium at specific T/P/X. "
+    "Required: `database_name`, `components`, `conditions` (dict like "
+    "{T: 1000, P: 101325, 'X(AL)': 0.3}). Optional: `phases`.\n"
+    "  • action='gibbs' — Gibbs energy surface for specified phases at a "
+    "given temperature. Required: `database_name`, `components`, `phases`, "
+    "`temperature`. Optional: `pressure`.\n"
+    "Use `calphad(action='list_databases')` first to discover what's "
+    "available, then `calphad(action='list_phases')` to see what phases "
+    "the database covers."
+)
+
+
 def create_calphad_tools(registry: ToolRegistry) -> None:
-    """Register all CALPHAD tools."""
+    """Register the unified `calphad` (read-only) + `calphad_compute` tools.
 
+    Round 5 collapses 6 → 2:
+      list_calphad_databases + list_phases + import_calphad_database
+        → calphad(action=…)
+      calculate_phase_diagram + calculate_equilibrium +
+        calculate_gibbs_energy → calphad_compute(action=…)
+
+    The split mirrors compute / compute_submit and bash_task / stop_bash_task:
+    destructive or money-spending actions stay isolated for per-tool
+    approval gating.
+    """
     registry.register(Tool(
-        name="calculate_phase_diagram",
-        description="Calculate a binary/ternary phase diagram from a TDB thermodynamic database.",
+        name="calphad",
+        description=_CALPHAD_DESCRIPTION,
         input_schema={
             "type": "object",
             "properties": {
-                "database_name": {"type": "string", "description": "Name of the TDB database (without .tdb extension)"},
-                "components": {"type": "array", "items": {"type": "string"}, "description": "Chemical components, e.g. ['Al', 'Ni']"},
-                "phases": {"type": "array", "items": {"type": "string"}, "description": "Phases to include (default: all in database)"},
-                "temperature_range": {"type": "array", "items": {"type": "number"}, "description": "Temperature range as [start, stop, step] in K. Default: [300, 2000, 50]"},
-                "pressure": {"type": "number", "description": "Pressure in Pa. Default: 101325"},
+                "action": {
+                    "type": "string",
+                    "enum": ["list_databases", "list_phases", "import"],
+                    "description": "Which CALPHAD catalog/IO operation.",
+                },
+                "database_name": {
+                    "type": "string",
+                    "description": "Database name for action='list_phases'.",
+                },
+                "components": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Component filter for action='list_phases'.",
+                },
+                "source_path": {
+                    "type": "string",
+                    "description": "Path to TDB file for action='import'.",
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name to register under for action='import' (default: file stem).",
+                },
             },
-            "required": ["database_name", "components"],
+            "required": ["action"],
+            "additionalProperties": False,
         },
-        func=_calculate_phase_diagram,
+        func=_calphad,
+    ))
+
+    registry.register(Tool(
+        name="calphad_compute",
+        description=_CALPHAD_COMPUTE_DESCRIPTION,
+        input_schema={
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["phase_diagram", "equilibrium", "gibbs"],
+                    "description": "Which CALPHAD calculation to run.",
+                },
+                "database_name": {
+                    "type": "string",
+                    "description": "TDB database name. Required for all actions.",
+                },
+                "components": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Chemical components, e.g. ['Al', 'Ni']. Required.",
+                },
+                "phases": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Phases to include. Required for action='gibbs'; optional for others (default: all in DB).",
+                },
+                "temperature_range": {
+                    "type": "array",
+                    "items": {"type": "number"},
+                    "description": "T range [start, stop, step] in K for action='phase_diagram'. Default [300, 2000, 50].",
+                },
+                "temperature": {
+                    "type": "number",
+                    "description": "Temperature in K for action='gibbs'.",
+                },
+                "pressure": {
+                    "type": "number",
+                    "description": "Pressure in Pa. Default 101325.",
+                },
+                "conditions": {
+                    "type": "object",
+                    "description": "Equilibrium conditions for action='equilibrium', e.g. {T: 1000, P: 101325, 'X(AL)': 0.3}.",
+                },
+            },
+            "required": ["action"],
+            "additionalProperties": False,
+        },
+        func=_calphad_compute,
         requires_approval=True,
-    ))
-
-    registry.register(Tool(
-        name="calculate_equilibrium",
-        description="Calculate thermodynamic equilibrium at specific conditions (T, P, composition).",
-        input_schema={
-            "type": "object",
-            "properties": {
-                "database_name": {"type": "string", "description": "Name of the TDB database"},
-                "components": {"type": "array", "items": {"type": "string"}, "description": "Chemical components, e.g. ['Al', 'Ni']"},
-                "phases": {"type": "array", "items": {"type": "string"}, "description": "Phases to include (default: all)"},
-                "conditions": {"type": "object", "description": "Equilibrium conditions, e.g. {\"T\": 1000, \"P\": 101325, \"X(AL)\": 0.3}"},
-            },
-            "required": ["database_name", "components", "conditions"],
-        },
-        func=_calculate_equilibrium,
-        requires_approval=True,
-    ))
-
-    registry.register(Tool(
-        name="calculate_gibbs_energy",
-        description="Calculate Gibbs energy surface for specified phases at given temperature.",
-        input_schema={
-            "type": "object",
-            "properties": {
-                "database_name": {"type": "string", "description": "Name of the TDB database"},
-                "components": {"type": "array", "items": {"type": "string"}, "description": "Chemical components"},
-                "phases": {"type": "array", "items": {"type": "string"}, "description": "Phases to calculate Gibbs energy for"},
-                "temperature": {"type": "number", "description": "Temperature in K"},
-                "pressure": {"type": "number", "description": "Pressure in Pa. Default: 101325"},
-            },
-            "required": ["database_name", "components", "phases", "temperature"],
-        },
-        func=_calculate_gibbs_energy,
-    ))
-
-    registry.register(Tool(
-        name="list_calphad_databases",
-        description="List available thermodynamic TDB database files.",
-        input_schema={"type": "object", "properties": {}},
-        func=_list_databases,
-    ))
-
-    registry.register(Tool(
-        name="list_phases",
-        description="List phases available in a thermodynamic database, optionally filtered by components.",
-        input_schema={
-            "type": "object",
-            "properties": {
-                "database_name": {"type": "string", "description": "Name of the TDB database"},
-                "components": {"type": "array", "items": {"type": "string"}, "description": "Filter phases by components"},
-            },
-            "required": ["database_name"],
-        },
-        func=_list_phases,
-    ))
-
-    registry.register(Tool(
-        name="import_calphad_database",
-        description="Import a TDB thermodynamic database file into PRISM's managed directory.",
-        input_schema={
-            "type": "object",
-            "properties": {
-                "source_path": {"type": "string", "description": "Path to the TDB file to import"},
-                "name": {"type": "string", "description": "Name for the database (default: filename without extension)"},
-            },
-            "required": ["source_path"],
-        },
-        func=_import_database,
     ))

--- a/app/tools/sim_tools.py
+++ b/app/tools/sim_tools.py
@@ -40,11 +40,15 @@ def _create_structure(**kwargs) -> dict:
         repeat_y = kwargs.get("repeat_y", 1)
         repeat_z = kwargs.get("repeat_z", 1)
 
-        bulk_kwargs = {"element": element, "crystalstructure": crystal_structure}
+        # NOTE: pyiron's StructureFactory.bulk() takes the element as the
+        # FIRST positional arg (named `name` in the signature), not as
+        # `element=`. Earlier versions accepted `element=`; newer ones
+        # don't. Pass positionally for forward-compat.
+        bulk_kwargs = {"crystalstructure": crystal_structure}
         if lattice_constant is not None:
             bulk_kwargs["a"] = lattice_constant
 
-        atoms = pr.create.structure.bulk(**bulk_kwargs)
+        atoms = pr.create.structure.bulk(element, **bulk_kwargs)
 
         if any(r > 1 for r in (repeat_x, repeat_y, repeat_z)):
             atoms = atoms.repeat([int(repeat_x), int(repeat_y), int(repeat_z)])
@@ -598,195 +602,383 @@ def _run_workflow(**kwargs) -> dict:
 # Registration
 # ===========================================================================
 
+# ---------------------------------------------------------------------------
+# Round 5 unified dispatchers
+# ---------------------------------------------------------------------------
+
+def _structure(**kwargs) -> dict:
+    """Unified structure dispatcher. Replaces create/modify/get_structure_info."""
+    action = kwargs.pop("action", None)
+    if not action:
+        return {
+            "error": "Missing 'action'. Valid: create, modify, info",
+            "hint": (
+                "structure(action='create', element='Al') / "
+                "structure(action='modify', structure_id=..., operation=...) / "
+                "structure(action='info', structure_id=...)"
+            ),
+        }
+    if action == "create":
+        if not kwargs.get("element"):
+            return {"error": "Action 'create' requires `element`"}
+        return _create_structure(**kwargs)
+    if action == "modify":
+        if not kwargs.get("structure_id") or not kwargs.get("operation"):
+            return {"error": "Action 'modify' requires `structure_id` and `operation`"}
+        return _modify_structure(**kwargs)
+    if action == "info":
+        if not kwargs.get("structure_id"):
+            return {"error": "Action 'info' requires `structure_id`"}
+        return _get_structure_info(**kwargs)
+    return {"error": f"Unknown action '{action}'. Valid: create, modify, info"}
+
+
+def _sim_run(**kwargs) -> dict:
+    """Unified simulation dispatcher. Replaces run_simulation + submit_hpc_job."""
+    target = kwargs.pop("target", "local")
+    if target not in ("local", "hpc"):
+        return {"error": f"Unknown target '{target}'. Valid: local, hpc"}
+    if not kwargs.get("structure_id"):
+        return {"error": f"Action target='{target}' requires `structure_id`"}
+    if target == "local":
+        return _run_simulation(**kwargs)
+    # target == "hpc"
+    return _submit_hpc_job(**kwargs)
+
+
+def _sim_job(**kwargs) -> dict:
+    """Unified job-mgmt dispatcher. Replaces get_job_status / get_job_results /
+    list_jobs / delete_job."""
+    action = kwargs.pop("action", None)
+    if not action:
+        return {
+            "error": "Missing 'action'. Valid: status, results, list, delete",
+            "hint": (
+                "sim_job(action='status', job_id=...) / "
+                "sim_job(action='results', job_id=..., properties=[...]) / "
+                "sim_job(action='list', status_filter=...) / "
+                "sim_job(action='delete', job_id=..., confirm=true)"
+            ),
+        }
+    if action == "status":
+        if not kwargs.get("job_id"):
+            return {"error": "Action 'status' requires `job_id`"}
+        return _get_job_status(**kwargs)
+    if action == "results":
+        if not kwargs.get("job_id"):
+            return {"error": "Action 'results' requires `job_id`"}
+        return _get_job_results(**kwargs)
+    if action == "list":
+        return _list_jobs(**kwargs)
+    if action == "delete":
+        if not kwargs.get("job_id"):
+            return {"error": "Action 'delete' requires `job_id`"}
+        return _delete_job(**kwargs)
+    return {"error": f"Unknown action '{action}'. Valid: status, results, list, delete"}
+
+
+# ---------------------------------------------------------------------------
+# Tool descriptions
+# ---------------------------------------------------------------------------
+
+_STRUCTURE_DESCRIPTION = (
+    "Build, transform, and inspect atomistic crystal structures (via "
+    "pyiron / ASE). ONE tool, three actions:\n"
+    "  • action='create' — bulk crystal structure from element + crystal type. "
+    "Required: `element`. Optional: `crystal_structure` (fcc default; bcc, "
+    "hcp, diamond, ...), `lattice_constant`, `repeat_x/y/z` for supercells. "
+    "Returns a structure_id used by other sim tools.\n"
+    "  • action='modify' — transform an existing structure. Required: "
+    "`structure_id`, `operation` (supercell / strain / add_vacancy / "
+    "substitute_atom). Operation-specific args go in `params`.\n"
+    "  • action='info' — composition, cell vectors, volume, symmetry of a "
+    "stored structure. Required: `structure_id`.\n"
+    "Structure storage is session-local; IDs are not persisted across runs. "
+    "NOT for searching materials databases (use materials_search) and NOT "
+    "for visualizing structures (no 3D viewer here)."
+)
+
+
+_SIM_RUN_DESCRIPTION = (
+    "Run an atomistic simulation. ONE tool, two targets:\n"
+    "  • target='local' — execute on this machine (fast feedback, small jobs). "
+    "Default if `target` omitted.\n"
+    "  • target='hpc' — submit to an HPC queue (SLURM/PBS/SGE) for large jobs. "
+    "Optional: `queue` (default 'default'), `cores` (default 1), `walltime` "
+    "(default '01:00:00').\n"
+    "Both targets share: `structure_id` (REQUIRED), `code` (lammps default; "
+    "vasp, abinit, gpaw, qe), `potential` (interatomic potential name for "
+    "LAMMPS — use `list_potentials` to discover), `parameters` (calc_type: "
+    "'static'|'minimize'|'md', temperature, pressure, n_ionic_steps, ...).\n"
+    "MONEY/COMPUTE-SPENDING action — requires_approval=True. The harness "
+    "prompts before each call. Use compute_estimate via `compute(action="
+    "'estimate')` first if you need a cost preview for the cloud broker, "
+    "though this tool dispatches via pyiron not the broker."
+)
+
+
+_SIM_JOB_DESCRIPTION = (
+    "Manage atomistic simulation jobs (started by `sim_run`). ONE tool, four "
+    "actions:\n"
+    "  • action='status' — current status of one job (queued / running / "
+    "finished / aborted). Required: `job_id`. Cheap to call repeatedly in a "
+    "polling loop.\n"
+    "  • action='results' — pull energy / forces / stress / volume from a "
+    "FINISHED job. Required: `job_id`. Optional: `properties` (list of "
+    "specific fields to retrieve).\n"
+    "  • action='list' — enumerate jobs. Optional: `status_filter`, "
+    "`code_filter`.\n"
+    "  • action='delete' — destructive. Removes job + output files. "
+    "Required: `job_id`, `confirm=true`. Cannot be undone.\n"
+    "NOT for the MARC27 compute broker (use `compute(action='status')` for "
+    "cloud broker jobs); these are local pyiron jobs."
+)
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
 def create_simulation_tools(registry: ToolRegistry) -> None:
-    """Register all simulation tools (guarded by pyiron availability)."""
+    """Register simulation tools (guarded by pyiron availability).
 
-    # --- C-1: Structure tools ------------------------------------------------
+    Round 5 collapses (13 → 7):
+      structure   ← create_structure + modify_structure + get_structure_info
+      sim_run     ← run_simulation + submit_hpc_job
+      sim_job     ← get_job_status + get_job_results + list_jobs + delete_job
+      list_potentials, run_convergence_test, run_workflow,
+      check_hpc_queue stay standalone (different shapes / specialized concepts)
+    """
+
+    # --- Unified: structure (3 → 1) ----------------------------------------
     registry.register(Tool(
-        name="create_structure",
-        description="Create an atomistic crystal structure. Returns structure ID for use in simulations.",
+        name="structure",
+        description=_STRUCTURE_DESCRIPTION,
         input_schema={
             "type": "object",
             "properties": {
-                "element": {"type": "string", "description": "Chemical element symbol, e.g. 'Fe', 'Al', 'Si'"},
-                "crystal_structure": {"type": "string", "description": "Crystal structure type: fcc, bcc, hcp, diamond, etc. Default: fcc"},
-                "lattice_constant": {"type": "number", "description": "Lattice constant in Angstroms (optional, uses default for element)"},
-                "repeat_x": {"type": "integer", "description": "Supercell repeat in x. Default: 1"},
-                "repeat_y": {"type": "integer", "description": "Supercell repeat in y. Default: 1"},
-                "repeat_z": {"type": "integer", "description": "Supercell repeat in z. Default: 1"},
+                "action": {
+                    "type": "string",
+                    "enum": ["create", "modify", "info"],
+                    "description": "Which structure operation to perform.",
+                },
+                "element": {
+                    "type": "string",
+                    "description": "Chemical element for action='create' (e.g. 'Fe', 'Al', 'Si').",
+                },
+                "crystal_structure": {
+                    "type": "string",
+                    "description": "Crystal structure type for action='create': fcc, bcc, hcp, diamond. Default: fcc.",
+                },
+                "lattice_constant": {
+                    "type": "number",
+                    "description": "Lattice constant in Angstroms for action='create'. Optional.",
+                },
+                "repeat_x": {"type": "integer", "description": "Supercell repeat in x for action='create'. Default 1."},
+                "repeat_y": {"type": "integer", "description": "Supercell repeat in y for action='create'. Default 1."},
+                "repeat_z": {"type": "integer", "description": "Supercell repeat in z for action='create'. Default 1."},
+                "structure_id": {
+                    "type": "string",
+                    "description": "Structure ID for action='modify' or action='info'.",
+                },
+                "operation": {
+                    "type": "string",
+                    "description": "Modification operation for action='modify': supercell, strain, add_vacancy, substitute_atom.",
+                },
+                "params": {
+                    "type": "object",
+                    "description": "Operation-specific parameters for action='modify' (e.g. {nx:2,ny:2,nz:2}).",
+                },
             },
-            "required": ["element"],
+            "required": ["action"],
+            "additionalProperties": False,
         },
-        func=_create_structure,
+        func=_structure,
     ))
 
+    # --- Unified: sim_run (2 → 1) ------------------------------------------
     registry.register(Tool(
-        name="modify_structure",
-        description="Modify an existing structure: supercell, strain, add_vacancy, or substitute_atom.",
+        name="sim_run",
+        description=_SIM_RUN_DESCRIPTION,
         input_schema={
             "type": "object",
             "properties": {
-                "structure_id": {"type": "string", "description": "ID of the structure to modify"},
-                "operation": {"type": "string", "description": "Operation: supercell, strain, add_vacancy, substitute_atom"},
-                "params": {"type": "object", "description": "Operation-specific parameters (e.g. {nx:2,ny:2,nz:2} for supercell, {strain:0.01} for strain, {index:0} for vacancy, {index:0,element:'Ni'} for substitution)"},
-            },
-            "required": ["structure_id", "operation"],
-        },
-        func=_modify_structure,
-    ))
-
-    registry.register(Tool(
-        name="get_structure_info",
-        description="Get detailed info about a stored structure: composition, cell, volume, symmetry.",
-        input_schema={
-            "type": "object",
-            "properties": {
-                "structure_id": {"type": "string", "description": "ID of the structure"},
+                "target": {
+                    "type": "string",
+                    "enum": ["local", "hpc"],
+                    "default": "local",
+                    "description": "'local' runs on this machine; 'hpc' submits to a SLURM/PBS/SGE queue.",
+                },
+                "structure_id": {
+                    "type": "string",
+                    "description": "Structure to simulate. Required.",
+                },
+                "code": {
+                    "type": "string",
+                    "description": "Simulation code: lammps (default), vasp, abinit, gpaw, qe.",
+                },
+                "potential": {
+                    "type": "string",
+                    "description": "Interatomic potential name (LAMMPS). Use list_potentials to discover.",
+                },
+                "parameters": {
+                    "type": "object",
+                    "description": "Code-specific params: {calc_type, temperature, pressure, n_ionic_steps, ...}.",
+                },
+                "queue": {
+                    "type": "string",
+                    "description": "Queue/partition for target='hpc'. Default 'default'.",
+                },
+                "cores": {
+                    "type": "integer",
+                    "description": "CPU cores for target='hpc'. Default 1.",
+                },
+                "walltime": {
+                    "type": "string",
+                    "description": "Wall-time limit for target='hpc' (e.g. '01:00:00').",
+                },
             },
             "required": ["structure_id"],
+            "additionalProperties": False,
         },
-        func=_get_structure_info,
+        func=_sim_run,
+        requires_approval=True,
     ))
 
+    # --- Unified: sim_job (4 → 1) ------------------------------------------
+    registry.register(Tool(
+        name="sim_job",
+        description=_SIM_JOB_DESCRIPTION,
+        input_schema={
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["status", "results", "list", "delete"],
+                    "description": "Which job-management operation to perform.",
+                },
+                "job_id": {
+                    "type": "string",
+                    "description": "Job ID for action='status'/'results'/'delete'.",
+                },
+                "properties": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Properties to retrieve for action='results' (energy_tot, forces, stress, volume).",
+                },
+                "status_filter": {
+                    "type": "string",
+                    "description": "Filter for action='list': finished, running, aborted.",
+                },
+                "code_filter": {
+                    "type": "string",
+                    "description": "Code filter for action='list': lammps, vasp, etc.",
+                },
+                "confirm": {
+                    "type": "boolean",
+                    "description": "Required (true) for action='delete'. Confirms destructive op.",
+                },
+            },
+            "required": ["action"],
+            "additionalProperties": False,
+        },
+        func=_sim_job,
+    ))
+
+    # --- Standalone (kept) -------------------------------------------------
+    # Catalog query — different concept (database lookup, not action on structure)
     registry.register(Tool(
         name="list_potentials",
-        description="List available interatomic potentials (EAM, MEAM, Tersoff, etc.) for a given element.",
+        description=(
+            "List interatomic potentials (EAM, MEAM, Tersoff, LJ, ...) "
+            "available in the pyiron LAMMPS potential database for a given "
+            "element / type. Use BEFORE sim_run when you need a `potential` "
+            "argument and don't know what's available. NOT for materials "
+            "search (use materials_search) and NOT for ML model listing "
+            "(use list_models)."
+        ),
         input_schema={
             "type": "object",
             "properties": {
                 "element": {"type": "string", "description": "Filter by element symbol, e.g. 'Fe'"},
-                "potential_type": {"type": "string", "description": "Filter by potential type: eam, meam, tersoff, lj, etc."},
+                "potential_type": {"type": "string", "description": "Filter by type: eam, meam, tersoff, lj"},
             },
         },
         func=_list_potentials,
     ))
 
-    # --- C-2: Simulation / Job tools -----------------------------------------
-    registry.register(Tool(
-        name="run_simulation",
-        description="Run an atomistic simulation (LAMMPS, VASP, ABINIT, GPAW, QE) on a structure.",
-        input_schema={
-            "type": "object",
-            "properties": {
-                "structure_id": {"type": "string", "description": "ID of the structure to simulate"},
-                "code": {"type": "string", "description": "Simulation code: lammps, vasp, abinit, gpaw, qe. Default: lammps"},
-                "potential": {"type": "string", "description": "Interatomic potential name (for LAMMPS)"},
-                "parameters": {"type": "object", "description": "Code-specific parameters: {calc_type: 'static'|'minimize'|'md', temperature: 300, pressure: 0, n_ionic_steps: 1000}"},
-            },
-            "required": ["structure_id"],
-        },
-        func=_run_simulation,
-        requires_approval=True,
-    ))
-
-    registry.register(Tool(
-        name="get_job_status",
-        description="Get the current status of a simulation job.",
-        input_schema={
-            "type": "object",
-            "properties": {
-                "job_id": {"type": "string", "description": "Job ID returned by run_simulation"},
-            },
-            "required": ["job_id"],
-        },
-        func=_get_job_status,
-    ))
-
-    registry.register(Tool(
-        name="get_job_results",
-        description="Get results from a completed simulation job: energy, forces, stress, volume.",
-        input_schema={
-            "type": "object",
-            "properties": {
-                "job_id": {"type": "string", "description": "Job ID"},
-                "properties": {"type": "array", "items": {"type": "string"}, "description": "Properties to retrieve: energy_tot, forces, stress, volume, etc."},
-            },
-            "required": ["job_id"],
-        },
-        func=_get_job_results,
-    ))
-
-    registry.register(Tool(
-        name="list_jobs",
-        description="List simulation jobs, optionally filtered by status or code.",
-        input_schema={
-            "type": "object",
-            "properties": {
-                "status_filter": {"type": "string", "description": "Filter by status: finished, running, aborted, etc."},
-                "code_filter": {"type": "string", "description": "Filter by simulation code: lammps, vasp, etc."},
-            },
-        },
-        func=_list_jobs,
-    ))
-
-    registry.register(Tool(
-        name="delete_job",
-        description="Delete a simulation job and its output files.",
-        input_schema={
-            "type": "object",
-            "properties": {
-                "job_id": {"type": "string", "description": "Job ID to delete"},
-                "confirm": {"type": "boolean", "description": "Must be true to confirm deletion"},
-            },
-            "required": ["job_id"],
-        },
-        func=_delete_job,
-    ))
-
-    # --- C-3: HPC + Workflow tools -------------------------------------------
-    registry.register(Tool(
-        name="submit_hpc_job",
-        description="Submit an atomistic simulation to an HPC queue (SLURM/PBS/SGE).",
-        input_schema={
-            "type": "object",
-            "properties": {
-                "structure_id": {"type": "string", "description": "Structure ID"},
-                "code": {"type": "string", "description": "Simulation code: lammps, vasp, etc. Default: lammps"},
-                "potential": {"type": "string", "description": "Potential name"},
-                "parameters": {"type": "object", "description": "Code-specific parameters"},
-                "queue": {"type": "string", "description": "Queue/partition name. Default: default"},
-                "cores": {"type": "integer", "description": "Number of CPU cores. Default: 1"},
-                "walltime": {"type": "string", "description": "Wall time limit, e.g. '01:00:00'. Default: 01:00:00"},
-            },
-            "required": ["structure_id"],
-        },
-        func=_submit_hpc_job,
-        requires_approval=True,
-    ))
-
+    # HPC queue inspection — different concept (queue-level, not job-level)
     registry.register(Tool(
         name="check_hpc_queue",
-        description="Check the HPC queue for running and queued simulation jobs.",
+        description=(
+            "Inspect the HPC queue (SLURM/PBS/SGE) for running and queued "
+            "atomistic simulation jobs. Returns queue-level state across "
+            "all of YOUR jobs. Different from sim_job(action='list') which "
+            "lists pyiron-tracked jobs in your local session — this one "
+            "talks to the actual scheduler. Use to see what's pending in "
+            "the queue, not what you've spawned locally."
+        ),
         input_schema={"type": "object", "properties": {}},
         func=_check_hpc_queue,
     ))
 
+    # Convergence test — different shape (parameter sweep, not single sim)
     registry.register(Tool(
         name="run_convergence_test",
-        description="Run a convergence test: vary one parameter (encut, kpoints) across multiple values and return energies.",
+        description=(
+            "Run an atomistic convergence test: vary one parameter (encut, "
+            "kpoints, ecutwfc, ...) across N values and return energies for "
+            "each. Use to check that simulation parameters are converged "
+            "before running a real production calc. Returns "
+            "{parameter_values, energies} suitable for plotting. Different "
+            "shape from sim_run (which runs ONE simulation); this dispatches "
+            "N simulations in sequence. Money/compute-spending — keep N "
+            "reasonable (3-7 values typically)."
+        ),
         input_schema={
             "type": "object",
             "properties": {
                 "structure_id": {"type": "string", "description": "Structure ID"},
                 "code": {"type": "string", "description": "Simulation code. Default: lammps"},
                 "potential": {"type": "string", "description": "Potential name"},
-                "parameter_name": {"type": "string", "description": "Parameter to vary: encut, kpoints, etc."},
-                "parameter_values": {"type": "array", "items": {"type": "number"}, "description": "List of values to test"},
+                "parameter_name": {"type": "string", "description": "Parameter to vary: encut, kpoints, ecutwfc, ..."},
+                "parameter_values": {
+                    "type": "array",
+                    "items": {"type": "number"},
+                    "description": "List of values to test. Keep length 3-7 to bound compute cost.",
+                },
             },
             "required": ["structure_id", "parameter_name", "parameter_values"],
         },
         func=_run_convergence_test,
     ))
 
+    # Predefined workflow — different shape (multi-step, named)
     registry.register(Tool(
         name="run_workflow",
-        description="Run a predefined workflow: elastic_constants, phonons, equation_of_state, thermal_expansion.",
+        description=(
+            "Run a predefined named workflow on a structure. Available: "
+            "elastic_constants (full elastic tensor), phonons (phonon "
+            "dispersion + DOS), equation_of_state (Murnaghan EoS fit → bulk "
+            "modulus), thermal_expansion (quasi-harmonic approx). Each "
+            "workflow internally dispatches multiple sim_run calls — "
+            "this is the highest-level atomistic-sim entry point. NOT a "
+            "substitute for sim_run (which runs ONE calc); use sim_run when "
+            "you want fine-grained control. Money/compute-spending."
+        ),
         input_schema={
             "type": "object",
             "properties": {
-                "workflow_type": {"type": "string", "description": "Workflow type: elastic_constants, phonons, equation_of_state, thermal_expansion"},
+                "workflow_type": {
+                    "type": "string",
+                    "enum": ["elastic_constants", "phonons", "equation_of_state", "thermal_expansion"],
+                    "description": "Predefined workflow name.",
+                },
                 "structure_id": {"type": "string", "description": "Structure ID"},
-                "parameters": {"type": "object", "description": "Workflow parameters including 'code' and 'potential' for the reference job"},
+                "parameters": {
+                    "type": "object",
+                    "description": "Workflow params: {code: 'lammps'|'vasp'|..., potential: '...'}",
+                },
             },
             "required": ["workflow_type", "structure_id"],
         },

--- a/tests/test_round5_sim_collapse.py
+++ b/tests/test_round5_sim_collapse.py
@@ -1,0 +1,269 @@
+"""Tests for the Round 5 sim_tools + calphad collapses.
+
+These tests use mocked underlying impls so they can run on any Python
+environment (including Python 3.14 where pyiron_atomistics + pyiron_base
+0.9+ aren't yet supported). The actual pyiron path is exercised by
+end-to-end smoke tests when running in a pyiron-capable env.
+"""
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from app.tools.base import ToolRegistry
+
+
+# ---------------------------------------------------------------------------
+# Helpers — bypass the pyiron-availability check so the dispatchers register
+# even on environments without pyiron installed (e.g. Python 3.14).
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def sim_registry():
+    """Force pyiron_available=True so create_simulation_tools registers
+    the unified dispatchers, then patch the bridge layer so dispatcher
+    calls go through cleanly without touching pyiron."""
+    with patch("app.tools.simulation.bridge.check_pyiron_available", return_value=True):
+        from app.tools.sim_tools import create_simulation_tools
+        reg = ToolRegistry()
+        create_simulation_tools(reg)
+        yield reg
+
+
+@pytest.fixture
+def calphad_registry():
+    with patch("app.tools.simulation.calphad_bridge.check_calphad_available", return_value=True):
+        from app.tools.calphad import create_calphad_tools
+        reg = ToolRegistry()
+        create_calphad_tools(reg)
+        yield reg
+
+
+# ===========================================================================
+# Sim collapse: 13 → 7
+# ===========================================================================
+
+class TestSimRegistration:
+    def test_unified_tools_registered(self, sim_registry):
+        names = [t.name for t in sim_registry.list_tools()]
+        # 3 unified
+        assert "structure" in names
+        assert "sim_run" in names
+        assert "sim_job" in names
+        # 4 standalone (kept — different shapes/concepts)
+        assert "list_potentials" in names
+        assert "check_hpc_queue" in names
+        assert "run_convergence_test" in names
+        assert "run_workflow" in names
+
+    def test_old_names_removed(self, sim_registry):
+        names = [t.name for t in sim_registry.list_tools()]
+        for old in (
+            "create_structure", "modify_structure", "get_structure_info",
+            "run_simulation", "submit_hpc_job",
+            "get_job_status", "get_job_results", "list_jobs", "delete_job",
+        ):
+            assert old not in names, f"{old} should have been collapsed"
+
+    def test_total_count(self, sim_registry):
+        names = [t.name for t in sim_registry.list_tools()]
+        assert len(names) == 7  # was 13 pre-Round-5
+
+    def test_sim_run_requires_approval(self, sim_registry):
+        """sim_run is money/compute-spending — must be approval-gated."""
+        assert sim_registry.get("sim_run").requires_approval is True
+
+    def test_structure_no_approval(self, sim_registry):
+        """Structure ops are cheap CPU — should NOT require approval."""
+        assert sim_registry.get("structure").requires_approval is False
+
+    def test_sim_job_no_approval(self, sim_registry):
+        """Job mgmt ops are cheap polling/cleanup — should NOT require approval."""
+        assert sim_registry.get("sim_job").requires_approval is False
+
+
+class TestStructureDispatcher:
+    def test_missing_action(self, sim_registry):
+        r = sim_registry.get("structure").execute()
+        assert "error" in r and "Missing 'action'" in r["error"]
+
+    def test_unknown_action(self, sim_registry):
+        r = sim_registry.get("structure").execute(action="bogus")
+        assert "error" in r and "Unknown action" in r["error"]
+
+    def test_create_requires_element(self, sim_registry):
+        r = sim_registry.get("structure").execute(action="create")
+        assert "error" in r and "element" in r["error"]
+
+    def test_modify_requires_id_and_op(self, sim_registry):
+        r = sim_registry.get("structure").execute(action="modify")
+        assert "error" in r
+        assert "structure_id" in r["error"] and "operation" in r["error"]
+
+    def test_info_requires_id(self, sim_registry):
+        r = sim_registry.get("structure").execute(action="info")
+        assert "error" in r and "structure_id" in r["error"]
+
+    def test_create_dispatches(self, sim_registry):
+        with patch("app.tools.sim_tools._create_structure", return_value={"structure_id": "s1"}) as m:
+            r = sim_registry.get("structure").execute(action="create", element="Al")
+            assert r == {"structure_id": "s1"}
+            # action= is consumed by the dispatcher before forwarding
+            m.assert_called_once_with(element="Al")
+
+    def test_modify_dispatches(self, sim_registry):
+        with patch("app.tools.sim_tools._modify_structure", return_value={"structure_id": "s1", "operation": "supercell"}) as m:
+            sim_registry.get("structure").execute(
+                action="modify", structure_id="s1", operation="supercell",
+            )
+            m.assert_called_once()
+
+    def test_info_dispatches(self, sim_registry):
+        with patch("app.tools.sim_tools._get_structure_info", return_value={"formula": "Al"}) as m:
+            sim_registry.get("structure").execute(action="info", structure_id="s1")
+            m.assert_called_once()
+
+
+class TestSimRunDispatcher:
+    def test_missing_structure_id_local(self, sim_registry):
+        r = sim_registry.get("sim_run").execute()
+        assert "error" in r and "structure_id" in r["error"]
+
+    def test_unknown_target(self, sim_registry):
+        r = sim_registry.get("sim_run").execute(target="moon")
+        assert "error" in r and "Unknown target" in r["error"]
+
+    def test_local_dispatches(self, sim_registry):
+        with patch("app.tools.sim_tools._run_simulation", return_value={"job_id": "j1"}) as m:
+            sim_registry.get("sim_run").execute(target="local", structure_id="s1")
+            m.assert_called_once()
+
+    def test_hpc_dispatches(self, sim_registry):
+        with patch("app.tools.sim_tools._submit_hpc_job", return_value={"job_id": "j1"}) as m:
+            sim_registry.get("sim_run").execute(target="hpc", structure_id="s1", queue="big")
+            m.assert_called_once()
+
+    def test_default_target_is_local(self, sim_registry):
+        with patch("app.tools.sim_tools._run_simulation", return_value={"job_id": "j1"}) as m:
+            sim_registry.get("sim_run").execute(structure_id="s1")
+            m.assert_called_once()
+
+
+class TestSimJobDispatcher:
+    def test_missing_action(self, sim_registry):
+        r = sim_registry.get("sim_job").execute()
+        assert "error" in r and "Missing 'action'" in r["error"]
+
+    def test_unknown_action(self, sim_registry):
+        r = sim_registry.get("sim_job").execute(action="explode")
+        assert "error" in r and "Unknown action" in r["error"]
+
+    def test_status_requires_job_id(self, sim_registry):
+        r = sim_registry.get("sim_job").execute(action="status")
+        assert "error" in r and "job_id" in r["error"]
+
+    def test_results_requires_job_id(self, sim_registry):
+        r = sim_registry.get("sim_job").execute(action="results")
+        assert "error" in r and "job_id" in r["error"]
+
+    def test_delete_requires_job_id(self, sim_registry):
+        r = sim_registry.get("sim_job").execute(action="delete")
+        assert "error" in r and "job_id" in r["error"]
+
+    def test_list_no_required_args(self, sim_registry):
+        with patch("app.tools.sim_tools._list_jobs", return_value={"jobs": [], "count": 0}) as m:
+            r = sim_registry.get("sim_job").execute(action="list")
+            assert "error" not in r
+            m.assert_called_once()
+
+    def test_status_dispatches(self, sim_registry):
+        with patch("app.tools.sim_tools._get_job_status", return_value={"status": "finished"}) as m:
+            sim_registry.get("sim_job").execute(action="status", job_id="j1")
+            m.assert_called_once()
+
+    def test_results_dispatches(self, sim_registry):
+        with patch("app.tools.sim_tools._get_job_results", return_value={"energy_tot": -1.5}) as m:
+            sim_registry.get("sim_job").execute(action="results", job_id="j1")
+            m.assert_called_once()
+
+    def test_delete_dispatches(self, sim_registry):
+        with patch("app.tools.sim_tools._delete_job", return_value={"deleted": "j1"}) as m:
+            sim_registry.get("sim_job").execute(action="delete", job_id="j1", confirm=True)
+            m.assert_called_once()
+
+
+# ===========================================================================
+# Calphad collapse: 6 → 2
+# ===========================================================================
+
+class TestCalphadRegistration:
+    def test_both_tools_registered(self, calphad_registry):
+        names = [t.name for t in calphad_registry.list_tools()]
+        assert "calphad" in names
+        assert "calphad_compute" in names
+
+    def test_old_names_removed(self, calphad_registry):
+        names = [t.name for t in calphad_registry.list_tools()]
+        for old in (
+            "calculate_phase_diagram", "calculate_equilibrium", "calculate_gibbs_energy",
+            "list_calphad_databases", "list_phases", "import_calphad_database",
+        ):
+            assert old not in names, f"{old} should have been collapsed"
+
+    def test_calphad_compute_requires_approval(self, calphad_registry):
+        """Compute actions are real-money — must be approval-gated."""
+        assert calphad_registry.get("calphad_compute").requires_approval is True
+
+    def test_calphad_no_approval(self, calphad_registry):
+        """Catalog/IO ops are cheap — should NOT require approval."""
+        assert calphad_registry.get("calphad").requires_approval is False
+
+
+class TestCalphadDispatcher:
+    def test_missing_action(self, calphad_registry):
+        r = calphad_registry.get("calphad").execute()
+        assert "error" in r and "Missing 'action'" in r["error"]
+
+    def test_list_phases_requires_db(self, calphad_registry):
+        r = calphad_registry.get("calphad").execute(action="list_phases")
+        assert "error" in r and "database_name" in r["error"]
+
+    def test_import_requires_path(self, calphad_registry):
+        r = calphad_registry.get("calphad").execute(action="import")
+        assert "error" in r and "source_path" in r["error"]
+
+    def test_list_databases_dispatches(self, calphad_registry):
+        with patch("app.tools.calphad._list_databases", return_value={"databases": [], "count": 0}) as m:
+            r = calphad_registry.get("calphad").execute(action="list_databases")
+            assert "error" not in r
+            m.assert_called_once()
+
+
+class TestCalphadComputeDispatcher:
+    def test_missing_action(self, calphad_registry):
+        r = calphad_registry.get("calphad_compute").execute()
+        assert "error" in r and "Missing 'action'" in r["error"]
+
+    def test_phase_diagram_requires_db(self, calphad_registry):
+        r = calphad_registry.get("calphad_compute").execute(action="phase_diagram")
+        assert "error" in r and "database_name" in r["error"]
+
+    def test_equilibrium_requires_conditions(self, calphad_registry):
+        r = calphad_registry.get("calphad_compute").execute(
+            action="equilibrium", database_name="d", components=["A", "B"],
+        )
+        assert "error" in r and "conditions" in r["error"]
+
+    def test_gibbs_requires_temperature(self, calphad_registry):
+        r = calphad_registry.get("calphad_compute").execute(
+            action="gibbs", database_name="d", components=["A", "B"], phases=["P"],
+        )
+        assert "error" in r and "temperature" in r["error"]
+
+    def test_phase_diagram_dispatches(self, calphad_registry):
+        with patch("app.tools.calphad._calculate_phase_diagram", return_value={"diagram": {}}) as m:
+            calphad_registry.get("calphad_compute").execute(
+                action="phase_diagram",
+                database_name="alni",
+                components=["Al", "Ni"],
+            )
+            m.assert_called_once()


### PR DESCRIPTION
## Summary

Two collapses gated on optional deps (pyiron / pycalphad). When the deps are installed, the registered tool surface drops from 19 to 9.

### (1) sim_tools collapse (13 → 7)

| Cluster | Was | After |
|---|---|---|
| Structure | create_structure, modify_structure, get_structure_info | `structure(action='create'\|'modify'\|'info')` |
| Sim run | run_simulation, submit_hpc_job | `sim_run(target='local'\|'hpc')` (`requires_approval=True`) |
| Job mgmt | get_job_status, get_job_results, list_jobs, delete_job | `sim_job(action='status'\|'results'\|'list'\|'delete')` |
| **Standalone (kept)** | list_potentials, check_hpc_queue, run_convergence_test, run_workflow | (kept — different shapes / specialized concepts) |

`sim_run` carries `requires_approval=True` (compute-spending). `structure` and `sim_job` are read-only/cheap and stay un-gated.

### (2) calphad collapse (6 → 2)

| Tool | Actions | Approval |
|---|---|---|
| `calphad` | list_databases, list_phases, import | ❌ no (read-only/IO) |
| `calphad_compute` | phase_diagram, equilibrium, gibbs | ✅ yes |

Same pattern as compute / compute_submit and bash_task / stop_bash_task.

## Incidental fix

`_create_structure` called pyiron's `StructureFactory.bulk(element=...)` with `element` as a keyword. Newer pyiron (≥ 0.8.x) renamed the first parameter to `name` and requires it positionally. Live end-to-end test caught it; passing positionally now works on both old and new pyiron.

## Cumulative surface

| | Tools |
|---|---|
| Pre-Round-4 (with optional deps) | 94 |
| Post-Round-7 + Round-5 | 40 |
| **Delta** | **−54 (−57%)** |

## Test plan

- [x] 41 new tests in `tests/test_round5_sim_collapse.py` (use mocked underlying impls so they run on Python 3.14 without pyiron)
- [x] **70/70 tests pass** (Round 5 + bootstrap + capabilities)
- [x] Live end-to-end verified in conda pyiron_env (Python 3.12 + pyiron_atomistics 0.8.7): `structure(create)` → `structure(modify, supercell 2x2x2)` → `structure(info)` produced correct formula / n_atoms / volume / space group; live `calphad(list_databases)` round-trip clean.
- [x] Zero regression on existing tests.

## Out of scope

- `pyproject.toml` gate (`python_version<'3.15'` from PR #17) was based on the `atomistics` lower-level wrapper which IS 3.14-ready. But pyiron-base itself caps at `<3.14` still. Will tighten the gate in a separate corrective PR (or wait for pyiron-base to gain 3.14 support).
- per-action `requires_approval` in `Tool.execute` (architectural; would re-fold compute_submit + stop_bash_task + sim_run + calphad_compute into their parents).

🤖 Generated with [Claude Code](https://claude.com/claude-code)