### PR TITLE
feat(forge_main): /exit prints conversation UUID + how to resume (slice 1 of resume feature)

### DIFF
--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -2051,6 +2051,22 @@ impl<A: API + ConsoleWriter + 'static, F: Fn(ForgeConfig) -> A + Send + Sync> UI
                 on_update(self.api.clone(), None).await;
             }
             AppCommand::Exit => {
+                // Print a resume hint so the user has the UUID + the
+                // exact command to come back. Forge auto-titles
+                // conversations and `/conversation` (no arg) is the
+                // picker; `--cid <id>` jumps straight in.
+                //
+                // Suppressed if there's no conversation_id (the user
+                // exited before sending any turn) — nothing to resume.
+                if let Some(cid) = self.state.conversation_id {
+                    let id_str = cid.into_string();
+                    use std::io::Write as _;
+                    let mut stderr = std::io::stderr();
+                    let _ = writeln!(stderr);
+                    let _ = writeln!(stderr, "Conversation saved · id: {id_str}");
+                    let _ = writeln!(stderr, "  resume:  prism tui --cid {id_str}");
+                    let _ = writeln!(stderr, "  picker:  prism tui   then type  /conversation");
+                }
                 return Ok(true);
             }
 


### PR DESCRIPTION
## What changed

When the user types \`/exit\`, the TUI now prints the conversation UUID and the two ways to resume:

\`\`\`
Conversation saved · id: 59caba8b-cdb7-4a5f-b8b9-9dbd1428f5a3
  resume:  prism tui --cid 59caba8b-cdb7-4a5f-b8b9-9dbd1428f5a3
  picker:  prism tui   then type  /conversation
\`\`\`

Suppressed when there's no \`conversation_id\` — user exited before sending any turn, nothing to resume.

## Why this slice

Forge already had everything needed for resume: session persistence, \`/conversation\` slash-command picker, and a \`--cid <id>\` CLI flag. What was missing was telling the user the ID exists and how to come back. This is the smallest possible win for a real-feeling session story.

Slice 2 (a top-level \`prism resume\` subcommand that auto-launches the picker without going through \`/conversation\`) will land as a separate PR.

## Live verified

iTerm2, real conversation, real LLM turn, then \`/exit\`. The 4-line message printed exactly as designed.

## Files

- \`crates/forge_main/src/ui.rs\` — \`AppCommand::Exit\` branch now prints the resume hint to stderr before returning

## Test plan

- [x] \`cargo build --release\` clean
- [x] \`cargo clippy -p forge_main -- -D warnings\` clean
- [x] Live: exit after a turn → prints UUID + two resume paths
- [x] Live: exit with no conversation_id (user exited before chatting) → no spurious "Conversation saved" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)