### PR TITLE
fix(forge_main): unflake test_format_path_for_display_no_home

### DIFF
--- a/crates/forge_main/src/info.rs
+++ b/crates/forge_main/src/info.rs
@@ -768,9 +768,19 @@ mod tests {
         use fake::{Fake, Faker};
         let mut fixture: Environment = Faker.fake();
         fixture = fixture.os(os.to_string());
-        if let Some(home_path) = home {
-            fixture = fixture.home(PathBuf::from(home_path));
-        }
+        // CRITICAL: when the caller passes `None` they mean "no home
+        // configured" — but `Faker.fake()` above just filled `home`
+        // with a random path. Without this branch the field still
+        // holds whatever Faker generated, which causes
+        // `format_path_for_display` to strip a random prefix and the
+        // `_no_home` tests fail non-deterministically on CI.
+        fixture = match home {
+            Some(home_path) => fixture.home(PathBuf::from(home_path)),
+            None => Environment {
+                home: None,
+                ..fixture
+            },
+        };
         fixture
     }
 


### PR DESCRIPTION
## Symptom

\`info::tests::test_format_path_for_display_no_home\` fails on Linux CI but passes on macOS. Currently blocking PR #32.

## Real cause

\`\`\`rust
fn create_env(os: &str, home: Option<&str>) -> Environment {
    let mut fixture: Environment = Faker.fake();   // home is RANDOM
    fixture = fixture.os(os.to_string());
    if let Some(home_path) = home {
        fixture = fixture.home(PathBuf::from(home_path));
    }
    // ↑ when home == None, fixture.home still holds a random PathBuf
    //   that Faker generated. Test result depends on whether that
    //   random path overlaps with the test input path.
    fixture
}
\`\`\`

When the random fake home prefix happened to overlap with \`/home/user/project\`, \`format_path_for_display\` would strip it and return \`~/...\` — failing the equality check. On macOS the fakes never collided; on Linux they sometimes did.

## Fix

When the caller passes \`home == None\`, explicitly set \`fixture.home = None\`. The test now means what it says.

## Test plan

- [x] \`cargo test -p forge_main info::tests::test_format_path_for_display\` — 6/6 pass
- [x] \`cargo clippy -p forge_main --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt -- --check\` — clean
- [ ] CI Rust Lint And Test on Linux ← the actual proof point

## Why this matters

This test has been the cause of CI red on PRs that don't touch \`forge_main\` at all. PR #32 is currently blocked by it. Landing this removes a CI red-herring that wastes contributor cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by ensuring deterministic behavior in test helper functions that previously produced nondeterministic results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->