### PR TITLE
chore(mcp): wire 3 TUI MCPs + install script for the rest

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -3,7 +3,23 @@
     "pty-debug": {
       "command": "pty-mcp-server",
       "args": [],
-      "description": "PTY/TUI debug MCP — drives interactive terminal programs (PRISM TUI, llama-server, REPLs) from Claude Code. Used for engine-layer empirical observation per Phase 1 of redesign roadmap. Pair with the tui-use CLI for cross-validation. See memory/project_redesign_roadmap_2026_05.md."
+      "description": "PRIMARY TUI MCP — text snapshots. Drives interactive terminal programs (PRISM TUI, llama-server, REPLs). Local, fast, no network. NOTE: needs spawn-helper +x bit (chmod fix shipped). Capabilities: spawn_session, send_input, get_snapshot (text), list_sessions, close_session, resize_terminal."
+    },
+    "terminalcp": {
+      "command": "npx",
+      "args": ["-y", "@mariozechner/terminalcp"],
+      "description": "FULL PTY emulation — preserves colors, cursor movement, special keys (better fidelity than pty-debug for visually-rich TUIs). Auto-installs on first use via npx. Use when pty-debug's text dump misses ANSI / color / cursor state."
+    },
+    "iterm-tmux": {
+      "command": "npx",
+      "args": ["-y", "mcpretentious"],
+      "description": "iTerm2 (macOS native) + tmux session control via WebSocket API. Lets Claude drive a REAL terminal window the user can watch, instead of headless PTY. Use when you want the human to see the agent typing. Auto-installs via npx."
     }
-  }
+  },
+  "_notes_for_installer": [
+    "Two more MCPs are NOT on npm and need a manual install — run scripts/install-tui-mcps.sh:",
+    "  • mcp-tui-driver (Rust, screenshot/PNG capable) — adds tui_screenshot tool for visual TUI verification",
+    "  • mcp-tui-test (Python, Playwright-style snapshot testing) — buffer-mode position assertions",
+    "Plus a CI-grade dev tool: `@microsoft/tui-test` for end-to-end TUI regression coverage in CI."
+  ]
 }

--- a/scripts/install-tui-mcps.sh
+++ b/scripts/install-tui-mcps.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+#
+# install-tui-mcps.sh — One-command install of the TUI testing MCPs that
+# can't ship via npm/npx auto-pull (because they're not on npm).
+#
+# After running this, restart Claude Code so the new MCPs are picked up
+# from .mcp.json. The npm-distributed ones (pty-debug, terminalcp,
+# iterm-tmux) are already wired and don't need this script.
+#
+# Run this from the PRISM project root:
+#   ./scripts/install-tui-mcps.sh
+#
+# Idempotent — safe to re-run.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+ROOT="$(pwd)"
+
+c_grn='\033[0;32m'
+c_yel='\033[0;33m'
+c_red='\033[0;31m'
+c_off='\033[0m'
+
+log()  { printf "${c_grn}[install-tui-mcps]${c_off} %s\n" "$*"; }
+warn() { printf "${c_yel}[install-tui-mcps]${c_off} %s\n" "$*"; }
+err()  { printf "${c_red}[install-tui-mcps]${c_off} %s\n" "$*"; }
+
+# ── 1. mcp-tui-driver ─────────────────────────────────────────────────
+# Rust binary. Adds a `tui_screenshot` tool that returns a PNG of the
+# terminal — visual verification that text-only pty-debug can't give.
+# Repo: https://github.com/michaellee8/mcp-tui-driver
+log "Installing mcp-tui-driver (Rust, screenshot-capable)..."
+if command -v mcp-tui-driver >/dev/null 2>&1; then
+    log "  already installed → $(command -v mcp-tui-driver)"
+else
+    if ! command -v cargo >/dev/null 2>&1; then
+        err "  cargo not found — install Rust first: https://rustup.rs"
+        exit 1
+    fi
+    cargo install --git https://github.com/michaellee8/mcp-tui-driver --locked
+    log "  installed → $(command -v mcp-tui-driver)"
+fi
+
+# ── 2. mcp-tui-test ───────────────────────────────────────────────────
+# Python MCP server — Playwright-style buffer-mode TUI testing with
+# position assertions and snapshot diffing.
+# Repo: https://github.com/GeorgePearse/mcp-tui-test
+log "Installing mcp-tui-test (Python, Playwright-style)..."
+TUI_TEST_DIR="$HOME/.prism/mcps/mcp-tui-test"
+if [[ -d "$TUI_TEST_DIR/.git" ]]; then
+    log "  already cloned → $TUI_TEST_DIR (pulling latest)"
+    git -C "$TUI_TEST_DIR" pull --quiet || warn "  pull failed; using local copy"
+else
+    mkdir -p "$(dirname "$TUI_TEST_DIR")"
+    git clone --depth 1 https://github.com/GeorgePearse/mcp-tui-test "$TUI_TEST_DIR"
+fi
+
+if ! command -v uv >/dev/null 2>&1; then
+    warn "  uv not found — falling back to pip. Install uv for faster setup: https://docs.astral.sh/uv/"
+    python3 -m venv "$TUI_TEST_DIR/.venv"
+    "$TUI_TEST_DIR/.venv/bin/pip" install -q -e "$TUI_TEST_DIR"
+else
+    (cd "$TUI_TEST_DIR" && uv venv --quiet && uv pip install -q -e .)
+fi
+log "  installed in $TUI_TEST_DIR/.venv"
+
+# ── 3. @microsoft/tui-test (CI-grade end-to-end TUI testing) ──────────
+# Not an MCP — it's a Playwright-style test FRAMEWORK we add to PRISM's
+# CI matrix to catch TUI regressions before they ship.
+# Repo: https://github.com/microsoft/tui-test
+log "Adding @microsoft/tui-test as a dev dependency for PRISM CI..."
+if [[ -f "$ROOT/package.json" ]]; then
+    npm install --save-dev --silent @microsoft/tui-test
+    log "  installed in $ROOT/node_modules"
+else
+    warn "  no package.json at project root — skipping. Add it manually with:"
+    warn "    npm i -D @microsoft/tui-test"
+fi
+
+# ── 4. Update .mcp.json with the cargo+python entries ─────────────────
+# We add these to .mcp.json AFTER install confirms they exist, so an
+# unfinished install doesn't leave a broken MCP entry.
+log "Wiring installed MCPs into .mcp.json..."
+python3 <<PY
+import json
+import sys
+from pathlib import Path
+
+cfg_path = Path(".mcp.json")
+cfg = json.loads(cfg_path.read_text())
+servers = cfg.setdefault("mcpServers", {})
+
+# mcp-tui-driver: visual screenshot (PNG) capability
+servers["tui-driver"] = {
+    "command": "mcp-tui-driver",
+    "args": [],
+    "description": (
+        "VISUAL TUI MCP — adds tui_screenshot (PNG) for verifying "
+        "color, alignment, kerning, banner geometry. Use when "
+        "text-only snapshots can't tell you what the human will see."
+    ),
+}
+
+# mcp-tui-test: Playwright-style buffer-mode testing
+import os
+home = os.environ.get("HOME", "")
+tui_test_python = f"{home}/.prism/mcps/mcp-tui-test/.venv/bin/python"
+tui_test_module = f"{home}/.prism/mcps/mcp-tui-test/server.py"
+servers["tui-test"] = {
+    "command": tui_test_python,
+    "args": [tui_test_module],
+    "description": (
+        "PLAYWRIGHT-style TUI testing — buffer mode with position "
+        "assertions, snapshot diffing, wait_for_text, cursor tracking. "
+        "Use for writing reusable TUI regression tests."
+    ),
+}
+
+cfg_path.write_text(json.dumps(cfg, indent=2) + "\n")
+print("  .mcp.json updated with tui-driver + tui-test entries")
+PY
+
+log "All TUI MCPs installed and wired."
+log ""
+log "Next: restart Claude Code so the new MCPs are picked up."
+log "Quick smoke check (after restart):"
+log "  in any conversation, ask Claude to call \\\`mcp-tui-driver --help\\\`"
+log "  or \\\`mcp-tui-test\\\` — both should be visible."


### PR DESCRIPTION
## Per directive

> "Get them all loaded. Okay? And then I will shut down the PC because it's already 11:30 right now, and we begin the testy testy tomorrow."

Five TUI/terminal MCPs lined up so tomorrow's session has full coverage. Three auto-pull via npx (no install step), two need a real install (script provided), plus a CI-grade test framework.

## Wired into \`.mcp.json\` now (auto-pull on first use)

| MCP | Capability |
|---|---|
| \`pty-debug\` (already there) | Text snapshots, fast, local (spawn-helper +x fix shipped) |
| \`terminalcp\` (\`@mariozechner/terminalcp\`) | Full PTY emulation — colors, cursor, special keys preserved |
| \`iterm-tmux\` (\`mcpretentious\`) | iTerm2 + tmux WebSocket control — drives a REAL terminal window the user can watch |

## Manual via \`scripts/install-tui-mcps.sh\`

| MCP | Capability | Why manual |
|---|---|---|
| \`mcp-tui-driver\` | **\`tui_screenshot\` returns PNG** — visual verification of color / alignment / kerning that text dumps can't catch | Rust binary; \`cargo install --git\` from a non-npm repo (system gates this) |
| \`mcp-tui-test\` | Playwright-style buffer-mode TUI testing — position assertions, snapshot diffing, wait_for_text | Python; clones to \`~/.prism/mcps/\`, dedicated venv |
| \`@microsoft/tui-test\` | CI-grade end-to-end TUI testing framework (NOT an MCP — dev dep for PRISM's CI matrix) | npm dev dep |

The script is idempotent. Restart Claude Code after running so new \`.mcp.json\` entries activate.

## Why this matters

The Apple-feel TUI work was bottlenecked by text-only snapshots. \`mcp-tui-driver\`'s PNG output lets me visually verify each TUI fix instead of guessing. \`mcp-tui-test\` gives reusable regression tests so the same TUI bug doesn't come back twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)