### PR TITLE
docs(readme): drop "TUI" wording + correct phantom feature claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 PRISM is a single binary that gives you an AI agent for materials science. It searches knowledge graphs, runs compute jobs, orchestrates workflows, and connects to a federated mesh of research nodes.
 
 ```bash
-prism                    # Launch interactive TUI
+prism                    # Launch interactive chat
 prism query --platform "nickel superalloys"
 prism research "high-entropy alloys" --depth 1
 prism billing            # Check credit balance
@@ -39,15 +39,14 @@ cd PRISM && cargo build --release
 cp target/release/prism ~/.local/bin/
 ```
 
-## Interactive TUI
+## Interactive chat
 
-Run `prism` to launch the terminal UI with:
-- Workspace tabs (Chat, Explorer, Models, Compute, Mesh, Workflows, Marketplace, Data, Settings)
-- Command palette (type `/` to search 69+ commands)
-- Model picker with 535 hosted models across 4 providers
-- Sidebar browser per workspace (file tree, model catalog, mesh peers, GPU resources)
-- Inline tool cards showing execution results
+Run `prism` to launch a slash-command-driven AI agent with:
+- Slash-command palette — type `/` for commands like `/new`, `/info`, `/usage`, `/help`, `/model`, `/agent`, `/update`, `/exit`
+- Model picker via `/model` (hundreds of hosted models routed through MARC27)
+- Inline tool cards showing materials-science tool execution results (CALPHAD, pyiron, OPTIMADE, ML predictions, federated knowledge graph)
 - Streaming AI responses with markdown rendering
+- Boot diagnostics (Platform, Auth, Knowledge Graph, LLM Models, Compute, Marketplace, Local Node, Policy Engine) on every launch — run `prism doctor` for the full report
 
 ## CLI Commands
 
@@ -61,7 +60,7 @@ prism status             # Auth state, paths, endpoints
 
 ### AI Agent
 ```
-prism                    # Interactive TUI agent
+prism                    # Interactive chat agent
 prism query --platform "titanium alloys"
 prism query --semantic "creep resistance"
 prism query --cypher "MATCH (a:Alloy) RETURN a"


### PR DESCRIPTION
## Summary

The README's \"Interactive TUI\" section claimed features that no longer exist on the current \`prism\` chat surface (the v2.7.0 forge-based slash-command UI, not the deprecated Ink TUI):

- ❌ \"Workspace tabs (Chat, Explorer, Models, Compute, Mesh, Workflows, Marketplace, Data, Settings)\" — never shipped on the new surface
- ❌ \"Sidebar browser per workspace\" — not in the current binary

Verified live via \`pty-debug\` against \`./target/release/prism\` — neither feature renders.

## What ships now (live-verified)

- ✅ Slash-command palette (\`/new\`, \`/info\`, \`/usage\`, \`/help\`, \`/model\`, \`/agent\`, \`/update\`, \`/exit\`)
- ✅ /model picker (hundreds of hosted models)
- ✅ Inline tool cards (CALPHAD, pyiron, OPTIMADE, ML predictions, federated KG)
- ✅ Streaming markdown
- ✅ Boot diagnostics on launch (Platform/Auth/KG/Models/Compute/Marketplace/LocalNode/Policy)
- ✅ \`prism doctor\` for the full picture — references PR #62

## Plus: user-facing \"TUI\" wording dropped

Per project directive (\"drop \`tui\` from user-facing wording — \`prism\` is \`prism\`\"), 3 user-visible \"TUI\" mentions in the README's user-flow sections are now \"chat\". Internal architecture mentions are kept where \"TUI\" is a precise technical term (Ratatui crate, prism-cli's TUI layer, license attribution).

## Test plan

- [x] Live TUI verification with pty-debug — confirmed which features actually render
- [x] No code change; pure README

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README to document interactive chat features including slash-command palette, model selection, inline tool cards, streaming markdown responses, and diagnostic commands.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Darth-Hidious/PRISM/pull/66)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->