### PR TITLE
fix(marketplace): harden install against silent overwrites + bad downloads — Bug #34

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2103,10 +2103,38 @@ async fn main() -> Result<()> {
                     }
                 }
                 MarketplaceCommands::Install { name, workflow } => {
+                    // Reject names containing path separators / parent refs.
+                    // Without this, `prism marketplace install ../../../foo`
+                    // would write to ~/.prism/tools/../../../foo.py — a self-
+                    // inflicted path traversal. Marketplace slugs are always
+                    // simple identifiers in practice, so the restriction is
+                    // safe and surfaces typos early.
+                    if name.contains('/')
+                        || name.contains('\\')
+                        || name.contains("..")
+                        || name.starts_with('.')
+                    {
+                        anyhow::bail!(
+                            "Invalid marketplace name '{name}'. Names must be simple slugs \
+                             (no `/`, `\\`, `..`, or leading `.`)."
+                        );
+                    }
+
                     let url = marketplace.install_url(&name).await?;
                     let client = reqwest::Client::new();
-                    let resp = client.get(&url).send().await?;
-                    let content = resp.text().await?;
+                    // error_for_status() converts 4xx/5xx into Err so a 404
+                    // doesn't end up saved as a Python file. Previously the
+                    // download path happily wrote HTML 404 pages as `.py`,
+                    // which then auto-loaded on next launch and crashed the
+                    // tool router with a syntax error.
+                    let content = client
+                        .get(&url)
+                        .send()
+                        .await?
+                        .error_for_status()
+                        .with_context(|| format!("downloading {name} from {url}"))?
+                        .text()
+                        .await?;
 
                     let home = std::env::var("HOME").unwrap_or_default();
                     let dest = if workflow {
@@ -2118,6 +2146,18 @@ async fn main() -> Result<()> {
                         std::fs::create_dir_all(&dir)?;
                         dir.join(format!("{name}.py"))
                     };
+
+                    // Refuse to silently overwrite a local edit. Marketplace
+                    // installs are expected to be additive; if the user
+                    // wants the upstream version they can `rm` the file
+                    // first or pass a future `--force` flag.
+                    if dest.exists() {
+                        anyhow::bail!(
+                            "Refusing to overwrite existing file at {}. \
+                             Remove it first if you want the marketplace version.",
+                            dest.display()
+                        );
+                    }
 
                     std::fs::write(&dest, &content)?;
                     let kind = if workflow { "workflow" } else { "tool" };


### PR DESCRIPTION
## Summary

\`prism marketplace install <name>\` had three quiet failure modes that all bit users in slightly different ways. This PR closes all three at the install entry point.

## The bugs

### 1. No HTTP status check → 404s saved as \`.py\`

\`\`\`rust
let resp = client.get(&url).send().await?;
let content = resp.text().await?;
\`\`\`

\`reqwest\`'s \`?\` only propagates transport errors. A marketplace 404 returns a successful HTTP transaction with HTML in the body — \`text()\` happily returns that, and we wrote it as \`~/.prism/tools/{name}.py\`. Next launch the tool router auto-loaded the HTML, hit a Python syntax error, and chat broke.

**Fix:** \`.error_for_status()\` between \`send()\` and \`text()\`.

### 2. Silent overwrite of local edits

\`std::fs::write(&dest, &content)?\` clobbered any existing file. A user who customized \`~/.prism/tools/myalloy.py\` after install and then ran the install again lost their work with no warning.

**Fix:** check \`dest.exists()\` first and bail with a clear \"remove it first if you want upstream\" message.

### 3. Path traversal via slug

\`prism marketplace install ../../../etc/passwd\` would write to \`~/.prism/tools/../../../etc/passwd.py\`. Marketplace slugs are simple identifiers in practice (the platform won't issue weird ones), so reject any name containing \`/\`, \`\\\\\`, \`..\`, or a leading \`.\` up front.

This is self-inflicted (no privilege escalation — user already controls their own home dir), but defense-in-depth.

## What didn't change

- The \"auto-discovered on next prism run\" model is intentional.
- No checksum / signature verification was added — that's a marketplace-API design decision (signed manifests) and out of scope for this PR.

## Test plan

- [x] cargo check -p prism-cli — clean
- [x] cargo clippy -p prism-cli --all-targets -- -D warnings — clean
- [ ] Live exercise once marketplace API has a known 404 case to point at

🤖 Generated with [Claude Code](https://claude.com/claude-code)