### PR TITLE
fix(forge_app): salvage title from malformed JSON fallback — Bug #30

### DIFF
--- a/crates/forge_app/src/title_generator.rs
+++ b/crates/forge_app/src/title_generator.rs
@@ -85,9 +85,100 @@ impl<S: AS> TitleGenerator<S> {
         match serde_json::from_str::<TitleResponse>(&content) {
             Ok(response) => Ok(Some(response.title)),
             Err(_) => {
-                // Fallback: Some providers don't support structured output, treat as plain text
-                Ok(Some(content.trim().to_string()))
+                // Fallback: some providers' structured-output mode returns
+                // malformed JSON like `{"titleSimple Greeting Test"}` (missing
+                // `":"` between key and value, or stray quotes). Saving that
+                // verbatim leaks JSON syntax into the conversation picker —
+                // titles show up as `{"titleSimple Greeting Test"}` instead
+                // of `Simple Greeting Test`. See PRISM Bug #30.
+                //
+                // Strip JSON-shape leftovers from the raw content so the
+                // human-readable value stays. Conservative: only touches
+                // characters that are clearly JSON syntax + the literal
+                // "title" key; word content is preserved.
+                Ok(Some(salvage_title_from_malformed(&content)))
             }
         }
+    }
+}
+
+/// Best-effort extraction of a human-readable title from a content string
+/// that wasn't valid JSON.
+///
+/// Handles the observed real-world failure shape — the upstream emits
+/// `{"title<value>"}` (no `:` separator, value not quoted). Strips the
+/// JSON-object braces, the `"title"` key, residual quotes, and
+/// surrounding whitespace.
+fn salvage_title_from_malformed(content: &str) -> String {
+    let s = content.trim();
+    // 1. Drop leading "{ and trailing }" if present.
+    let s = s.trim_start_matches('{').trim_end_matches('}').trim();
+    // 2. Drop a single leading or trailing quote (the JSON wrapper).
+    let s = s.trim_start_matches('"').trim_end_matches('"').trim();
+    // 3. Drop the literal `"title"` key + any `:` / `"` / space that follow.
+    //    Variants we've seen: `"title":"X"`, `"titleX"`, `title:"X"`, `titleX`.
+    let s = s.trim_start_matches("\"title\"");
+    let s = s.trim_start_matches("title");
+    let s = s
+        .trim_start_matches(['"', ':', ' ', '\t'])
+        .trim_end_matches(['"', ' ', '\t']);
+    s.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn salvage_handles_well_formed_json_value_substring() {
+        // Already-clean title text passes through unchanged.
+        assert_eq!(salvage_title_from_malformed("Hello"), "Hello");
+        assert_eq!(salvage_title_from_malformed("  Hello  "), "Hello");
+    }
+
+    #[test]
+    fn salvage_strips_full_quoted_string() {
+        assert_eq!(
+            salvage_title_from_malformed("\"Hello World\""),
+            "Hello World"
+        );
+    }
+
+    #[test]
+    fn salvage_handles_real_malformed_output_from_marc27_upstream() {
+        // The actual shape we observed via PRISM_BRIDGE_DUMP: the model's
+        // JSON-mode output came back missing the `":"` between key and
+        // value, which serde_json correctly rejects.
+        // Bug #30 reproduction.
+        assert_eq!(
+            salvage_title_from_malformed("{\"titleSpecific Sentence\"}"),
+            "Specific Sentence"
+        );
+        assert_eq!(
+            salvage_title_from_malformed("{\"titleSimple Greeting Test\"}"),
+            "Simple Greeting Test"
+        );
+    }
+
+    #[test]
+    fn salvage_handles_well_quoted_but_unparseable() {
+        // `"title":"Foo"` is valid JSON-fragment-ish but missing braces;
+        // serde would reject it too. Should still produce a clean title.
+        assert_eq!(salvage_title_from_malformed("\"title\":\"Foo\""), "Foo");
+    }
+
+    #[test]
+    fn salvage_handles_object_with_proper_separator_but_missing_value_quotes() {
+        assert_eq!(
+            salvage_title_from_malformed("{\"title\":Bar Baz}"),
+            "Bar Baz"
+        );
+    }
+
+    #[test]
+    fn salvage_empty_input_returns_empty() {
+        assert_eq!(salvage_title_from_malformed(""), "");
+        assert_eq!(salvage_title_from_malformed("   "), "");
+        assert_eq!(salvage_title_from_malformed("{}"), "");
     }
 }


### PR DESCRIPTION
## What broke

\`prism resume\` showed conversation titles like:

\`\`\`
▌ {"titleSimple Greeting Test"}              12m ago
▌ {"titleInel 718 Overview"}                 1day 16h 51m ago
\`\`\`

JSON syntax leaking into user-visible titles. Caught while live-verifying PR #58 (\`prism resume\` picker).

## Root cause

Some upstream LLMs in structured-output mode return broken JSON:

\`\`\`
{"titleSpecific Sentence"}
\`\`\`

— missing the \`":"\` separator and the value's opening quote. \`serde_json::from_str\` correctly rejects, and the previous fallback path saved \`content.trim()\` verbatim.

Confirmed via \`PRISM_BRIDGE_DUMP=1\` capturing upstream chunks:

\`\`\`
{"delta":"{\"title"}        # opens with `{"title` only
{"delta":"Specific"}        # bare `Specific`, no `:` or `"`
{"delta":" Sentence"}
{"delta":"\"}"}             # closes with `"}`
\`\`\`

## Fix

Best-effort \`salvage_title_from_malformed()\` strips:
- leading \`{\` and trailing \`}\`
- surrounding \`"\` quotes
- the literal \`"title"\` key (with or without quotes)
- residual \`:\`, \`"\`, whitespace

Word content is preserved. Conservative — only touches what's clearly JSON syntax.

## Test plan

6 new unit tests, all passing:

- [x] real-world \`{"titleX Y"}\` → \`X Y\` (the actual observed shape)
- [x] already-clean \`Hello\` → \`Hello\` (passthrough)
- [x] well-quoted \`"Hello"\` → \`Hello\`
- [x] half-formed \`"title":"Foo"\` → \`Foo\`
- [x] \`{"title":Bar Baz}\` (proper separator, missing value quotes) → \`Bar Baz\`
- [x] empty / whitespace / \`{}\` → empty (no spurious title)

Doesn't touch the happy path: well-formed JSON still parses via \`serde_json\` as before. New code only runs when JSON parsing fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved title generation robustness when handling unexpected response formats, now gracefully extracts readable titles from malformed data instead of falling back to raw content.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Darth-Hidious/PRISM/pull/60)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->