### PR TITLE
fix(security): credentials.json written 0600 not world-readable — Bug #39

### DIFF
--- a/crates/agent/src/protocol.rs
+++ b/crates/agent/src/protocol.rs
@@ -419,7 +419,28 @@ fn sync_sdk_credentials(creds: &StoredCredentials) {
             let _ = fs::create_dir_all(parent);
         }
         if let Ok(json) = serde_json::to_string_pretty(&sdk_creds) {
-            let _ = fs::write(sdk_path, json);
+            // 0600 on unix — file holds bearer + refresh tokens. Plain
+            // fs::write inherits the user's umask (typically 0644 = world-
+            // readable on most Linux distros), which would let any other
+            // local user read PRISM tokens.
+            #[cfg(unix)]
+            {
+                use std::io::Write;
+                use std::os::unix::fs::OpenOptionsExt;
+                if let Ok(mut file) = fs::OpenOptions::new()
+                    .write(true)
+                    .create(true)
+                    .truncate(true)
+                    .mode(0o600)
+                    .open(&sdk_path)
+                {
+                    let _ = file.write_all(json.as_bytes());
+                }
+            }
+            #[cfg(not(unix))]
+            {
+                let _ = fs::write(&sdk_path, json);
+            }
         }
     }
 }

--- a/crates/cli/src/forge_chat.rs
+++ b/crates/cli/src/forge_chat.rs
@@ -363,7 +363,29 @@ fn upsert_openai_compatible_credential(proxy_url: &str, access_token: &str) -> R
     });
 
     let text = serde_json::to_string_pretty(&entries).context("serialising credentials")?;
-    std::fs::write(&path, text).with_context(|| format!("writing {}", path.display()))?;
+    // 0600 on unix — file holds the user's MARC27 access_token (as
+    // openai_compatible api_key). Plain fs::write inherits the user's
+    // umask (typically 0644 = world-readable), which would let any
+    // other local user read PRISM tokens. Same fix as Bug #39 for
+    // `~/.prism/credentials.json` — we missed this sibling file path.
+    #[cfg(unix)]
+    {
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(&path)
+            .with_context(|| format!("writing {}", path.display()))?;
+        file.write_all(text.as_bytes())
+            .with_context(|| format!("writing {}", path.display()))?;
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::write(&path, text).with_context(|| format!("writing {}", path.display()))?;
+    }
     Ok(())
 }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1031,7 +1031,14 @@ async fn main() -> Result<()> {
             });
             paths.save_cli_state(&state)?;
 
-            // Sync credentials to ~/.prism/credentials.json for Python SDK
+            // Sync credentials to ~/.prism/credentials.json for Python SDK.
+            //
+            // The file holds an access_token + refresh_token, so it must be
+            // 0600. Plain `fs::write` would inherit the user's umask
+            // (typically 0644 = world-readable on most Linux distros),
+            // which would let any other local user read the tokens.
+            // cli_state.json (saved via PrismPaths::save_cli_state) already
+            // uses 0600 for the same reason; this path just got missed.
             if let Some(ref creds) = state.credentials {
                 let sdk_creds = serde_json::json!({
                     "access_token": creds.access_token,
@@ -1046,8 +1053,28 @@ async fn main() -> Result<()> {
                         .join(".prism")
                         .join("credentials.json");
                     if let Ok(json) = serde_json::to_string_pretty(&sdk_creds) {
-                        let _ = std::fs::create_dir_all(sdk_path.parent().unwrap());
-                        let _ = std::fs::write(&sdk_path, json);
+                        if let Some(parent) = sdk_path.parent() {
+                            let _ = std::fs::create_dir_all(parent);
+                        }
+                        // 0600 on unix; default ACLs on windows.
+                        #[cfg(unix)]
+                        {
+                            use std::io::Write;
+                            use std::os::unix::fs::OpenOptionsExt;
+                            if let Ok(mut file) = std::fs::OpenOptions::new()
+                                .write(true)
+                                .create(true)
+                                .truncate(true)
+                                .mode(0o600)
+                                .open(&sdk_path)
+                            {
+                                let _ = file.write_all(json.as_bytes());
+                            }
+                        }
+                        #[cfg(not(unix))]
+                        {
+                            let _ = std::fs::write(&sdk_path, json);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Two code paths wrote \`~/.prism/credentials.json\` (which contains the user's MARC27 \`access_token\` AND \`refresh_token\`) using plain \`std::fs::write\`. On Unix that inherits the user's umask, which is **0644 (world-readable)** on most Linux distros and macOS by default — meaning any other local user could \`cat ~/.prism/credentials.json\` and steal the tokens.

\`crates/runtime/src/lib.rs::PrismPaths::save_cli_state\` (the \`cli-state.json\` writer) already does this correctly with \`OpenOptions::new().mode(0o600)\` for the same reason. These two SDK-sync paths just got missed:

1. **\`crates/cli/src/main.rs\`** — \`prism login\` writes the file after successful device-flow or token login.
2. **\`crates/agent/src/protocol.rs::sync_sdk_credentials\`** — agent protocol writes the file when refreshing tokens server-side.

Both now use \`OpenOptions::new().write(true).create(true).truncate(true).mode(0o600).open(&sdk_path)\` on unix; default behavior is preserved on windows since NTFS ACLs work differently.

## Severity

**Medium**: local-only attack surface, but the file holds **refresh_token** (not just a short-lived bearer), so an attacker gets persistent access. Anyone running PRISM in:

- a shared dev environment,
- a container with multi-user setup, or
- a misconfigured CI runner with non-private \$HOME

…would have been exposed. Files written before this fix stay 0644 until rewritten — users may want to \`chmod 600 ~/.prism/credentials.json\` after merging.

## Test plan

- [x] cargo check -p prism-cli -p prism-agent — clean
- [x] cargo clippy -p prism-cli -p prism-agent --all-targets -- -D warnings — clean
- [ ] After merge: live verify with \`stat -f '%Lp' ~/.prism/credentials.json\` (expect 600)

🤖 Generated with [Claude Code](https://claude.com/claude-code)