### PR TITLE
fix(privacy): block PRISM token egress to forgecode.dev — Bug #35

### DIFF
--- a/crates/cli/src/forge_chat.rs
+++ b/crates/cli/src/forge_chat.rs
@@ -211,6 +211,19 @@ pub async fn run(
             .auto_update(false),
     );
 
+    // Block forge_services::auth from POST'ing the user's PRISM token to
+    // https://api.forgecode.dev/auth/user and /auth/usage on every /info
+    // and /usage call. PRISM users authenticate against MARC27, not
+    // ForgeCode — sending their bearer token to a third-party domain
+    // would be a privacy bug, and the call would always 401 anyway.
+    //
+    // Setting services_url to a known-bad value makes the Url::parse in
+    // forge_services::auth fail fast with no network egress. The
+    // forge_main /usage caller already swallows the error gracefully
+    // (REQUEST QUOTA section just doesn't render), so this is a clean
+    // suppression rather than a hard break.
+    config.services_url = String::new();
+
     let cwd = project_root.to_path_buf();
     let mut ui = UI::init(cli, config, move |config| {
         ForgeAPI::init(cwd.clone(), config)

--- a/crates/forge_main/src/info.rs
+++ b/crates/forge_main/src/info.rs
@@ -384,9 +384,14 @@ impl From<&ForgeConfig> for Info {
                 );
         }
 
+        // Skip the "ForgeCode Service URL" line entirely when PRISM has
+        // disabled it (services_url == ""). Showing an empty value or
+        // the upstream forgecode.dev default would be misleading.
+        info = info.add_title("API CONFIGURATION");
+        if !config.services_url.is_empty() {
+            info = info.add_key_value("Services URL", config.services_url.to_string());
+        }
         info = info
-            .add_title("API CONFIGURATION")
-            .add_key_value("ForgeCode Service URL", config.services_url.to_string())
             .add_title("TOOL CONFIGURATION")
             .add_key_value("Tool Timeout", format!("{}s", config.tool_timeout_secs))
             .add_key_value(


### PR DESCRIPTION
## Summary

The vendored \`forge_services::auth\` POSTs the user's bearer token to \`https://api.forgecode.dev/auth/user\` and \`/auth/usage\` on every \`/info\` and \`/usage\` invocation. The destination URL comes from \`services_url\` in \`forge_config\`'s default \`.forge.toml\`, which we never overrode.

For PRISM users this is a **privacy bug**:
- The token is a MARC27 platform token, not a forgecode.dev token.
- The destination is a third-party domain users haven't consented to share credentials with.
- The call always 401's anyway, so it's purely outbound leakage with no useful response.

This PR is the \"send no tokens to the wrong server\" companion to:
- PR #63 (banner / agent-ID / init message branding)
- PR #64 (/update install URL)

Together they close the user-facing forgecode.dev exposure surface.

## Surgical fixes

### 1. \`crates/cli/src/forge_chat.rs\` — neutralize the URL

Blank \`config.services_url\` before launching the chat UI. \`Url::parse\` in \`forge_services::auth\` fails fast on the empty string, **no network egress**. The /usage caller already \`if let Ok(...)\`'s the result so the REQUEST QUOTA section just doesn't render.

### 2. \`crates/forge_main/src/info.rs\` — hide the empty row in /info

Skip the \"ForgeCode Service URL\" row when \`services_url\` is empty (without this it'd render as \`ForgeCode Service URL:\` with no value). Also relabeled to neutral \"Services URL\" since \"ForgeCode\" is engine-level, not user-facing.

## Test plan

- [x] cargo check -p forge_main -p prism-cli — clean
- [x] cargo clippy -p forge_main -p prism-cli --all-targets -- -D warnings — clean
- [x] cargo test -p forge_main --lib — 329 passed
- [ ] Live verify /info no longer shows the row + no outbound to api.forgecode.dev (will check once PR #62/#63 land)

🤖 Generated with [Claude Code](https://claude.com/claude-code)