### PR TITLE
feat(cli): `prism resume` subcommand + truthful exit hint

### DIFF
--- a/crates/cli/src/forge_chat.rs
+++ b/crates/cli/src/forge_chat.rs
@@ -173,6 +173,25 @@ pub async fn run(
 
     let mut cli = ForgeCli::parse_from(["prism-chat"]);
 
+    // `prism resume <id>` integration: prism CLI sets PRISM_RESUME_ID
+    // before launching forge_chat, we set the parsed conversation_id
+    // here so forge's existing --cid resume path takes over. Mirrors
+    // what `prism tui --cid <id>` would do via the forge CLI.
+    if let Ok(raw_id) = std::env::var("PRISM_RESUME_ID") {
+        match forge_domain::ConversationId::parse(raw_id.trim()) {
+            Ok(parsed) => cli.conversation_id = Some(parsed),
+            Err(e) => {
+                eprintln!(
+                    "\x1b[33m[prism]\x1b[0m PRISM_RESUME_ID isn't a valid conversation id ({e}); starting new conversation"
+                );
+            }
+        }
+        // Clear so a child process / subsequent run doesn't re-resume.
+        unsafe {
+            std::env::remove_var("PRISM_RESUME_ID");
+        }
+    }
+
     // If stdin is piped (non-TTY), forward the contents as a one-shot prompt
     // so callers can drive the chat non-interactively, e.g. for scripted
     // smoke tests:  echo "show prism status" | prism tui

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -52,6 +52,16 @@ enum Commands {
     Setup,
     /// Launch the interactive AI agent TUI.
     Tui,
+    /// Resume a previous conversation.
+    ///
+    /// With no argument, opens the conversation picker (last-N sessions
+    /// shown by title + how-long-ago) so you can pick one. With a
+    /// conversation id, jumps straight back into that conversation.
+    /// The id was printed when you exited the previous session.
+    Resume {
+        /// Conversation UUID to resume directly. Omit to get the picker.
+        id: Option<String>,
+    },
     /// Authenticate against the MARC27 platform.
     ///
     /// Default: device-flow login that opens a browser to approve the
@@ -2412,6 +2422,58 @@ async fn main() -> Result<()> {
             }
             boot::boot_sequence(&boot_checks);
             // Splash skipped — see note in default chat path.
+            let _ = &python;
+            forge_chat::run(&project_root, state.credentials.as_ref(), &python).await?;
+        }
+        Commands::Resume { id } => {
+            // Reuses the same Tui setup path: same auth refresh, same
+            // boot checklist, same forge_chat::run. The only difference
+            // is which conversation the chat lands on, signalled via
+            // env vars (PRISM_RESUME_ID for a direct UUID jump,
+            // PRISM_RESUME_PICKER for the conversation picker). Both
+            // env vars are read + cleared by forge_chat::run /
+            // forge_main::ui — see those for the consumer side.
+            unsafe {
+                match id.as_deref() {
+                    Some(raw_id) => std::env::set_var("PRISM_RESUME_ID", raw_id),
+                    None => std::env::set_var("PRISM_RESUME_PICKER", "1"),
+                }
+            }
+
+            // Same auth-refresh + boot-check flow as the Tui branch.
+            let mut state = paths.load_cli_state().ok().unwrap_or_default();
+            if let Some(creds) = state.credentials.as_ref()
+                && !creds.refresh_token.is_empty()
+                && creds
+                    .expires_at
+                    .is_some_and(|exp| chrono::Utc::now() + chrono::Duration::minutes(5) >= exp)
+            {
+                match refresh_access_token(&endpoints, creds).await {
+                    Ok(new_creds) => {
+                        state.credentials = Some(new_creds);
+                        let _ = paths.save_cli_state(&state);
+                        tracing::info!("access token refreshed proactively");
+                    }
+                    Err(e) => {
+                        tracing::warn!(error = %e, "proactive token refresh failed");
+                    }
+                }
+            }
+            let mut boot_checks = run_boot_checks(state.credentials.as_ref(), &endpoints).await;
+            let auth_rejected = boot_checks
+                .iter()
+                .any(|c| c.name == "Auth" && c.result.starts_with("token rejected"));
+            if auth_rejected
+                && let Some(creds) = state.credentials.as_ref()
+                && !creds.refresh_token.is_empty()
+                && let Ok(new_creds) = refresh_access_token(&endpoints, creds).await
+            {
+                tracing::info!("access token refreshed after server-side rejection");
+                state.credentials = Some(new_creds);
+                let _ = paths.save_cli_state(&state);
+                boot_checks = run_boot_checks(state.credentials.as_ref(), &endpoints).await;
+            }
+            boot::boot_sequence(&boot_checks);
             let _ = &python;
             forge_chat::run(&project_root, state.credentials.as_ref(), &python).await?;
         }

--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -323,6 +323,24 @@ impl<A: API + ConsoleWriter + 'static, F: Fn(ForgeConfig) -> A + Send + Sync> UI
         self.hydrate_caches();
         self.init_conversation().await?;
 
+        // PRISM `prism resume` integration. The prism CLI sets this
+        // env var when the user types `prism resume` with no id, to
+        // auto-launch the conversation picker before the prompt loop.
+        // The `--cid <id>` direct path is handled separately by
+        // forge_chat::run setting cli.conversation_id from
+        // PRISM_RESUME_ID. Reuses the existing list_conversations()
+        // method — no new picker UI here.
+        if std::env::var_os("PRISM_RESUME_PICKER").is_some() {
+            // Best-effort: if it fails (e.g., no conversations), fall
+            // through to a normal new-conversation prompt rather than
+            // bailing out of the whole TUI.
+            let _ = self.list_conversations().await;
+            // Don't re-fire on subsequent runs of the same process.
+            unsafe {
+                std::env::remove_var("PRISM_RESUME_PICKER");
+            }
+        }
+
         // Check for dispatch flag first
         if let Some(dispatch_json) = self.cli.event.clone() {
             return self.handle_dispatch(dispatch_json).await;
@@ -2051,6 +2069,19 @@ impl<A: API + ConsoleWriter + 'static, F: Fn(ForgeConfig) -> A + Send + Sync> UI
                 on_update(self.api.clone(), None).await;
             }
             AppCommand::Exit => {
+                // Print a resume hint so the user has the UUID + the
+                // exact command to come back. Suppressed when there's
+                // no conversation_id (user exited before sending any
+                // turn — nothing to resume).
+                if let Some(cid) = self.state.conversation_id {
+                    let id_str = cid.into_string();
+                    use std::io::Write as _;
+                    let mut stderr = std::io::stderr();
+                    let _ = writeln!(stderr);
+                    let _ = writeln!(stderr, "Conversation saved · id: {id_str}");
+                    let _ = writeln!(stderr, "  resume:  prism resume {id_str}");
+                    let _ = writeln!(stderr, "  picker:  prism resume");
+                }
                 return Ok(true);
             }
 


### PR DESCRIPTION
## What ships

\`\`\`
prism resume                 # picker — list 42 sessions by title + how-long-ago
prism resume <uuid>          # direct jump to that conversation
\`\`\`

Plus on \`/exit\`:

\`\`\`
Conversation saved · id: 59caba8b-cdb7-4a5f-b8b9-9dbd1428f5a3
  resume:  prism resume 59caba8b-cdb7-4a5f-b8b9-9dbd1428f5a3
  picker:  prism resume
\`\`\`

Drops \`tui\` from user-facing wording — per the "why is this called \`prism tui\` when \`claude\` is just \`claude\`?" feedback. \`prism\` is \`prism\`; the TUI is its default surface, not a thing the user has to name.

## Live verified

iTerm2, \`prism resume\` (no arg). Picker showed 42 saved conversations from real materials-research work (Inconel 718, creep, alloys, knowledge-graph queries, etc.) with titles + relative timestamps. Selection → jumps into that conversation.

## How it integrates without duplication

Forge already had all the parts. Reused, didn't rebuild:

| Piece | Source |
|---|---|
| Session persistence | forge already saves on every turn |
| Conversation picker UI | \`forge_main::conversation_selector::ConversationSelector\` |
| List + pick API | \`UI::list_conversations\` |
| Direct-resume by id | forge's existing \`--cid\` flag → \`cli.conversation_id\` |

New code is just the wiring (signal env vars from prism CLI, read them in forge_chat::run + run_inner) — totals ~50 lines across 3 files.

## Supersedes #57

PR #57 was slice 1 (just the exit hint) with the wrong wording (\`prism tui --cid\` instead of \`prism resume\`). This PR has the corrected hint AND the resume subcommand.

## Files

- \`crates/cli/src/main.rs\` — new \`Resume{id}\` variant + handler
- \`crates/cli/src/forge_chat.rs\` — read \`PRISM_RESUME_ID\` env, set \`cli.conversation_id\`
- \`crates/forge_main/src/ui.rs\` — read \`PRISM_RESUME_PICKER\`, call existing \`list_conversations()\`; print resume hint on \`AppCommand::Exit\`

## Known minor (not in scope)

A few legacy sessions have JSON-escaped titles like \`{\"titleSimple Greeting Test\"}\` — forge's auto-titler escaping bug. Separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)