### PR TITLE
fix(mcp): forge parser is strict — move installer notes to sidecar md

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -13,13 +13,7 @@
     "iterm-tmux": {
       "command": "npx",
       "args": ["-y", "mcpretentious"],
-      "description": "iTerm2 (macOS native) + tmux session control via WebSocket API. Lets Claude drive a REAL terminal window the user can watch, instead of headless PTY. Use when you want the human to see the agent typing. Auto-installs via npx."
+      "description": "iTerm2 (macOS native) + tmux session control via WebSocket API. Lets Claude drive a REAL terminal window the user can watch, instead of headless PTY. Use when you want the human to see the agent typing. Auto-installs via npx. See .mcp.json.notes.md for the manual-install MCPs (mcp-tui-driver, mcp-tui-test) that scripts/install-tui-mcps.sh handles."
     }
-  },
-  "_notes_for_installer": [
-    "Two more MCPs are NOT on npm and need a manual install — run scripts/install-tui-mcps.sh:",
-    "  • mcp-tui-driver (Rust, screenshot/PNG capable) — adds tui_screenshot tool for visual TUI verification",
-    "  • mcp-tui-test (Python, Playwright-style snapshot testing) — buffer-mode position assertions",
-    "Plus a CI-grade dev tool: `@microsoft/tui-test` for end-to-end TUI regression coverage in CI."
-  ]
+  }
 }

--- a/.mcp.json.notes.md
+++ b/.mcp.json.notes.md
@@ -1,0 +1,73 @@
+# `.mcp.json` — operator notes
+
+This file documents the MCP servers PRISM uses for TUI testing. The
+authoritative config lives in `.mcp.json`; this doc explains the *why*
+and lists the additional MCPs that don't live in `.mcp.json` because
+they need a manual install step.
+
+## Why notes aren't in `.mcp.json` itself
+
+Forge's MCP config parser is **strict on top-level fields** — it only
+accepts `mcpServers`. An earlier version of this file inlined a
+`_notes_for_installer` array, and forge's TUI failed to boot with:
+
+```
+ERROR: An error occurred while reading config at: ./.mcp.json
+Caused by:
+    unknown field `_notes_for_installer`, expected `mcpServers` at line 19 column 24
+```
+
+Hence: this sidecar `.md`. Don't put metadata back inside the JSON.
+
+## Already wired in `.mcp.json` (auto-pull on first use)
+
+| MCP | When to reach for it |
+|-----|----------------------|
+| **`pty-debug`** | First. Fast, local, text snapshots. Already installed (with the `spawn-helper +x` fix shipped 2026-05-08). |
+| **`terminalcp`** (`@mariozechner/terminalcp`) | Full PTY emulation — preserves ANSI colors, cursor, special keys with higher fidelity than pty-debug. Auto-pulls via `npx -y` on first start. |
+| **`iterm-tmux`** (`mcpretentious`) | Drives a REAL iTerm2/tmux window the user can watch. Use when the human should see the agent typing in their actual terminal. Has `mcpretentious-screenshot` for visual layered snapshots (text + cursor + colors + styles). |
+
+## Manual install via `scripts/install-tui-mcps.sh`
+
+These need `cargo install` or `git clone + uv pip install` and aren't
+distributed via npm — Claude Code's permission gate blocks
+agent-initiated installs from non-registry sources, so the install
+script runs them under explicit user authorization.
+
+| MCP | What it adds | Install path |
+|-----|--------------|--------------|
+| **`mcp-tui-driver`** | `tui_screenshot` returns a real PNG of the screen — visual verification of color, kerning, alignment that text dumps can't show. | `cargo install --git https://github.com/michaellee8/mcp-tui-driver --locked` |
+| **`mcp-tui-test`** | Playwright-style buffer-mode TUI testing — position assertions, `wait_for_text`, snapshot diffing for regression coverage. | Cloned to `~/.prism/mcps/mcp-tui-test/` with its own venv. |
+| **`@microsoft/tui-test`** | NOT an MCP — a CI dev dependency. End-to-end TUI test framework for PRISM's CI matrix. | `npm i -D @microsoft/tui-test` |
+
+## Bringup checklist
+
+After cloning the repo or pulling on a fresh machine:
+
+```bash
+cd ~/Downloads/PRISM
+bash scripts/install-tui-mcps.sh   # adds the 3 manual MCPs/dev-deps
+# then restart Claude Code so the new MCP entries are picked up
+```
+
+The script is idempotent and updates `.mcp.json` itself once the
+binaries / venvs install successfully.
+
+## Known gotchas
+
+1. **Don't add comments / sidebands to `.mcp.json`.** Forge fails the
+   whole TUI boot if there's any unknown top-level key. The boot error
+   surfaces in the chat panel as `An error occurred while reading
+   config at: ./.mcp.json` — easy to misread as a server problem.
+
+2. **`pty-mcp-server`'s `spawn-helper` needs `+x`.** If a Node upgrade
+   or homebrew reinstall clears the bit, every spawn fails with
+   `posix_spawnp failed`. Re-run:
+   ```bash
+   chmod +x /opt/homebrew/lib/node_modules/@so2liu/pty-mcp-server/node_modules/node-pty/prebuilds/darwin-arm64/spawn-helper
+   ```
+
+3. **Auto-install via `npx -y` requires network on first start.** If
+   you're offline at first launch, the `terminalcp` and `iterm-tmux`
+   MCPs will fail to come up. Pre-warm them once with internet, then
+   they're cached.


### PR DESCRIPTION
## Bug found in TUI hands-on testing

PR #40 added a `_notes_for_installer` array as a top-level key in `.mcp.json` for documentation. **Forge's MCP config parser rejects unknown top-level fields**, so every TUI launch on main since #40 merged was failing with:

```
ERROR: An error occurred while reading config at: ./.mcp.json
Caused by: unknown field `_notes_for_installer`,
           expected `mcpServers` at line 19 column 24
```

This breaks chat — the LLM call short-circuits before it can run.
Caught hands-on this morning via `mcpretentious-screenshot` of a real iTerm session — exactly the visual verification path the PR-#40 toolchain set up.

## Fix

- Drop the `_notes_for_installer` field from `.mcp.json`
- Move the same content (plus operator notes + known gotchas) to a sibling file `.mcp.json.notes.md`. Forge ignores `*.md`; the human-facing reference stays exactly where someone reading `.mcp.json` would look

## Cross-referenced from

- `.mcp.json` `iterm-tmux` description (mentions the sidecar)
- `scripts/install-tui-mcps.sh` (already references the file)
- Memory's `reference_tui_mcp_toolchain.md`

## Test plan

- [x] \`python3 -c "import json; json.load(open('.mcp.json'))"\` — valid
- [x] Confirmed \`.mcp.json\` has only \`mcpServers\` at the top level
- [x] Verified TUI boots clean (no MCP config error) via mcpretentious in iTerm window
- [x] Verified chat turn proceeds after the fix (multi-turn works)

## Lesson captured in the new sidecar

> Don't add comments / sidebands to `.mcp.json`. Forge fails the whole TUI boot if there's any unknown top-level key. The boot error surfaces in the chat panel as "An error occurred while reading config at: ./.mcp.json" — easy to misread as a server problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide explaining MCP server configuration, manual installation steps, and known setup issues.

* **Chores**
  * Updated server configuration descriptions to reference documentation and installation resources.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Darth-Hidious/PRISM/pull/41)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->