### PR TITLE
fix(mesh): drop unwrap() in federated query path — Bug #38

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -5878,8 +5878,15 @@ async fn handle_federated_query(
         Err(e) => println!("  error: {e}"),
     }
 
-    // Step 3: Query each peer
-    let peers = peer_list.unwrap();
+    // Step 3: Query each peer.
+    //
+    // The early-return on `peer_count == 0` above means peer_list must be
+    // Some(non-empty) here, but expressing that with `unwrap()` is brittle —
+    // a future refactor of the early-return path would crash production. Use
+    // the explicit form so a regression is at most an empty iteration.
+    let Some(peers) = peer_list else {
+        return Ok(());
+    };
     for peer in peers {
         let addr = peer["address"].as_str().unwrap_or("127.0.0.1");
         let port = peer["port"].as_u64().unwrap_or(7327);


### PR DESCRIPTION
## Summary

\`prism mesh query\` had a brittle pattern:

\`\`\`rust
let peer_list = resp[\"peers\"].as_array();
let peer_count = peer_list.map(|a| a.len()).unwrap_or(0);
if peer_count == 0 { return Ok(()); }
...
let peers = peer_list.unwrap();    // ← brittle
\`\`\`

The unwrap is safe today (the early-return guarantees \`Some(non-empty)\`), but a future refactor of the early-return path would turn this into a production panic. Replaced with:

\`\`\`rust
let Some(peers) = peer_list else { return Ok(()); };
\`\`\`

Now a regression is at most an empty iteration, not a crash.

Defensive cleanup, no behavior change in the happy path.

## Test plan

- [x] cargo check -p prism-cli — clean
- [x] cargo clippy -p prism-cli --all-targets -- -D warnings — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)