### PR TITLE
fix(branding): drop user-facing forge leaks (banner, /info, init)

### DIFF
--- a/crates/cli/src/forge_chat.rs
+++ b/crates/cli/src/forge_chat.rs
@@ -54,7 +54,7 @@ const PRISM_BANNER: &str = "\x1b[38;2;0;255;255m\
 ██╔═══╝ ██╔══██╗██║╚════██║██║╚██╔╝██║
 ██║     ██║  ██║██║███████║██║ ╚═╝ ██║
 ╚═╝     ╚═╝  ╚═╝╚═╝╚══════╝╚═╝     ╚═╝\x1b[0m\n\
-\x1b[38;2;120;120;120m              · built on Forge ·\x1b[0m";
+\x1b[38;2;120;120;120m         · AI-native materials discovery ·\x1b[0m";
 
 pub async fn run(
     project_root: &Path,

--- a/crates/forge_main/src/info.rs
+++ b/crates/forge_main/src/info.rs
@@ -629,7 +629,7 @@ impl From<&ForgeCommandManager> for Info {
         info = info
             .add_title("KEYBOARD SHORTCUTS")
             .add_key_value("<CTRL+C>", "Interrupt current operation")
-            .add_key_value("<CTRL+D>", "Quit Forge interactive shell")
+            .add_key_value("<CTRL+D>", "Quit PRISM interactive shell")
             .add_key_value(multiline_shortcut, "Insert new line (multiline input)");
 
         info

--- a/crates/forge_main/src/model.rs
+++ b/crates/forge_main/src/model.rs
@@ -574,8 +574,8 @@ pub enum AppCommand {
     #[strum(props(usage = "Exit the application"))]
     Exit,
 
-    /// Updates the forge version
-    #[strum(props(usage = "Updates to the latest compatible version of forge"))]
+    /// Updates the prism version
+    #[strum(props(usage = "Updates to the latest compatible version of prism"))]
     Update,
 
     /// Switch to "forge" agent.

--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -1655,10 +1655,21 @@ impl<A: API + ConsoleWriter + 'static, F: Fn(ForgeConfig) -> A + Send + Sync> UI
         // Fetch default provider (could be different from the set provider)
         let default_provider = self.api.get_default_provider().await.ok();
 
-        // Add agent information
+        // Add agent information.
+        //
+        // The default forge agent has id "forge" — we display it as "PRISM"
+        // so users see the product they're running, not the underlying
+        // engine. Custom agents (anything else) keep their actual id so
+        // /info remains useful for debugging multi-agent setups.
         info = info.add_title("AGENT");
         if let Some(agent) = agent {
-            info = info.add_key_value("ID", agent.as_str().to_uppercase());
+            let raw = agent.as_str();
+            let display = if raw.eq_ignore_ascii_case("forge") {
+                "PRISM".to_string()
+            } else {
+                raw.to_uppercase()
+            };
+            info = info.add_key_value("ID", display);
         }
 
         // Add model information if available
@@ -3275,8 +3286,9 @@ impl<A: API + ConsoleWriter + 'static, F: Fn(ForgeConfig) -> A + Send + Sync> UI
         self.api.create_auth_credentials().await?;
         let env = self.api.environment();
         let credentials_path = crate::info::format_path_for_display(&env, &env.credentials_path());
+        // User-facing label: PRISM, not the underlying engine name.
         self.writeln_title(
-            TitleFormat::info("ForgeCode Services enabled").sub_title(&credentials_path),
+            TitleFormat::info("PRISM services enabled").sub_title(&credentials_path),
         )?;
         Ok(())
     }


### PR DESCRIPTION
## Summary

Three user-visible places where the underlying engine name leaked into the PRISM surface:

1. **Splash banner subtitle**: `· built on Forge ·` → `· AI-native materials discovery ·`. Engine attribution stays in license/about pages; the splash subtitle is product identity.

2. **\`/info\` agent ID**: when the active agent is the default forge agent (id \`forge\`), display \`PRISM\` instead of \`FORGE\`. Custom agent IDs (anything else) render unchanged so multi-agent debugging stays useful.

3. **Service init message**: \`ForgeCode Services enabled\` → \`PRISM services enabled\` (the line printed when chat creates the auth/credentials cache on first run).

## Live verification

Splash banner — confirmed via pty-debug:

\`\`\`
██████╗ ██████╗ ██╗███████╗███╗   ███╗
██╔══██╗██╔══██╗██║██╔════╝████╗ ████║
██████╔╝██████╔╝██║███████╗██╔████╔██║
██╔═══╝ ██╔══██╗██║╚════██║██║╚██╔╝██║
██║     ██║  ██║██║███████║██║ ╚═╝ ██║
╚═╝     ╚═╝  ╚═╝╚═╝╚══════╝╚═╝     ╚═╝
         · AI-native materials discovery ·
         Version: 2.7.0
\`\`\`

\`/info\` change couldn't be live-exercised here (token expired, awaiting refresh) but the change is a pure display-time string swap with no behavioral effect. \`cargo test -p forge_main\` — 329 tests still pass.

## Not in scope (separate follow-ups)

- **VS Code extension messaging** still says \"Forge VS Code extension\" — that command actually installs Forge's real extension; PRISM doesn't have its own yet.
- **Zsh rprompt** shows \`FORGE\` — separate channel; updating it would invalidate ~10 zsh rprompt unit tests.
- **Legacy env-var migration warning** points to forgecode.dev docs — correct, because that code path is specifically about migrating off forge env vars.

## Test plan

- [x] cargo build -p prism-cli --release
- [x] cargo test -p forge_main --lib (329 passed)
- [x] cargo clippy -p forge_main --all-targets -- -D warnings
- [x] Live splash render via pty-debug
- [ ] Live /info exercise (needs auth refresh)

🤖 Generated with [Claude Code](https://claude.com/claude-code)