### PR TITLE
fix(doctor): make `prism doctor` a true superset of boot — Bug #28

### DIFF
--- a/crates/cli/src/boot.rs
+++ b/crates/cli/src/boot.rs
@@ -23,6 +23,9 @@ pub struct BootCheck {
 }
 
 /// Run the boot sequence (raw stdout, ANSI colors only).
+///
+/// Prints the "Initializing..." banner, every check line, and the
+/// "Igniting core..." trailer. Used at `prism` startup.
 pub fn boot_sequence(checks: &[BootCheck]) {
     let print_colored = |text: &str| {
         print!("{text}");
@@ -33,6 +36,23 @@ pub fn boot_sequence(checks: &[BootCheck]) {
         "\x1b[38;2;0;255;255m[PRISM]\x1b[0m \x1b[38;2;200;200;200mInitializing Materials Discovery Node...\x1b[0m\n",
     );
     thread::sleep(Duration::from_millis(200));
+
+    print_check_lines(checks);
+
+    print_colored(
+        "\n\x1b[38;2;0;255;255m[PRISM]\x1b[0m \x1b[38;2;200;200;200mIgniting core...\x1b[0m\n",
+    );
+    thread::sleep(Duration::from_millis(300));
+}
+
+/// Print just the check lines without the "Initializing..." / "Igniting core..."
+/// frame. Used by `prism doctor` so each section under its own [PRISM] header
+/// reads as one continuous tree instead of repeating the boot banner.
+pub fn print_check_lines(checks: &[BootCheck]) {
+    let print_colored = |text: &str| {
+        print!("{text}");
+        let _ = io::stdout().flush();
+    };
 
     for check in checks {
         print_colored(&format!(
@@ -55,11 +75,6 @@ pub fn boot_sequence(checks: &[BootCheck]) {
             ));
         }
     }
-
-    print_colored(
-        "\n\x1b[38;2;0;255;255m[PRISM]\x1b[0m \x1b[38;2;200;200;200mIgniting core...\x1b[0m\n",
-    );
-    thread::sleep(Duration::from_millis(300));
 }
 
 // ── Shared styling for section-style output ──────────────────────────

--- a/crates/cli/src/boot_checks.rs
+++ b/crates/cli/src/boot_checks.rs
@@ -110,7 +110,13 @@ pub async fn run_boot_checks(
             .send()
             .await
             .ok()
-            .and_then(|r| if r.status().is_success() { Some(r) } else { None });
+            .and_then(|r| {
+                if r.status().is_success() {
+                    Some(r)
+                } else {
+                    None
+                }
+            });
         let (kg_ok, kg_msg) = if let Some(resp) = stats {
             let data: serde_json::Value = resp.json().await.unwrap_or_default();
             let nodes = data.get("node_count").and_then(|v| v.as_u64()).unwrap_or(0);
@@ -145,7 +151,13 @@ pub async fn run_boot_checks(
                 .send()
                 .await
                 .ok()
-                .and_then(|r| if r.status().is_success() { Some(r) } else { None });
+                .and_then(|r| {
+                    if r.status().is_success() {
+                        Some(r)
+                    } else {
+                        None
+                    }
+                });
             let (m_ok, m_msg) = if let Some(resp) = models {
                 let data: serde_json::Value = resp.json().await.unwrap_or_default();
                 let count = if let Some(arr) = data.as_array() {
@@ -178,7 +190,13 @@ pub async fn run_boot_checks(
             .send()
             .await
             .ok()
-            .and_then(|r| if r.status().is_success() { Some(r) } else { None });
+            .and_then(|r| {
+                if r.status().is_success() {
+                    Some(r)
+                } else {
+                    None
+                }
+            });
         let (c_ok, c_msg) = if let Some(resp) = gpus {
             let data: serde_json::Value = resp.json().await.unwrap_or_default();
             let count = data.as_array().map(|a| a.len()).unwrap_or(0);
@@ -203,7 +221,13 @@ pub async fn run_boot_checks(
             .send()
             .await
             .ok()
-            .and_then(|r| if r.status().is_success() { Some(r) } else { None });
+            .and_then(|r| {
+                if r.status().is_success() {
+                    Some(r)
+                } else {
+                    None
+                }
+            });
         let (mk_ok, mk_msg) = if let Some(resp) = mkt {
             let data: serde_json::Value = resp.json().await.unwrap_or_default();
             let count = data.as_array().map(|a| a.len()).unwrap_or(0);

--- a/crates/cli/src/boot_checks.rs
+++ b/crates/cli/src/boot_checks.rs
@@ -1,0 +1,252 @@
+//! Platform-connectivity boot checks shared by `prism` startup and `prism doctor`.
+//!
+//! Pings the live MARC27 platform endpoints (auth, KG, models, compute,
+//! marketplace) plus the local node and policy engine, returns a vector of
+//! [`BootCheck`] for the renderer to print.
+//!
+//! Extracted from `main.rs` so `prism doctor` can run the same checks
+//! without duplicating the logic — keeps the doctor a true superset of
+//! the boot screen (local setup + platform connectivity).
+
+use std::time::Duration;
+
+use prism_runtime::{PlatformEndpoints, StoredCredentials};
+
+use crate::boot;
+
+/// Run the live platform-connectivity checks.
+///
+/// Each check times out after 5s; failures are reported as `[--]` so the
+/// boot screen never hangs.
+pub async fn run_boot_checks(
+    creds: Option<&StoredCredentials>,
+    endpoints: &PlatformEndpoints,
+) -> Vec<boot::BootCheck> {
+    let mut checks = Vec::new();
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .unwrap_or_default();
+
+    let token = creds.map(|c| c.access_token.as_str()).unwrap_or("");
+    let api = &endpoints.api_base;
+
+    // 1. Platform connection — use /agent/capabilities (always 200 with auth)
+    let auth_header = format!("Bearer {token}");
+    let platform_ok = client
+        .get(format!("{api}/agent/capabilities"))
+        .header("Authorization", &auth_header)
+        .send()
+        .await
+        .map(|r| r.status().is_success())
+        .unwrap_or(false);
+    let host = api
+        .replace("https://", "")
+        .replace("http://", "")
+        .replace("/api/v1", "");
+    checks.push(boot::BootCheck {
+        name: "Platform".into(),
+        result: if platform_ok {
+            format!("{host} connected")
+        } else {
+            format!("{host} unreachable")
+        },
+        ok: platform_ok,
+        dots: 8,
+        delay_ms: 30,
+    });
+
+    // 2. Auth — distinguish actual expiry from scope/network/server errors.
+    if !token.is_empty() {
+        let user_resp = client
+            .get(format!("{api}/users/me"))
+            .header("Authorization", format!("Bearer {token}"))
+            .send()
+            .await;
+        let (auth_ok, auth_msg) = match user_resp {
+            Ok(r) if r.status().is_success() => {
+                let data: serde_json::Value = r.json().await.unwrap_or_default();
+                let name = data
+                    .get("display_name")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("authenticated");
+                (true, name.to_string())
+            }
+            Ok(r) if r.status() == reqwest::StatusCode::UNAUTHORIZED => {
+                (false, "token rejected — run prism login".into())
+            }
+            Ok(r) if r.status() == reqwest::StatusCode::FORBIDDEN => {
+                (false, "token lacks user scope (agent key?)".into())
+            }
+            Ok(r) => (
+                false,
+                format!("platform error (HTTP {})", r.status().as_u16()),
+            ),
+            Err(e) if e.is_timeout() => (false, "platform unreachable (timeout)".into()),
+            Err(_) => (false, "platform unreachable".into()),
+        };
+        checks.push(boot::BootCheck {
+            name: "Auth".into(),
+            result: auth_msg,
+            ok: auth_ok,
+            dots: 6,
+            delay_ms: 20,
+        });
+    } else {
+        checks.push(boot::BootCheck {
+            name: "Auth".into(),
+            result: "not logged in — run prism login".into(),
+            ok: false,
+            dots: 3,
+            delay_ms: 20,
+        });
+    }
+
+    // 3. Knowledge Graph
+    if !token.is_empty() {
+        let stats = client
+            .get(format!("{api}/knowledge/graph/stats"))
+            .header("Authorization", format!("Bearer {token}"))
+            .send()
+            .await
+            .ok()
+            .and_then(|r| if r.status().is_success() { Some(r) } else { None });
+        let (kg_ok, kg_msg) = if let Some(resp) = stats {
+            let data: serde_json::Value = resp.json().await.unwrap_or_default();
+            let nodes = data.get("node_count").and_then(|v| v.as_u64()).unwrap_or(0);
+            let edges = data.get("edge_count").and_then(|v| v.as_u64()).unwrap_or(0);
+            if nodes > 0 {
+                (
+                    true,
+                    format!("{}K nodes, {}M edges", nodes / 1000, edges / 1_000_000),
+                )
+            } else {
+                (true, "connected".into())
+            }
+        } else {
+            (false, "unavailable".into())
+        };
+        checks.push(boot::BootCheck {
+            name: "Knowledge Graph".into(),
+            result: kg_msg,
+            ok: kg_ok,
+            dots: 12,
+            delay_ms: 25,
+        });
+    }
+
+    // 4. Models
+    if !token.is_empty() {
+        let project_id = creds.and_then(|c| c.project_id.as_deref()).unwrap_or("");
+        if !project_id.is_empty() {
+            let models = client
+                .get(format!("{api}/projects/{project_id}/llm/models"))
+                .header("Authorization", format!("Bearer {token}"))
+                .send()
+                .await
+                .ok()
+                .and_then(|r| if r.status().is_success() { Some(r) } else { None });
+            let (m_ok, m_msg) = if let Some(resp) = models {
+                let data: serde_json::Value = resp.json().await.unwrap_or_default();
+                let count = if let Some(arr) = data.as_array() {
+                    arr.len()
+                } else {
+                    data.get("models")
+                        .and_then(|v| v.as_array())
+                        .map(|a| a.len())
+                        .unwrap_or(0)
+                };
+                (true, format!("{count} hosted models"))
+            } else {
+                (false, "unavailable".into())
+            };
+            checks.push(boot::BootCheck {
+                name: "LLM Models".into(),
+                result: m_msg,
+                ok: m_ok,
+                dots: 10,
+                delay_ms: 20,
+            });
+        }
+    }
+
+    // 5. Compute
+    if !token.is_empty() {
+        let gpus = client
+            .get(format!("{api}/compute/gpus"))
+            .header("Authorization", format!("Bearer {token}"))
+            .send()
+            .await
+            .ok()
+            .and_then(|r| if r.status().is_success() { Some(r) } else { None });
+        let (c_ok, c_msg) = if let Some(resp) = gpus {
+            let data: serde_json::Value = resp.json().await.unwrap_or_default();
+            let count = data.as_array().map(|a| a.len()).unwrap_or(0);
+            (true, format!("{count} GPU types available"))
+        } else {
+            (false, "unavailable".into())
+        };
+        checks.push(boot::BootCheck {
+            name: "Compute".into(),
+            result: c_msg,
+            ok: c_ok,
+            dots: 8,
+            delay_ms: 25,
+        });
+    }
+
+    // 6. Marketplace
+    if !token.is_empty() {
+        let mkt = client
+            .get(format!("{api}/marketplace/resources"))
+            .header("Authorization", format!("Bearer {token}"))
+            .send()
+            .await
+            .ok()
+            .and_then(|r| if r.status().is_success() { Some(r) } else { None });
+        let (mk_ok, mk_msg) = if let Some(resp) = mkt {
+            let data: serde_json::Value = resp.json().await.unwrap_or_default();
+            let count = data.as_array().map(|a| a.len()).unwrap_or(0);
+            (true, format!("{count} resources"))
+        } else {
+            (false, "unavailable".into())
+        };
+        checks.push(boot::BootCheck {
+            name: "Marketplace".into(),
+            result: mk_msg,
+            ok: mk_ok,
+            dots: 6,
+            delay_ms: 30,
+        });
+    }
+
+    // 7. Local node
+    let node_ok = client
+        .get("http://127.0.0.1:7327/api/health")
+        .send()
+        .await
+        .map(|r| r.status().is_success())
+        .unwrap_or(false);
+    checks.push(boot::BootCheck {
+        name: "Local Node".into(),
+        result: if node_ok {
+            "online at :7327".into()
+        } else {
+            "offline — run prism node up".into()
+        },
+        ok: node_ok,
+        dots: 4,
+        delay_ms: 20,
+    });
+
+    // 8. Policy engine (always local, always OK)
+    checks.push(boot::BootCheck {
+        name: "Policy Engine".into(),
+        result: "OPA/Rego loaded".into(),
+        ok: true,
+        dots: 4,
+        delay_ms: 15,
+    });
+
+    checks
+}

--- a/crates/cli/src/doctor.rs
+++ b/crates/cli/src/doctor.rs
@@ -1,18 +1,31 @@
 //! `prism doctor` — diagnostic snapshot of everything PRISM needs to run.
 //!
-//! Lists each runtime dependency with [OK] / [--] / [!] markers. Designed
-//! to be the first thing a user runs when something feels off — gives them
-//! a single screen of what's healthy and what's missing.
+//! Runs in two clearly-labeled sections:
+//!
+//! 1. **Local Setup** — binaries, files, project root, python interpreter.
+//!    The "is your laptop ready?" pass.
+//! 2. **Platform Connectivity** — auth, KG, models, compute, marketplace,
+//!    local node, policy engine. The same checks `prism` runs on startup,
+//!    so a green doctor means a green boot.
+//!
+//! Lists each check with [OK] / [--] markers. Designed to be the first
+//! thing a user runs when something feels off — single screen, full picture.
 
 use std::path::PathBuf;
 
 use anyhow::Result;
+use prism_runtime::{PlatformEndpoints, PrismPaths};
 
-use crate::boot::{BootCheck, boot_sequence};
+use crate::boot::{self, BootCheck, print_check_lines};
+use crate::boot_checks;
 
 pub async fn run(project_root: &std::path::Path, python_bin: &std::path::Path) -> Result<()> {
     let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
     let prism_dir = PathBuf::from(&home).join(".prism");
+
+    // ── Section 1: local setup ────────────────────────────────────────
+    boot::section("Local Setup");
+
     let mut checks: Vec<BootCheck> = Vec::new();
 
     // 1. llama-server (homebrew or PATH)
@@ -29,7 +42,7 @@ pub async fn run(project_root: &std::path::Path, python_bin: &std::path::Path) -
     checks.push(check_file(
         "EmbeddingGemma model",
         &embed_gguf,
-        "auto-downloads on first `prism tui`",
+        "auto-downloads on first `prism`",
     ));
 
     // 3. FunctionGemma model — DEPRECATED. The Stage 2.2 local-routing
@@ -75,7 +88,7 @@ pub async fn run(project_root: &std::path::Path, python_bin: &std::path::Path) -
     checks.push(check_file(
         "forge MCP config",
         &forge_mcp,
-        "auto-generated on first `prism tui`",
+        "auto-generated on first `prism`",
     ));
 
     // 7. Tool router index (rebuilt automatically; informational)
@@ -110,15 +123,25 @@ pub async fn run(project_root: &std::path::Path, python_bin: &std::path::Path) -
         delay_ms: 0,
     });
 
-    boot_sequence(&checks);
+    print_check_lines(&checks);
+
+    // ── Section 2: platform connectivity (same checks as `prism` boot) ─
+    boot::section("Platform Connectivity");
+
+    let paths = PrismPaths::discover()?;
+    let state = paths.load_cli_state().unwrap_or_default();
+    let endpoints = PlatformEndpoints::from_env();
+    let platform_checks =
+        boot_checks::run_boot_checks(state.credentials.as_ref(), &endpoints).await;
+    print_check_lines(&platform_checks);
 
     println!();
     println!("Anything marked [--] means: not yet present, but PRISM will set it up");
     println!("on demand or via the documented one-liner.");
     println!();
     println!("If chat is misbehaving in unexpected ways, also try:");
-    println!("  rm -rf ~/.prism/tool_router && prism tui    # rebuilds tool index");
-    println!("  rm  ~/.forge/.mcp.json && prism tui          # rewrites MCP config");
+    println!("  rm -rf ~/.prism/tool_router && prism    # rebuilds tool index");
+    println!("  rm  ~/.forge/.mcp.json && prism          # rewrites MCP config");
     Ok(())
 }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -5,6 +5,7 @@
 //! discovery from `~/.prism/workflows/`.
 
 mod boot;
+mod boot_checks;
 mod chat_config;
 mod doctor;
 mod forge_chat;
@@ -957,7 +958,7 @@ async fn main() -> Result<()> {
             // still have a refresh_token we haven't tried yet (local
             // expires_at said fresh but server disagreed → server-side
             // rotation), try one more refresh + redo the check.
-            let mut boot_checks = run_boot_checks(state.credentials.as_ref(), &endpoints).await;
+            let mut boot_checks = boot_checks::run_boot_checks(state.credentials.as_ref(), &endpoints).await;
             let auth_rejected = boot_checks
                 .iter()
                 .any(|c| c.name == "Auth" && c.result.starts_with("token rejected"));
@@ -971,7 +972,7 @@ async fn main() -> Result<()> {
                         state.credentials = Some(new_creds);
                         paths.save_cli_state(&state)?;
                         // Redo the boot checks with the new token.
-                        boot_checks = run_boot_checks(state.credentials.as_ref(), &endpoints).await;
+                        boot_checks = boot_checks::run_boot_checks(state.credentials.as_ref(), &endpoints).await;
                     }
                     Err(e) => {
                         tracing::warn!(
@@ -2396,7 +2397,7 @@ async fn main() -> Result<()> {
                     }
                 }
             }
-            let mut boot_checks = run_boot_checks(state.credentials.as_ref(), &endpoints).await;
+            let mut boot_checks = boot_checks::run_boot_checks(state.credentials.as_ref(), &endpoints).await;
             let auth_rejected = boot_checks
                 .iter()
                 .any(|c| c.name == "Auth" && c.result.starts_with("token rejected"));
@@ -2408,7 +2409,7 @@ async fn main() -> Result<()> {
                 tracing::info!("access token refreshed after server-side rejection");
                 state.credentials = Some(new_creds);
                 let _ = paths.save_cli_state(&state);
-                boot_checks = run_boot_checks(state.credentials.as_ref(), &endpoints).await;
+                boot_checks = boot_checks::run_boot_checks(state.credentials.as_ref(), &endpoints).await;
             }
             boot::boot_sequence(&boot_checks);
             // Splash skipped — see note in default chat path.
@@ -6105,274 +6106,6 @@ async fn handle_job_status(job_id_str: &str) -> Result<()> {
     }
 
     Ok(())
-}
-
-// ── Boot checks (real API pings) ──────────────────────────────────────
-
-async fn run_boot_checks(
-    creds: Option<&StoredCredentials>,
-    endpoints: &PlatformEndpoints,
-) -> Vec<boot::BootCheck> {
-    let mut checks = Vec::new();
-    let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(5))
-        .build()
-        .unwrap_or_default();
-
-    let token = creds.map(|c| c.access_token.as_str()).unwrap_or("");
-    let api = &endpoints.api_base;
-
-    // 1. Platform connection — use /agent/capabilities (always 200 with auth)
-    let auth_header = format!("Bearer {token}");
-    let platform_ok = client
-        .get(format!("{api}/agent/capabilities"))
-        .header("Authorization", &auth_header)
-        .send()
-        .await
-        .map(|r| r.status().is_success())
-        .unwrap_or(false);
-    let host = api
-        .replace("https://", "")
-        .replace("http://", "")
-        .replace("/api/v1", "");
-    checks.push(boot::BootCheck {
-        name: "Platform".into(),
-        result: if platform_ok {
-            format!("{host} connected")
-        } else {
-            format!("{host} unreachable")
-        },
-        ok: platform_ok,
-        dots: 8,
-        delay_ms: 30,
-    });
-
-    // 2. Auth — distinguish actual expiry from scope/network/server errors.
-    // Previously this said "token expired" on ANY non-2xx, which is
-    // misleading because /users/me can fail for reasons other than
-    // expiry (token scope insufficient, server flap, network blip).
-    // Be honest about which failure mode we actually saw.
-    if !token.is_empty() {
-        let user_resp = client
-            .get(format!("{api}/users/me"))
-            .header("Authorization", format!("Bearer {token}"))
-            .send()
-            .await;
-        let (auth_ok, auth_msg) = match user_resp {
-            Ok(r) if r.status().is_success() => {
-                let data: serde_json::Value = r.json().await.unwrap_or_default();
-                let name = data
-                    .get("display_name")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("authenticated");
-                (true, name.to_string())
-            }
-            Ok(r) if r.status() == reqwest::StatusCode::UNAUTHORIZED => {
-                // Real auth rejection — token expired, revoked, or
-                // missing the /users/me scope.
-                (false, "token rejected — run prism login".into())
-            }
-            Ok(r) if r.status() == reqwest::StatusCode::FORBIDDEN => {
-                // Token authenticates but lacks /users/me scope.
-                // Common with agent / project-scoped keys; do NOT
-                // prompt re-login since chat / research still work.
-                (false, "token lacks user scope (agent key?)".into())
-            }
-            Ok(r) => (
-                false,
-                format!("platform error (HTTP {})", r.status().as_u16()),
-            ),
-            Err(e) if e.is_timeout() => (false, "platform unreachable (timeout)".into()),
-            Err(_) => (false, "platform unreachable".into()),
-        };
-        checks.push(boot::BootCheck {
-            name: "Auth".into(),
-            result: auth_msg,
-            ok: auth_ok,
-            dots: 6,
-            delay_ms: 20,
-        });
-    } else {
-        checks.push(boot::BootCheck {
-            name: "Auth".into(),
-            result: "not logged in — run prism login".into(),
-            ok: false,
-            dots: 3,
-            delay_ms: 20,
-        });
-    }
-
-    // 3. Knowledge Graph
-    if !token.is_empty() {
-        let stats = client
-            .get(format!("{api}/knowledge/graph/stats"))
-            .header("Authorization", format!("Bearer {token}"))
-            .send()
-            .await
-            .ok()
-            .and_then(|r| {
-                if r.status().is_success() {
-                    Some(r)
-                } else {
-                    None
-                }
-            });
-        let (kg_ok, kg_msg) = if let Some(resp) = stats {
-            let data: serde_json::Value = resp.json().await.unwrap_or_default();
-            let nodes = data.get("node_count").and_then(|v| v.as_u64()).unwrap_or(0);
-            let edges = data.get("edge_count").and_then(|v| v.as_u64()).unwrap_or(0);
-            if nodes > 0 {
-                (
-                    true,
-                    format!("{}K nodes, {}M edges", nodes / 1000, edges / 1_000_000),
-                )
-            } else {
-                (true, "connected".into())
-            }
-        } else {
-            (false, "unavailable".into())
-        };
-        checks.push(boot::BootCheck {
-            name: "Knowledge Graph".into(),
-            result: kg_msg,
-            ok: kg_ok,
-            dots: 12,
-            delay_ms: 25,
-        });
-    }
-
-    // 4. Models
-    if !token.is_empty() {
-        let project_id = creds.and_then(|c| c.project_id.as_deref()).unwrap_or("");
-        if !project_id.is_empty() {
-            let models = client
-                .get(format!("{api}/projects/{project_id}/llm/models"))
-                .header("Authorization", format!("Bearer {token}"))
-                .send()
-                .await
-                .ok()
-                .and_then(|r| {
-                    if r.status().is_success() {
-                        Some(r)
-                    } else {
-                        None
-                    }
-                });
-            let (m_ok, m_msg) = if let Some(resp) = models {
-                let data: serde_json::Value = resp.json().await.unwrap_or_default();
-                let count = if let Some(arr) = data.as_array() {
-                    arr.len()
-                } else {
-                    data.get("models")
-                        .and_then(|v| v.as_array())
-                        .map(|a| a.len())
-                        .unwrap_or(0)
-                };
-                (true, format!("{count} hosted models"))
-            } else {
-                (false, "unavailable".into())
-            };
-            checks.push(boot::BootCheck {
-                name: "LLM Models".into(),
-                result: m_msg,
-                ok: m_ok,
-                dots: 10,
-                delay_ms: 20,
-            });
-        }
-    }
-
-    // 5. Compute
-    if !token.is_empty() {
-        let gpus = client
-            .get(format!("{api}/compute/gpus"))
-            .header("Authorization", format!("Bearer {token}"))
-            .send()
-            .await
-            .ok()
-            .and_then(|r| {
-                if r.status().is_success() {
-                    Some(r)
-                } else {
-                    None
-                }
-            });
-        let (c_ok, c_msg) = if let Some(resp) = gpus {
-            let data: serde_json::Value = resp.json().await.unwrap_or_default();
-            let count = data.as_array().map(|a| a.len()).unwrap_or(0);
-            (true, format!("{count} GPU types available"))
-        } else {
-            (false, "unavailable".into())
-        };
-        checks.push(boot::BootCheck {
-            name: "Compute".into(),
-            result: c_msg,
-            ok: c_ok,
-            dots: 8,
-            delay_ms: 25,
-        });
-    }
-
-    // 6. Marketplace
-    if !token.is_empty() {
-        let mkt = client
-            .get(format!("{api}/marketplace/resources"))
-            .header("Authorization", format!("Bearer {token}"))
-            .send()
-            .await
-            .ok()
-            .and_then(|r| {
-                if r.status().is_success() {
-                    Some(r)
-                } else {
-                    None
-                }
-            });
-        let (mk_ok, mk_msg) = if let Some(resp) = mkt {
-            let data: serde_json::Value = resp.json().await.unwrap_or_default();
-            let count = data.as_array().map(|a| a.len()).unwrap_or(0);
-            (true, format!("{count} resources"))
-        } else {
-            (false, "unavailable".into())
-        };
-        checks.push(boot::BootCheck {
-            name: "Marketplace".into(),
-            result: mk_msg,
-            ok: mk_ok,
-            dots: 6,
-            delay_ms: 30,
-        });
-    }
-
-    // 7. Local node
-    let node_ok = client
-        .get("http://127.0.0.1:7327/api/health")
-        .send()
-        .await
-        .map(|r| r.status().is_success())
-        .unwrap_or(false);
-    checks.push(boot::BootCheck {
-        name: "Local Node".into(),
-        result: if node_ok {
-            "online at :7327".into()
-        } else {
-            "offline — run prism node up".into()
-        },
-        ok: node_ok,
-        dots: 4,
-        delay_ms: 20,
-    });
-
-    // 8. Policy engine (always local, always OK)
-    checks.push(boot::BootCheck {
-        name: "Policy Engine".into(),
-        result: "OPA/Rego loaded".into(),
-        ok: true,
-        dots: 4,
-        delay_ms: 15,
-    });
-
-    checks
 }
 
 // ── prism report ───────────────────────────────────────────────────────

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -958,7 +958,8 @@ async fn main() -> Result<()> {
             // still have a refresh_token we haven't tried yet (local
             // expires_at said fresh but server disagreed → server-side
             // rotation), try one more refresh + redo the check.
-            let mut boot_checks = boot_checks::run_boot_checks(state.credentials.as_ref(), &endpoints).await;
+            let mut boot_checks =
+                boot_checks::run_boot_checks(state.credentials.as_ref(), &endpoints).await;
             let auth_rejected = boot_checks
                 .iter()
                 .any(|c| c.name == "Auth" && c.result.starts_with("token rejected"));
@@ -972,7 +973,9 @@ async fn main() -> Result<()> {
                         state.credentials = Some(new_creds);
                         paths.save_cli_state(&state)?;
                         // Redo the boot checks with the new token.
-                        boot_checks = boot_checks::run_boot_checks(state.credentials.as_ref(), &endpoints).await;
+                        boot_checks =
+                            boot_checks::run_boot_checks(state.credentials.as_ref(), &endpoints)
+                                .await;
                     }
                     Err(e) => {
                         tracing::warn!(
@@ -2397,7 +2400,8 @@ async fn main() -> Result<()> {
                     }
                 }
             }
-            let mut boot_checks = boot_checks::run_boot_checks(state.credentials.as_ref(), &endpoints).await;
+            let mut boot_checks =
+                boot_checks::run_boot_checks(state.credentials.as_ref(), &endpoints).await;
             let auth_rejected = boot_checks
                 .iter()
                 .any(|c| c.name == "Auth" && c.result.starts_with("token rejected"));
@@ -2409,7 +2413,8 @@ async fn main() -> Result<()> {
                 tracing::info!("access token refreshed after server-side rejection");
                 state.credentials = Some(new_creds);
                 let _ = paths.save_cli_state(&state);
-                boot_checks = boot_checks::run_boot_checks(state.credentials.as_ref(), &endpoints).await;
+                boot_checks =
+                    boot_checks::run_boot_checks(state.credentials.as_ref(), &endpoints).await;
             }
             boot::boot_sequence(&boot_checks);
             // Splash skipped — see note in default chat path.

--- a/crates/cli/src/platform_bridge.rs
+++ b/crates/cli/src/platform_bridge.rs
@@ -303,12 +303,16 @@ fn fifo_trim(req: &mut Value, tools: &mut Vec<Value>) {
             .unwrap_or(usize::MAX);
     }
     if kept.len() != original {
-        eprintln!(
-            "[platform_bridge] FIFO fallback trim: {} → {} (body {} / budget {})",
-            original,
-            kept.len(),
-            size,
-            MARC27_BODY_BUDGET,
+        // Bug #30b: was eprintln! → leaked into the chat panel on
+        // every turn. Demote to tracing::debug! so operators on
+        // RUST_LOG=debug still see it but the user doesn't.
+        tracing::debug!(
+            target: "platform_bridge",
+            original_tools = original,
+            kept_tools = kept.len(),
+            body_bytes = size,
+            budget = MARC27_BODY_BUDGET,
+            "FIFO fallback trim"
         );
     }
 }
@@ -341,10 +345,14 @@ fn truncate_oversized_messages(req: &mut Value) {
             // Safety brake: if we haven't fit after 50 truncations, give up
             // and let MARC27 reject — surfacing the underlying bug is better
             // than silently looping.
-            eprintln!(
-                "[platform_bridge] truncate_oversized_messages: gave up at \
-                 iteration 50 with body {} > {} budget",
-                size, MARC27_BODY_BUDGET
+            // Loud warning — this is a real bailout, operators want to know.
+            // Still tracing rather than eprintln! so it goes to logs not the
+            // user-facing chat panel (Bug #30b).
+            tracing::warn!(
+                target: "platform_bridge",
+                body_bytes = size,
+                budget = MARC27_BODY_BUDGET,
+                "truncate_oversized_messages: gave up at iteration 50"
             );
             break;
         }
@@ -404,9 +412,15 @@ fn truncate_oversized_messages(req: &mut Value) {
     }
 
     if total_truncated_bytes > 0 {
-        eprintln!(
-            "[platform_bridge] truncated {} bytes across {} iteration(s) to fit {} byte budget",
-            total_truncated_bytes, iterations, MARC27_BODY_BUDGET
+        // Bug #30b: was eprintln! → leaked into the chat panel on
+        // turns where the body had to be truncated. Demote to debug
+        // (operators can see it via RUST_LOG=debug).
+        tracing::debug!(
+            target: "platform_bridge",
+            truncated_bytes = total_truncated_bytes,
+            iterations = iterations,
+            budget = MARC27_BODY_BUDGET,
+            "truncated body to fit budget"
         );
     }
 }
@@ -534,9 +548,18 @@ async fn chat_completions(State(state): State<Arc<ProxyState>>, body: Bytes) -> 
                     req["tools"] = Value::Array(kept);
                     if kept_count != original {
                         let final_size = serde_json::to_vec(&req).map(|b| b.len()).unwrap_or(0);
-                        eprintln!(
-                            "[platform_bridge] semantic top-K: {} → {} tools (body {} bytes)",
-                            original, kept_count, final_size
+                        // Bug #30b: was eprintln! → fired EVERY turn,
+                        // dumping operational debug info ('semantic
+                        // top-K: 149 → 12 tools (body 39859 bytes)')
+                        // straight into the user-facing chat panel.
+                        // Demote to tracing::debug! — operators on
+                        // RUST_LOG=debug still see it.
+                        tracing::debug!(
+                            target: "platform_bridge",
+                            original_tools = original,
+                            kept_tools = kept_count,
+                            body_bytes = final_size,
+                            "semantic top-K trim"
                         );
                     }
                 }


### PR DESCRIPTION
## Summary

`prism doctor` now checks **both** local setup (binaries, models, venv, credentials) **and** platform connectivity (auth, KG, models, compute, marketplace, local node, policy engine) in two clearly-labeled sections — so a green doctor means a green boot.

Before, the two diagnostics didn't overlap: doctor only inspected the laptop, the boot screen only inspected the platform. Users running `prism doctor` after a failed boot got a misleading "all green" report.

## What changed

- Extracted `run_boot_checks` (260 lines) from `main.rs` into `crates/cli/src/boot_checks.rs` so it's callable from both `prism` startup and `prism doctor`.
- Split `boot::boot_sequence` into:
  - `boot_sequence` — framed version (banner + checks + trailer), used by `prism` startup, shape unchanged.
  - `print_check_lines` — bare check-tree printer, used by `prism doctor` so two sections under their own `[PRISM]` headers read as one continuous tree without repeating the boot banner.
- 4 call sites in `main.rs` now call `boot_checks::run_boot_checks(...)`.

## Live verification

```
[PRISM] Local Setup
 ├── llama-server .... [OK] (/opt/homebrew/bin/llama-server)
 ├── EmbeddingGemma model .... [OK] (313 MB)
 ├── PRISM Python venv .... [OK]
 ├── PRISM credentials .... [OK]
 ├── forge MCP config .... [OK]
 ├── Tool router index .... [OK]
 ├── Project root .. [OK]
 └── Python interpreter .. [OK]

[PRISM] Platform Connectivity
 ├── Platform ........ [OK] (api.marc27.com connected)
 ├── Auth ...... [--] (token rejected — run prism login)
 ├── Knowledge Graph ............ [OK] (connected)
 ├── LLM Models .......... [OK] (597 hosted models)
 ├── Compute ........ [--] (unavailable)
 ├── Marketplace ...... [OK] (15 resources)
 ├── Local Node .... [--] (offline — run prism node up)
 └── Policy Engine .... [OK] (OPA/Rego loaded)
```

`prism` startup output unchanged (same `boot_sequence` call).

## Test plan

- [x] `cargo check -p prism-cli` — passes
- [x] `cargo clippy -p prism-cli --all-targets -- -D warnings` — clean
- [x] `cargo build -p prism-cli --release` — passes
- [x] Live run: `./target/release/prism doctor` — both sections render
- [ ] CI matrix (will run on push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)