### PR TITLE
fix(install): patch mcp-tui-test pyproject so install-tui-mcps.sh actually completes

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -3,17 +3,36 @@
     "pty-debug": {
       "command": "pty-mcp-server",
       "args": [],
-      "description": "PRIMARY TUI MCP — text snapshots. Drives interactive terminal programs (PRISM TUI, llama-server, REPLs). Local, fast, no network. NOTE: needs spawn-helper +x bit (chmod fix shipped). Capabilities: spawn_session, send_input, get_snapshot (text), list_sessions, close_session, resize_terminal."
+      "description": "PRIMARY TUI MCP \u2014 text snapshots. Drives interactive terminal programs (PRISM TUI, llama-server, REPLs). Local, fast, no network. NOTE: needs spawn-helper +x bit (chmod fix shipped). Capabilities: spawn_session, send_input, get_snapshot (text), list_sessions, close_session, resize_terminal."
     },
     "terminalcp": {
       "command": "npx",
-      "args": ["-y", "@mariozechner/terminalcp", "--mcp"],
-      "description": "FULL PTY emulation — preserves colors, cursor movement, special keys (better fidelity than pty-debug for visually-rich TUIs). Auto-installs on first use via npx. Use when pty-debug's text dump misses ANSI / color / cursor state. NOTE: requires `--mcp` arg — without it, terminalcp prints a usage banner to stdout and rmcp can't parse it as JSON."
+      "args": [
+        "-y",
+        "@mariozechner/terminalcp",
+        "--mcp"
+      ],
+      "description": "FULL PTY emulation \u2014 preserves colors, cursor movement, special keys (better fidelity than pty-debug for visually-rich TUIs). Auto-installs on first use via npx. Use when pty-debug's text dump misses ANSI / color / cursor state. NOTE: requires `--mcp` arg \u2014 without it, terminalcp prints a usage banner to stdout and rmcp can't parse it as JSON."
     },
     "iterm-tmux": {
       "command": "npx",
-      "args": ["-y", "mcpretentious"],
+      "args": [
+        "-y",
+        "mcpretentious"
+      ],
       "description": "iTerm2 (macOS native) + tmux session control via WebSocket API. Lets Claude drive a REAL terminal window the user can watch, instead of headless PTY. Use when you want the human to see the agent typing. Auto-installs via npx. See .mcp.json.notes.md for the manual-install MCPs (mcp-tui-driver, mcp-tui-test) that scripts/install-tui-mcps.sh handles."
+    },
+    "tui-driver": {
+      "command": "mcp-tui-driver",
+      "args": [],
+      "description": "VISUAL TUI MCP \u2014 adds tui_screenshot (PNG) for verifying color, alignment, kerning, banner geometry. Use when text-only snapshots can't tell you what the human will see."
+    },
+    "tui-test": {
+      "command": "/Users/siddharthakovid/.prism/mcps/mcp-tui-test/.venv/bin/python",
+      "args": [
+        "/Users/siddharthakovid/.prism/mcps/mcp-tui-test/server.py"
+      ],
+      "description": "PLAYWRIGHT-style TUI testing \u2014 buffer mode with position assertions, snapshot diffing, wait_for_text, cursor tracking. Use for writing reusable TUI regression tests."
     }
   }
 }

--- a/scripts/install-tui-mcps.sh
+++ b/scripts/install-tui-mcps.sh
@@ -55,6 +55,20 @@ else
     git clone --depth 1 https://github.com/GeorgePearse/mcp-tui-test "$TUI_TEST_DIR"
 fi
 
+# Workaround: upstream pyproject.toml has both `server.py` and
+# `example_tui_app.py` at the top level and doesn't declare which is
+# the package, so setuptools `flat-layout` discovery refuses to build.
+# Pin the package to `server` (the actual MCP entry point) if not
+# already pinned. Idempotent.
+if ! grep -q '\[tool.setuptools\]' "$TUI_TEST_DIR/pyproject.toml"; then
+    cat >> "$TUI_TEST_DIR/pyproject.toml" <<'PATCH'
+
+[tool.setuptools]
+py-modules = ["server"]
+PATCH
+    log "  patched pyproject.toml to constrain py-modules=['server']"
+fi
+
 if ! command -v uv >/dev/null 2>&1; then
     warn "  uv not found — falling back to pip. Install uv for faster setup: https://docs.astral.sh/uv/"
     python3 -m venv "$TUI_TEST_DIR/.venv"


### PR DESCRIPTION
## What was broken

\`bash scripts/install-tui-mcps.sh\` failed at step 2 with:

\`\`\`
error: Multiple top-level modules discovered in a flat-layout:
['server', 'example_tui_app'].
\`\`\`

mcp-tui-test's upstream pyproject.toml has both \`server.py\` (the actual MCP entry point) and \`example_tui_app.py\` (a demo) at the top level, and doesn't declare which is the package. setuptools refuses to guess.

Result: anyone running the install script yesterday got an installed \`mcp-tui-driver\` (Rust, fine) but a half-cloned \`mcp-tui-test\` with no venv, and the wire-up step at the end produced an .mcp.json pointing at a venv that never existed.

## The fix

After cloning, the script appends to the local pyproject.toml:

\`\`\`toml
[tool.setuptools]
py-modules = ["server"]
\`\`\`

Idempotent — only added if missing. \`pip install -e .\` then succeeds, the venv gets the \`mcp\`, \`pexpect\`, \`pyte\` deps, and the wire-up step produces a working tui-test entry in .mcp.json.

## How it was found

By actually running the install script — exactly the kind of thing yesterday's PR #40 set up but didn't verify ran clean.

## Side effect committed

\`scripts/install-tui-mcps.sh\` already auto-wires .mcp.json after a successful install, so this PR also includes the resulting .mcp.json with \`tui-driver\` + \`tui-test\` entries pointing at the now-actually-installable binaries.

## Test plan

- [x] \`rm -rf ~/.prism/mcps/mcp-tui-test && bash scripts/install-tui-mcps.sh\` — completes cleanly
- [x] Generated \`.mcp.json\` has 5 MCP entries (was 3)
- [ ] Restart Claude Code; tui-driver + tui-test tools become callable

🤖 Generated with [Claude Code](https://claude.com/claude-code)