### PR TITLE
fix(update): /update installed FORGE over PRISM — Bug #31 (CRITICAL)

### DIFF
--- a/crates/forge_main/src/info.rs
+++ b/crates/forge_main/src/info.rs
@@ -642,17 +642,12 @@ impl From<&UserUsage> for Info {
 
         let mut info = Info::new().add_title("REQUEST QUOTA");
 
-        if plan.is_upgradeable() {
-            info = info.add_key_value(
-                "Subscription",
-                format!(
-                    "{} [Upgrade https://app.forgecode.dev/app/billing]",
-                    plan.r#type.to_uppercase()
-                ),
-            );
-        } else {
-            info = info.add_key_value("Subscription", plan.r#type.to_uppercase());
-        }
+        // Show plan name. The upstream Forge build appended a forgecode.dev
+        // upgrade link here, but PRISM users are on MARC27 plans (managed
+        // through https://app.marc27.com), so the link would point to the
+        // wrong billing portal. Drop the link for now until PRISM has its
+        // own upgrade-CTA URL to wire in.
+        info = info.add_key_value("Subscription", plan.r#type.to_uppercase());
 
         info = info.add_key_value(
             "Usage",

--- a/crates/forge_main/src/update.rs
+++ b/crates/forge_main/src/update.rs
@@ -7,13 +7,18 @@ use forge_select::ForgeWidget;
 use forge_tracker::VERSION;
 use update_informer::{Check, Version, registry};
 
-/// Runs the official installation script to update Forge, failing silently.
+/// Runs the official PRISM installation script to update, failing silently.
 /// When `auto_update` is true, exits immediately after a successful update
 /// without prompting the user.
+///
+/// **Important**: this runs PRISM's installer (`prism.marc27.com/install.sh`),
+/// not the upstream Forge installer. The original code path would have
+/// reinstalled forge over the user's prism binary — broken before, now
+/// pointed at the right product.
 async fn execute_update_command(api: Arc<impl API>, auto_update: bool) {
     // Spawn a new task that won't block the main application
     let output = api
-        .execute_shell_command_raw("curl -fsSL https://forgecode.dev/cli | sh")
+        .execute_shell_command_raw("curl -fsSL https://prism.marc27.com/install.sh | bash")
         .await;
 
     match output {
@@ -28,7 +33,7 @@ async fn execute_update_command(api: Arc<impl API>, auto_update: bool) {
                     true
                 } else {
                     let answer = forge_select::ForgeWidget::confirm(
-                        "You need to close forge to complete update. Do you want to close it now?",
+                        "You need to close prism to complete update. Do you want to close it now?",
                     )
                     .with_default(true)
                     .prompt();
@@ -87,7 +92,10 @@ pub async fn on_update(api: Arc<impl API>, update: Option<&Update>) {
         return;
     }
 
-    let informer = update_informer::new(registry::GitHub, "tailcallhq/forgecode", VERSION)
+    // Check PRISM's GitHub releases, not the upstream Forge repo. The
+    // VERSION constant comes from forge_tracker but is bumped per-PRISM
+    // release in our Cargo.toml, so the comparison is apples-to-apples.
+    let informer = update_informer::new(registry::GitHub, "Darth-Hidious/PRISM", VERSION)
         .interval(frequency.into());
 
     if let Some(version) = informer.check_version().ok().flatten()


### PR DESCRIPTION
## Summary

\`prism /update\` was destructive: it would have **installed Forge on top of PRISM**.

The vendored \`crates/forge_main/src/update.rs\` was unchanged from upstream. When a user ran the \`/update\` slash command, it:

1. Polled \`https://api.github.com/repos/tailcallhq/forgecode/releases\` for the latest version.
2. If newer than \`VERSION\` (which we bump per-PRISM release), prompted \"Confirm upgrade from X.Y.Z → A.B.C\".
3. On confirm: ran \`curl -fsSL https://forgecode.dev/cli | sh\`, which is the upstream Forge installer.

That installer would have written a \`forge\` binary to the user's PATH and (depending on shell config) replaced their \`prism\` invocation. Worst case: a user runs \`/update\` thinking PRISM has a new version, ends up with Forge installed in its place.

## Fixes in this PR

1. **Update-check repo**: \`tailcallhq/forgecode\` → \`Darth-Hidious/PRISM\`.
   The \`VERSION\` constant from \`forge_tracker\` resolves at compile time from our \`Cargo.toml\` (\`v2.7.0\`), so version comparisons against PRISM's GitHub releases are apples-to-apples.

2. **Install URL**: \`https://forgecode.dev/cli\` → \`https://prism.marc27.com/install.sh\` (the URL the README documents).

3. **\`/usage\` upgrade link**: dropped \`[Upgrade https://app.forgecode.dev/app/billing]\` from the Subscription line. PRISM users are on MARC27 plans; the upstream link pointed at the wrong billing portal. Now just shows the plan name.

## Test plan

- [x] \`cargo check -p forge_main\` — clean
- [x] \`cargo clippy -p forge_main --all-targets -- -D warnings\` — clean
- [x] \`cargo test -p forge_main --lib\` — 329 passed
- [ ] CI matrix
- [ ] Live \`/update\` flow once PRISM has a release on GitHub newer than this binary

## Severity

**Critical**: silent destructive command, would actively harm users on the next \`/update\` keystroke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)