### PR TITLE
fix(security): open_browser refuses non-http(s) URLs — Bug #42 (defense-in-depth)

### DIFF
--- a/crates/agent/src/protocol.rs
+++ b/crates/agent/src/protocol.rs
@@ -490,14 +490,23 @@ fn apply_account_env(creds: Option<&StoredCredentials>) {
 }
 
 fn open_browser(url: &str) -> Result<()> {
+    // Defense-in-depth: only http(s) URLs. See crates/cli/src/main.rs for
+    // the same restriction — protects against a compromised platform
+    // returning `--version`, `file:///`, or a `javascript:` payload that
+    // some browser opener would happily execute.
+    let trimmed = url.trim();
+    if !(trimmed.starts_with("http://") || trimmed.starts_with("https://")) {
+        return Err(anyhow::anyhow!("refusing to open non-http(s) URL: {url}"));
+    }
+
     let status = if cfg!(target_os = "macos") {
-        std::process::Command::new("open").arg(url).status()
+        std::process::Command::new("open").arg(trimmed).status()
     } else if cfg!(target_os = "windows") {
         std::process::Command::new("cmd")
-            .args(["/C", "start", "", url])
+            .args(["/C", "start", "", trimmed])
             .status()
     } else {
-        std::process::Command::new("xdg-open").arg(url).status()
+        std::process::Command::new("xdg-open").arg(trimmed).status()
     }
     .context("failed to spawn browser opener")?;
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -5699,14 +5699,27 @@ async fn refresh_access_token(
 // Old Ink/TypeScript TUI launcher removed — native Ratatui TUI is in crates/cli/src/tui/
 
 fn open_browser(url: &str) -> Result<()> {
+    // Defense-in-depth: only http(s) URLs.
+    //
+    // The two callers pass `verification_uri` from the OAuth device-flow
+    // response and `checkout_url` from the billing topup response. Both
+    // come from the MARC27 platform and should always be https. Validating
+    // here means a compromised or buggy platform can't slip in
+    // `--version`, `file:///etc/passwd`, or a `javascript:` payload that
+    // some browser opener would happily execute.
+    let trimmed = url.trim();
+    if !(trimmed.starts_with("http://") || trimmed.starts_with("https://")) {
+        bail!("refusing to open non-http(s) URL: {url}");
+    }
+
     let status = if cfg!(target_os = "macos") {
-        std::process::Command::new("open").arg(url).status()
+        std::process::Command::new("open").arg(trimmed).status()
     } else if cfg!(target_os = "windows") {
         std::process::Command::new("cmd")
-            .args(["/C", "start", "", url])
+            .args(["/C", "start", "", trimmed])
             .status()
     } else {
-        std::process::Command::new("xdg-open").arg(url).status()
+        std::process::Command::new("xdg-open").arg(trimmed).status()
     }
     .context("failed to spawn browser opener")?;
 


### PR DESCRIPTION
## Summary

\`open_browser()\` lives in two places and is called from three sites. All three URLs come from the MARC27 platform and *should* always be \`https://\`:

- \`cli/main.rs::Login\` — \`verification_uri\` from the device-flow response
- \`cli/main.rs::Billing\` — \`checkout_url\` from the billing topup response
- \`agent/protocol.rs\` — same verification_uri path, agent-mode

But \"should always\" isn't a guarantee. If the platform is compromised — or has a benign bug — and returns a URL like:

\`\`\`
--version                   # macOS \`open\` prints app version
file:///etc/passwd          # \`open\` opens the file in Finder
javascript:alert(1)         # some xdg-open handlers run JS
/Applications/Calc.app      # macOS \`open\` launches a local app
\`\`\`

…the prism CLI would obediently spawn it. None catastrophic on their own (no privilege escalation), but unexpected behavior triggered by a remote-controlled string is the kind of soft attack surface that compounds in real CVEs.

## Fix

Both \`open_browser()\` functions reject any URL that doesn't start with \`http://\` or \`https://\`. Trimmed first so leading whitespace doesn't sneak past.

\`\`\`rust
let trimmed = url.trim();
if !(trimmed.starts_with(\"http://\") || trimmed.starts_with(\"https://\")) {
    bail!(\"refusing to open non-http(s) URL: {url}\");
}
\`\`\`

## Severity

**Low** — soft attack surface, requires platform compromise to exploit. Fix is one-line per call site. Hardening, not panic.

## Test plan

- [x] cargo check -p prism-cli -p prism-agent — clean
- [x] cargo clippy -p prism-cli -p prism-agent --all-targets -- -D warnings — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)