### PR TITLE
fix(cli): 5 user-flow papercuts found in hands-on testing

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -88,7 +88,7 @@ enum Commands {
     },
     /// Show runtime paths, endpoints, and auth status.
     Status,
-    /// List, inspect, and run YAML-defined workflows.
+    /// List, show, and run YAML-defined workflows.
     Workflow {
         #[command(subcommand)]
         command: WorkflowCommands,
@@ -566,6 +566,8 @@ enum MeshCommands {
 #[derive(Debug, Subcommand)]
 enum MarketplaceCommands {
     /// Search the MARC27 marketplace for tools and workflows.
+    /// Aliases: `list`, `browse` — shorthand for an empty search.
+    #[command(alias = "list", alias = "browse")]
     Search {
         /// Search query.
         query: Option<String>,
@@ -2327,13 +2329,12 @@ async fn main() -> Result<()> {
             match command {
                 None => {
                     // Default: show balance
-                    let resp: serde_json::Value = auth
+                    let raw = auth
                         .apply(client.get(format!("{api_base}/billing/balance")))
                         .send()
-                        .await?
-                        .error_for_status()?
-                        .json()
                         .await?;
+                    let resp: serde_json::Value =
+                        friendly_status(raw, "view billing balance")?.json().await?;
                     println!("\nMARC27 Credits");
                     println!(
                         "\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}"
@@ -2554,6 +2555,33 @@ fn render_workflow_spec(spec: &WorkflowSpec) {
             "--{}\t{}\t{}\t{}",
             argument.name, argument.r#type, required, argument.help
         );
+    }
+
+    // Two valid invocation paths exist for any workflow. Showing only
+    // the `--<arg>` table without the example invocations confused
+    // users into trying `prism workflow run <name> --<arg> <value>`,
+    // which clap rejects (the `run` subcommand takes `--set k=v` for
+    // forwarding). Make both paths visible.
+    let required_args: Vec<&str> = spec
+        .arguments
+        .iter()
+        .filter(|a| a.required)
+        .map(|a| a.name.as_str())
+        .collect();
+    if !required_args.is_empty() {
+        let top_level: String = required_args
+            .iter()
+            .map(|n| format!(" --{n} <{n}>"))
+            .collect();
+        let set_pairs: String = required_args
+            .iter()
+            .map(|n| format!(" --set {n}=<{n}>"))
+            .collect();
+        println!();
+        println!("usage:");
+        println!("  prism {}{}", spec.command_name, top_level);
+        println!("  prism workflow run {}{}", spec.command_name, set_pairs);
+        println!("  add `--execute` to run for real (default is dry-run plan)");
     }
 }
 
@@ -3827,6 +3855,31 @@ impl PlatformAuth {
     }
 }
 
+/// Friendlier replacement for `.error_for_status()` on platform calls.
+///
+/// Default reqwest error on 401 reads "HTTP status client error (401
+/// Unauthorized) for url ...", which leaves the user wondering what
+/// to do. This wrapper replaces that with an actionable message
+/// pointing at `prism login` and `prism status`. Other non-2xx
+/// responses fall through to the normal reqwest error.
+fn friendly_status(resp: reqwest::Response, action: &str) -> Result<reqwest::Response> {
+    let status = resp.status();
+    if status == reqwest::StatusCode::UNAUTHORIZED {
+        let url = resp.url().to_string();
+        bail!(
+            "Not authorized to {action}.\n\
+             \n\
+             Your platform token may be expired or missing the required \
+             scope for this endpoint. Try:\n\
+             \x20 prism login              # refresh your platform session\n\
+             \x20 prism status             # check current auth state\n\
+             \n\
+             Endpoint: {url}"
+        );
+    }
+    Ok(resp.error_for_status()?)
+}
+
 /// Resolve platform auth for agents (MARC27_API_KEY env var → X-API-Key header).
 /// Decoupled from user auth — agents use API keys, users use JWT.
 /// Falls back to user auth if no API key is set (backward compat).
@@ -4310,7 +4363,9 @@ async fn handle_deploy_command(command: DeployCommands) -> Result<()> {
                 request = request.query(&[("status", status)]);
             }
             let response: serde_json::Value =
-                request.send().await?.error_for_status()?.json().await?;
+                friendly_status(request.send().await?, "list compute deployments")?
+                    .json()
+                    .await?;
 
             if json {
                 println!("{}", serde_json::to_string_pretty(&response)?);
@@ -4565,13 +4620,12 @@ async fn handle_discourse_command(command: DiscourseCommands) -> Result<()> {
             }
         }
         DiscourseCommands::List { json } => {
-            let response: serde_json::Value = auth
+            let raw = auth
                 .apply(client.get(format!("{api_base}/discourse/specs")))
                 .send()
-                .await?
-                .error_for_status()?
-                .json()
                 .await?;
+            let response: serde_json::Value =
+                friendly_status(raw, "list discourse specs")?.json().await?;
 
             if json {
                 println!("{}", serde_json::to_string_pretty(&response)?);
@@ -5012,10 +5066,36 @@ async fn handle_query(
         })?;
         println!("Generating query embedding...");
         let llm_client = prism_ingest::llm::LlmClient::new(llm_cfg.clone());
-        let query_vec = llm_client
-            .embed_text(text)
-            .await
-            .context("failed to generate query embedding")?;
+        let query_vec = match llm_client.embed_text(text).await {
+            Ok(v) => v,
+            Err(e) => {
+                // Detect the most common misconfiguration: prism.toml's
+                // `[llm].url` points at MARC27's project-scoped LLM proxy
+                // (`/api/v1/projects/{id}/llm`) which doesn't expose
+                // `/v1/embeddings`. Without this hint a real user thinks
+                // the platform is down. Steer them to the working path.
+                let msg = e.to_string();
+                let looks_like_marc27_404 =
+                    msg.contains("404") && msg.contains("/projects/") && msg.contains("/llm/");
+                if looks_like_marc27_404 {
+                    bail!(
+                        "Local --semantic search needs an LLM that exposes \
+                         OpenAI-compatible /v1/embeddings, but the configured \
+                         URL ({}) is the MARC27 project-scoped LLM proxy \
+                         which serves chat-streaming only.\n\n\
+                         For platform knowledge-graph search, use:\n\
+                         \x20 prism query --platform --semantic \"{}\"\n\n\
+                         For local embeddings, run a server like Ollama or \
+                         llama.cpp and point prism at it via:\n\
+                         \x20 prism configure --llm-provider llamacpp\n\n\
+                         Underlying error: {e}",
+                        llm_cfg.base_url,
+                        text
+                    );
+                }
+                return Err(e).context("failed to generate query embedding");
+            }
+        };
 
         let store = QdrantVectorStore::new(qdrant_config);
         let results = store.query(&query_vec, limit).await?;


### PR DESCRIPTION
## What's in this PR

Five papercuts found by running PRISM the way a real user would, not just \`--help\` smoke. None of them break tests — they only surface when you actually invoke the binary.

| # | Symptom (user-visible) | Fix |
|---|---|---|
| **#1** | \`prism workflow --help\` says "List, inspect, and run" but the subcommand is \`show\`, not \`inspect\` | Help text now says "List, show, and run" |
| **#2** | \`prism workflow show forge\` advertises \`--paper string required\` but \`prism workflow run forge --paper x\` rejects the flag (clap requires \`--set paper=x\`) | Show output now prints a \`usage:\` block with **both** valid invocations |
| **#5 + #7** | \`prism query --semantic\` and \`prism ingest\` 404 with raw HTTP error against MARC27's project-scoped \`/llm\` URL (which serves \`/stream\` SSE, not OpenAI \`/v1/embeddings\`) | Detects that exact 404 shape and emits an actionable error pointing to \`--platform\` for knowledge search or \`prism configure --llm-provider llamacpp\` for local embeddings |
| **#6** | \`prism billing\` / \`deploy list\` / \`discourse list\` show only \`HTTP status client error (401 Unauthorized) for url ...\` — no signal what to do | New \`friendly_status(resp, action)\` helper catches 401 and prints \`Try: prism login / prism status\`. Wired into all 3 known sites |
| **#8** | \`prism marketplace list\` / \`browse\` were not recognized; only \`search\` worked | Added clap aliases — \`list\` and \`browse\` now both invoke search |

## Test plan

- [x] \`cargo fmt -- --check\` — clean
- [x] \`cargo clippy -p prism-cli --all-targets -- -D warnings\` — clean
- [x] \`cargo test -p prism-workflows --lib\` — 23/23 (regression)
- [ ] CI Rust Backbone matrix on this PR
- [ ] Hands-on rebuild + verify each bug now produces the new output

## Why no real test for friendly_status / friendly LLM 404

\`prism-cli\` is a binary with no library target, so it has no internal Rust tests. The helpers added here are exercised by the existing integration paths (the actual platform calls). Adding integration tests that hit the platform endpoints is out of scope for this PR — flagged for a future test-harness investment.

## Known follow-ups (not in this PR)

- The underlying LLM URL config in \`prism.toml\` is still wrong out of the box (the friendly error here is a band-aid). Long-term fix: \`prism configure --llm-provider marc27\` should write a URL the platform actually serves.
- \`prism workflow run <name> --<arg>\` could pass through to the workflow context instead of requiring \`--set k=v\`.
- 401 \`friendly_status\` is wired in 3 spots; the other call sites still use bare \`error_for_status()\`. Easy follow-up — same helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)