### PR TITLE
fix(mcp): terminalcp needs --mcp flag — caught by live TUI test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Claude Code session-local state — not for the repo
+.claude/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.mcp.json
+++ b/.mcp.json
@@ -7,8 +7,8 @@
     },
     "terminalcp": {
       "command": "npx",
-      "args": ["-y", "@mariozechner/terminalcp"],
-      "description": "FULL PTY emulation — preserves colors, cursor movement, special keys (better fidelity than pty-debug for visually-rich TUIs). Auto-installs on first use via npx. Use when pty-debug's text dump misses ANSI / color / cursor state."
+      "args": ["-y", "@mariozechner/terminalcp", "--mcp"],
+      "description": "FULL PTY emulation — preserves colors, cursor movement, special keys (better fidelity than pty-debug for visually-rich TUIs). Auto-installs on first use via npx. Use when pty-debug's text dump misses ANSI / color / cursor state. NOTE: requires `--mcp` arg — without it, terminalcp prints a usage banner to stdout and rmcp can't parse it as JSON."
     },
     "iterm-tmux": {
       "command": "npx",

--- a/.mcp.json.notes.md
+++ b/.mcp.json.notes.md
@@ -71,3 +71,16 @@ binaries / venvs install successfully.
    you're offline at first launch, the `terminalcp` and `iterm-tmux`
    MCPs will fail to come up. Pre-warm them once with internet, then
    they're cached.
+
+4. **`terminalcp` needs an explicit `--mcp` flag.** Without it, the
+   binary prints a usage banner to stdout and exits. rmcp tries to
+   parse the banner as JSON and the failure shows up as a chat-panel
+   error:
+   ```
+   ERROR rmcp::transport::async_rw: Error reading from stream:
+   serde error expected ident at line 1 column 2
+   ```
+   Args must include `"--mcp"`. Caught 2026-05-09 by driving the
+   live TUI under pty-debug. (`mcpretentious` and `pty-mcp-server`
+   correctly start in MCP mode by default — only terminalcp is
+   sensitive to this.)


### PR DESCRIPTION
## What it fixed

Without \`--mcp\`, terminalcp prints a usage banner to stdout and exits. rmcp tries to parse the banner as JSON-RPC and surfaces this as a chat-panel error on every TUI boot:

\`\`\`
ERROR rmcp::transport::async_rw: Error reading from stream:
serde error expected ident at line 1 column 2
\`\`\`

The other two auto-pull MCPs (\`pty-mcp-server\`, \`mcpretentious\`) start in MCP mode by default. Only \`terminalcp\` is sensitive to this flag.

## How it was found

By doing what was being asked: actually driving the TUI under \`pty-debug\` after PR #42 merged, instead of trusting unit tests as the only signal. The error was visible on line 35 of a freshly-booted TUI.

## What's documented

Added gotcha #4 to \`.mcp.json.notes.md\` alongside the other operator pitfalls (forge-strict-parser, spawn-helper +x bit, network-required-on-first-npx). Also added \`.claude/\` to \`.gitignore\` while I was there — Claude Code's session-local lock files were leaking into commits.

## Test plan

- [x] \`(echo init-rpc; sleep 2) | npx -y @mariozechner/terminalcp --mcp\` — returns valid JSON-RPC response
- [x] Same without \`--mcp\` — prints USAGE banner (the bug)
- [ ] Boot TUI fresh after merge; rmcp error gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)