### PR TITLE
fix(fetch): normalize protocol-relative + scheme-less URLs from LLM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,4 @@ node_modules/
 # the generic 'lib/' ignore above (Python convention) was matching it
 !shell-plugin/lib/
 !shell-plugin/lib/**
+/.mcp-tools/

--- a/crates/forge_services/src/tool_services/fetch.rs
+++ b/crates/forge_services/src/tool_services/fetch.rs
@@ -143,18 +143,131 @@ impl ForgeFetch {
     }
 }
 
+/// Coerce LLM-emitted URL strings into something the parser will accept.
+///
+/// Real LLMs in real PRISM sessions emit two recoverable URL shapes
+/// that `url::Url::parse` would otherwise reject:
+///
+/// 1. **Protocol-relative** (`//host/path`) — common when the model
+///    cites a URL from a page that used protocol-relative links;
+///    the leading `//` means "use the same scheme as the parent."
+///    Since we always fetch over HTTPS in this tool, prefix `https:`.
+/// 2. **Scheme-less** (`host.tld/path`) — the model wrote a domain
+///    without `https://`. Prefix `https://`.
+///
+/// We only do this when the input is otherwise unparseable. Inputs
+/// with a recognized scheme go through unchanged.
+fn normalize_url(input: &str) -> String {
+    let trimmed = input.trim();
+
+    // Already parseable as-is → return verbatim.
+    if Url::parse(trimmed).is_ok() {
+        return trimmed.to_string();
+    }
+
+    // Protocol-relative: `//host/path` → `https://host/path`
+    if let Some(rest) = trimmed.strip_prefix("//") {
+        return format!("https://{rest}");
+    }
+
+    // Scheme-less domain-shaped: `host.tld[/...]` (no scheme, no
+    // leading slash). Avoid prefixing if the input already starts
+    // with `/`, `?`, `#`, or `mailto:`-style — those aren't URLs we
+    // can safely recover.
+    if !trimmed.is_empty()
+        && !trimmed.starts_with('/')
+        && !trimmed.starts_with('?')
+        && !trimmed.starts_with('#')
+        && !trimmed.contains("://")
+        && trimmed
+            .split(['/', '?', '#'])
+            .next()
+            .is_some_and(|host| host.contains('.'))
+    {
+        return format!("https://{trimmed}");
+    }
+
+    // Give up — return the original so the caller's parse error is
+    // accurate.
+    trimmed.to_string()
+}
+
 #[async_trait::async_trait]
 impl NetFetchService for ForgeFetch {
     async fn fetch(&self, url: String, raw: Option<bool>) -> anyhow::Result<HttpResponse> {
-        let url = Url::parse(&url).with_context(|| format!("Failed to parse URL: {url}"))?;
+        let normalized = normalize_url(&url);
+        let parsed =
+            Url::parse(&normalized).with_context(|| format!("Failed to parse URL: {url}"))?;
 
-        self.fetch_url(&url, raw.unwrap_or(false)).await
+        self.fetch_url(&parsed, raw.unwrap_or(false)).await
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── normalize_url ────────────────────────────────────────────────
+
+    #[test]
+    fn normalize_url_passes_through_https() {
+        assert_eq!(
+            normalize_url("https://example.com/foo"),
+            "https://example.com/foo"
+        );
+    }
+
+    #[test]
+    fn normalize_url_passes_through_http() {
+        assert_eq!(
+            normalize_url("http://example.com/foo"),
+            "http://example.com/foo"
+        );
+    }
+
+    #[test]
+    fn normalize_url_fixes_protocol_relative() {
+        // Real example from a PRISM TUI session: LLM emitted this
+        // citing an azom.com page; the original parser bailed with
+        // "relative URL without a base". This is the bug fix.
+        assert_eq!(
+            normalize_url("//www.azom.com/spx?ArticleID=1"),
+            "https://www.azom.com/spx?ArticleID=1"
+        );
+    }
+
+    #[test]
+    fn normalize_url_fixes_scheme_less_domain() {
+        assert_eq!(
+            normalize_url("www.example.com/path"),
+            "https://www.example.com/path"
+        );
+        assert_eq!(normalize_url("example.com"), "https://example.com");
+    }
+
+    #[test]
+    fn normalize_url_trims_whitespace() {
+        assert_eq!(
+            normalize_url("  https://example.com  "),
+            "https://example.com"
+        );
+    }
+
+    #[test]
+    fn normalize_url_leaves_unrecoverable_inputs_alone() {
+        // Path-only, fragment-only, and query-only inputs aren't
+        // valid stand-alone URLs and we don't try to recover them.
+        // The downstream parser will return a meaningful error.
+        assert_eq!(normalize_url("/just/a/path"), "/just/a/path");
+        assert_eq!(normalize_url("#fragment"), "#fragment");
+        assert_eq!(normalize_url("?query=1"), "?query=1");
+    }
+
+    #[test]
+    fn normalize_url_does_not_prefix_bare_word() {
+        // "hello" has no dot, so we don't pretend it's a domain.
+        assert_eq!(normalize_url("hello"), "hello");
+    }
 
     #[test]
     fn test_is_binary_content_type_text_types_are_not_binary() {


### PR DESCRIPTION
## Real bug found via TUI hands-on testing

Asked PRISM "yield strength of Ti-6Al-4V" → LLM emitted a citation URL \`//www.azom.com/spx?ArticleID=1\` (protocol-relative) → fetch tool 404'd on parse with "relative URL without a base" → LLM gave up → user got no answer at all.

In a follow-up turn, the LLM emitted FOUR more bad URLs:
\`//en.wikipedia.wiki/Ti-6Al-4V\`, \`//www.matm/search/datashaspx?...\`, \`//www.azoarticle.aspx?...\` — all 404'd. Eventually the model fell back to training knowledge.

## Fix

The forge fetch tool was calling \`Url::parse(&url)\` directly with no recovery for the two shapes LLMs commonly emit:

| Shape | Example | Fix |
|---|---|---|
| Protocol-relative | \`//host/path\` | prepend \`https:\` |
| Scheme-less | \`host.tld/path\` | prepend \`https://\` |

Inputs with a recognized scheme pass through unchanged. Genuinely unrecoverable inputs (just a path / fragment / query / bare word) are returned as-is so the downstream parse error stays accurate.

## Test plan

- [x] \`cargo test -p forge_services normalize_url\` — **7/7 pass**:
  - normalize_url_passes_through_https
  - normalize_url_passes_through_http
  - normalize_url_fixes_protocol_relative   ← the actual bug
  - normalize_url_fixes_scheme_less_domain
  - normalize_url_trims_whitespace
  - normalize_url_leaves_unrecoverable_inputs_alone
  - normalize_url_does_not_prefix_bare_word
- [x] \`cargo fmt -- --check\` clean
- [x] \`cargo clippy -p forge_services --all-targets -- -D warnings\` clean

## Repro from the TUI session

Before this PR:
\`\`\`
❯ yield strength of Ti-6Al-4V
⠙ Reasoning ... [platform_bridge] semantic top-K: 104 → 13 tools
● [22:03:14] GET //www.azom.com/spx?ArticleID=1
ERROR: Failed to parse URL: //www.azom.com/spx?ArticleID=1
Caused by: relative URL without a base
● [22:03:18] Finished              ← turn ended with no answer
\`\`\`

After this PR the LLM still emits the same URL but the fetch tool recovers it to \`https://www.azom.com/spx?ArticleID=1\` and the research turn completes.

## Side: gitignore .mcp-tools/

Local pty-mcp-server install (used to fix a separate pty-debug MCP \`spawn-helper\` not-executable bug). Should not be tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)