### PR TITLE
ci: release-fast profile so macOS build doesn't hang for 35+ min

### DIFF
--- a/.github/workflows/rust-backbone.yml
+++ b/.github/workflows/rust-backbone.yml
@@ -84,4 +84,9 @@ jobs:
         run: mkdir -p dashboard/dist && echo '<html><body>placeholder</body></html>' > dashboard/dist/index.html
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: cargo build --workspace --release
+      # `release-fast` (defined in Cargo.toml) drops LTO and lifts
+      # codegen-units so cross-platform CI smoke finishes in ~10 min
+      # instead of 35+ min on macOS / Windows. Still opt-level=3, so
+      # the binary is representative for smoke. Production installers
+      # are built from the canonical `[profile.release]` separately.
+      - run: cargo build --workspace --profile release-fast

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,20 @@ codegen-units = 1
 opt-level = 3
 strip = true
 
+# Faster release profile for CI cross-platform smoke. Drops LTO and
+# unifies codegen-units back to the default so macOS / Windows builds
+# finish in ~10 min instead of 35+ min. Still optimized (opt-level=3)
+# so the resulting binary is representative of "release" behavior; we
+# just don't pay for whole-program optimization on every PR.
+#
+# The shipping macOS / Windows installers should be built with the
+# default `[profile.release]` for maximum runtime perf.
+[profile.release-fast]
+inherits = "release"
+lto = false
+codegen-units = 16
+strip = false
+
 # ─────────────────────────────────────────────────────────────────────
 # Workspace dependencies
 #


### PR DESCRIPTION
## Why

Every PR triggers \`Rust Build (macos-latest)\` which has been **hanging at 35+ minutes** with full LTO from a cold cache. PR #28 currently has 10/11 checks green — only macOS still pending after >30 min. Same on main. This is the "one of the CI was fail" the user flagged.

## Root cause

\`[profile.release]\` in \`Cargo.toml\` uses max-optimization shape — correct for **shipping binaries**, brutal for **PR smoke**:

| flag | value | cost |
|---|---|---|
| \`lto\` | \`true\` | whole-program optimization, single-threaded link |
| \`codegen-units\` | \`1\` | no parallel codegen |
| \`opt-level\` | \`3\` | OK |
| \`strip\` | \`true\` | OK |

The \`Rust Build\` matrix in \`rust-backbone.yml\` was just smoke — verifying the workspace links on each platform. For smoke, we don't need full LTO; we need it to finish.

## Fix

Add a \`[profile.release-fast]\` that inherits from \`release\` but drops the bottlenecks:

\`\`\`toml
[profile.release-fast]
inherits = "release"
lto = false
codegen-units = 16
strip = false
\`\`\`

Still \`opt-level = 3\`, so the binary is representative. Just no whole-program optimization on every PR.

The matrix now uses \`cargo build --workspace --profile release-fast\`. Production installers (the macOS / Windows / Linux artifacts users actually download) still build with the canonical \`[profile.release]\` — flagged in inline comments so a future release workflow won't regress.

## Test plan

- [x] \`cargo check --workspace --profile release-fast\` — clean locally in 50s
- [ ] CI on this PR — expected macOS-latest build time drops from 35+ min to ~10 min
- [ ] Same matrix passes on ubuntu-latest + windows-latest

## Why not other approaches considered

| Option | Rejected because |
|---|---|
| \`cargo check\` only | Doesn't link, misses link-time errors that the matrix is meant to catch |
| \`cargo build --workspace\` (debug) | Different code-gen path; binary not representative of release |
| Skip macOS on PR, run on main only | Then main can break and we wouldn't know until release |
| Larger CI runner | Costs money; this fix is free |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to improve CI pipeline performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->