### PR TITLE
fix(workflows): one bad YAML no longer breaks all workflow discovery — Bug #37

### DIFF
--- a/crates/workflows/src/lib.rs
+++ b/crates/workflows/src/lib.rs
@@ -169,10 +169,34 @@ pub fn discover_workflows(project_root: Option<&Path>) -> Result<BTreeMap<String
             if ext != "yml" && ext != "yaml" {
                 continue;
             }
-            let text = fs::read_to_string(&path)
-                .with_context(|| format!("failed to read workflow file {}", path.display()))?;
-            let spec = load_workflow_from_str(&text, &path.display().to_string())?;
-            specs.insert(spec.name.clone(), spec);
+            // Per-file failures are logged and skipped. One malformed YAML
+            // shouldn't break discovery for the user's other workflows —
+            // previously the `?` here propagated upward and made every
+            // `prism workflow list` (and every chat startup that loads
+            // workflows) fail with the first parse error encountered.
+            let text = match fs::read_to_string(&path) {
+                Ok(t) => t,
+                Err(e) => {
+                    tracing::warn!(
+                        path = %path.display(),
+                        error = %e,
+                        "skipping workflow file: read failed"
+                    );
+                    continue;
+                }
+            };
+            match load_workflow_from_str(&text, &path.display().to_string()) {
+                Ok(spec) => {
+                    specs.insert(spec.name.clone(), spec);
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        path = %path.display(),
+                        error = %format!("{e:#}"),
+                        "skipping workflow file: parse failed"
+                    );
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

\`discover_workflows()\` in \`crates/workflows/src/lib.rs\` propagated per-file errors with \`?\`:

\`\`\`rust
let text = fs::read_to_string(&path).with_context(...)?;
let spec = load_workflow_from_str(&text, ...)?;
specs.insert(spec.name.clone(), spec);
\`\`\`

That meant **a single malformed YAML file in \`~/.prism/workflows/\` masked every healthy workflow behind it**. The user would run \`prism workflow list\`, see no workflows, get no feedback about why, and assume nothing was installed.

This also affected chat startup, which loads workflows during boot.

## Fix

Per-file failures are now logged at warn-level and skipped. Healthy workflows load normally. The user gets:

\`\`\`
WARN skipping workflow file: parse failed path=~/.prism/workflows/broken.yaml error=...
\`\`\`

if they want to grep for what's missing.

Both \`fs::read_to_string\` failures (permission errors, file disappeared between readdir and read) and \`load_workflow_from_str\` failures (bad YAML, schema mismatch) are handled — both were fatal-to-discovery before.

## Test plan

- [x] cargo check -p prism-workflows — clean
- [x] cargo clippy -p prism-workflows --all-targets -- -D warnings — clean
- [x] cargo test -p prism-workflows --lib — 23 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)