### PR TITLE
fix(status): chat_surface should report "prism", not "forge" — Bug #36

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1072,7 +1072,10 @@ async fn main() -> Result<()> {
                     "backbone": {
                         "python_worker": "app.backend",
                         "node_binary": "prism-node",
-                        "chat_surface": "forge",
+                        // User-facing surface is "prism"; the underlying chat
+                        // harness is forge_main but that's an internal detail
+                        // that doesn't belong in machine-readable output.
+                        "chat_surface": "prism",
                         "workflow_runtime": "rust",
                     }
                 }))?


### PR DESCRIPTION
## Summary

\`prism status\` JSON output reported the user-facing chat surface as \`\"forge\"\`:

\`\`\`json
\"backbone\": {
  \"chat_surface\": \"forge\",
  ...
}
\`\`\`

That's the engine-level harness name leaking into machine-readable output. User-facing surface is \"prism\"; the fact that it's built on \`forge_main\` is an internal detail that doesn't belong in a field consumers key on.

## Live verified

\`\`\`
$ ./target/release/prism status | jq .backbone
{
  \"chat_surface\": \"forge\",       # ← was
  ...
}
\`\`\`

After this PR: \`\"chat_surface\": \"prism\"\`.

JSON-side companion to:
- PR #63 (banner / agent-ID / init message branding)
- PR #65 (installer copy)
- PR #68 (forgecode.dev token egress)

## Test plan

- [x] cargo check -p prism-cli — clean
- [x] cargo clippy -p prism-cli --all-targets -- -D warnings — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)