### PR TITLE
fix(workflows): clippy::unnecessary_map_or in suggest_action

### DIFF
--- a/crates/workflows/src/lib.rs
+++ b/crates/workflows/src/lib.rs
@@ -1152,10 +1152,12 @@ fn edit_distance(a: &str, b: &str) -> usize {
     for i in 1..=m {
         curr[0] = i;
         for j in 1..=n {
-            let cost = if a_bytes[i - 1] == b_bytes[j - 1] { 0 } else { 1 };
-            curr[j] = (prev[j] + 1)
-                .min(curr[j - 1] + 1)
-                .min(prev[j - 1] + cost);
+            let cost = if a_bytes[i - 1] == b_bytes[j - 1] {
+                0
+            } else {
+                1
+            };
+            curr[j] = (prev[j] + 1).min(curr[j - 1] + 1).min(prev[j - 1] + cost);
         }
         std::mem::swap(&mut prev, &mut curr);
     }
@@ -1562,7 +1564,10 @@ inputs:
         )
         .unwrap_err()
         .to_string();
-        assert!(err.contains("skill_workflow") || err.contains("dialect"), "got: {err}");
+        assert!(
+            err.contains("skill_workflow") || err.contains("dialect"),
+            "got: {err}"
+        );
     }
 
     #[test]

--- a/crates/workflows/src/lib.rs
+++ b/crates/workflows/src/lib.rs
@@ -1168,7 +1168,9 @@ fn suggest_action(unknown: &str) -> Option<&'static str> {
     let mut best: Option<(&str, usize)> = None;
     for &known in KNOWN_ACTIONS {
         let d = edit_distance(&lc, known);
-        if d <= 2 && best.map_or(true, |(_, bd)| d < bd) {
+        // Note: `is_none_or` (Rust 1.82+) is the clippy-preferred form
+        // over `map_or(true, ...)` for "None or matches predicate" checks.
+        if d <= 2 && best.is_none_or(|(_, bd)| d < bd) {
             best = Some((known, d));
         }
     }


### PR DESCRIPTION
## Why CI broke

CI runs Rust 1.95, which added \`clippy::unnecessary_map_or\` as a default warning. My local toolchain is 1.92, which does not flag it yet — so #24 and #25 both landed with the lint and the \`cargo clippy --workspace --all-targets -- -D warnings\` step failed on main.

\`\`\`
error: this map_or can be simplified
   --> crates/workflows/src/lib.rs:1171
1171 |   if d <= 2 && best.map_or(true, |(_, bd)| d < bd) {
help: use is_none_or instead
\`\`\`

## Fix

Single line. \`best.map_or(true, |(_, bd)| d < bd)\` → \`best.is_none_or(|(_, bd)| d < bd)\`. Same semantics. \`is_none_or\` was stabilized in Rust 1.82 so it works on every supported toolchain.

## Test plan

- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean locally
- [x] \`cargo test -p prism-workflows --lib\` — 23/23 still pass
- [x] CI on this branch should now go green

## Why local didn't catch it

Local rustc is 1.92, CI is 1.95. The lint exists only on the newer clippy. Action item: bump local toolchain or pin a CI-matching rust-toolchain.toml so the gap doesn't recur. Flagging as follow-up — not blocking this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)