### PR TITLE
fix(security): Cypher injection in mesh sync via dataset name — Bug #45 (HIGH)

### DIFF
--- a/crates/mesh/src/sync.rs
+++ b/crates/mesh/src/sync.rs
@@ -263,10 +263,33 @@ async fn sync_dataset_from_peer(
     dataset_name: &str,
     sync_config: &Option<SyncConfig>,
 ) -> Result<()> {
-    // Query the peer's graph for all entities in the dataset
+    // Reject malformed dataset names up front — defense-in-depth before
+    // we hand the value to a Cypher parameter binder that *should* be
+    // safe but isn't worth trusting blindly. Marketplace and platform
+    // dataset names are simple identifiers in practice; if a peer
+    // publishes something exotic, refuse to sync rather than send it
+    // through the query pipeline.
+    if !dataset_name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.'))
+        || dataset_name.is_empty()
+        || dataset_name.len() > 128
+    {
+        anyhow::bail!(
+            "refusing to sync dataset with invalid name (must be ASCII alphanumeric + _-., \
+             non-empty, ≤128 chars): {dataset_name:?}"
+        );
+    }
+
+    // Query the peer's graph for all entities in the dataset.
+    // Use a parameterized Cypher query — earlier code interpolated
+    // `dataset_name` straight into the query string, which let a
+    // malicious peer (or a peer with a buggy publish call) inject
+    // Cypher via the dataset name they publish. See Bug #45.
     let query_url = format!("{peer_url}/api/query");
     let body = serde_json::json!({
-        "query": format!("MATCH (n) WHERE n.dataset = '{dataset_name}' RETURN n LIMIT 1000"),
+        "query": "MATCH (n) WHERE n.dataset = $dataset RETURN n LIMIT 1000",
+        "params": { "dataset": dataset_name },
         "mode": "cypher",
     });
 
@@ -291,14 +314,21 @@ async fn sync_dataset_from_peer(
     // Write to local Neo4j if configured
     if let Some(cfg) = sync_config {
         let neo4j_url = format!("{}/db/neo4j/tx/commit", cfg.neo4j_url);
-        let results = data["results"].as_array().unwrap();
+        let Some(results) = data["results"].as_array() else {
+            return Ok(());
+        };
 
-        // Batch-create nodes from peer data using UNWIND
-        let cypher = format!(
-            "UNWIND $rows AS row \
-             MERGE (n:SyncedEntity {{name: row.name, source_dataset: '{dataset_name}'}}) \
-             SET n += row.properties"
-        );
+        // Batch-create nodes from peer data using UNWIND.
+        //
+        // Both `$rows` AND `$source` are passed as parameters — the
+        // earlier version interpolated `dataset_name` into the
+        // statement string, which would have let a malicious peer
+        // execute arbitrary Cypher against our LOCAL Neo4j (e.g. a
+        // dataset named `x' DETACH DELETE n RETURN '` would wipe the
+        // local graph). See Bug #45.
+        let cypher = "UNWIND $rows AS row \
+             MERGE (n:SyncedEntity {name: row.name, source_dataset: $source}) \
+             SET n += row.properties";
 
         let rows: Vec<serde_json::Value> = results
             .iter()
@@ -313,7 +343,7 @@ async fn sync_dataset_from_peer(
         let neo4j_body = serde_json::json!({
             "statements": [{
                 "statement": cypher,
-                "parameters": { "rows": rows },
+                "parameters": { "rows": rows, "source": dataset_name },
             }]
         });
 

--- a/crates/mesh/src/sync.rs
+++ b/crates/mesh/src/sync.rs
@@ -303,7 +303,30 @@ async fn sync_dataset_from_peer(
         );
     }
 
-    let data: serde_json::Value = resp.json().await?;
+    // Body size cap — a malicious or runaway peer could otherwise
+    // return gigabytes and OOM the local node. The peer query has
+    // a `LIMIT 1000` clause, so a well-behaved peer stays well under
+    // any reasonable cap. 32 MiB is far more headroom than the
+    // limit needs but stops the obvious DoS vector. See Bug #52.
+    const MAX_PEER_RESPONSE_BYTES: usize = 32 * 1024 * 1024;
+    if let Some(len) = resp.content_length()
+        && len as usize > MAX_PEER_RESPONSE_BYTES
+    {
+        anyhow::bail!(
+            "peer response too large ({} bytes; max {})",
+            len,
+            MAX_PEER_RESPONSE_BYTES
+        );
+    }
+    let body_bytes = resp.bytes().await?;
+    if body_bytes.len() > MAX_PEER_RESPONSE_BYTES {
+        anyhow::bail!(
+            "peer response too large ({} bytes; max {})",
+            body_bytes.len(),
+            MAX_PEER_RESPONSE_BYTES
+        );
+    }
+    let data: serde_json::Value = serde_json::from_slice(&body_bytes)?;
     let result_count = data["results"].as_array().map(|a| a.len()).unwrap_or(0);
 
     if result_count == 0 {


### PR DESCRIPTION
## Summary

\`crates/mesh/src/sync.rs::sync_dataset_from_peer()\` interpolated a peer-supplied \`dataset_name\` directly into Cypher query strings via \`format!()\`. The local-Neo4j write path is the dangerous one.

A malicious peer (or a peer with a buggy publish call) could publish a dataset with a name like:

\`\`\`
x' DETACH DELETE n RETURN '
\`\`\`

…and the syncing node would build this Cypher and execute it against the **local** graph database:

\`\`\`cypher
UNWIND \$rows AS row
MERGE (n:SyncedEntity {name: row.name, source_dataset:
                       'x' DETACH DELETE n RETURN ''})
SET n += row.properties
\`\`\`

Result: **remote-attacker-controlled, local data destruction**.

## Two fixes

### 1. Parameter binding on both queries

\`\$dataset\` (peer side) and \`\$source\` (local side) are now bound through the JSON parameters payload, never interpolated into the statement string.

\`\`\`rust
// peer query
let body = json!({
    \"query\": \"MATCH (n) WHERE n.dataset = \$dataset RETURN n LIMIT 1000\",
    \"params\": { \"dataset\": dataset_name },
    \"mode\": \"cypher\",
});

// local Neo4j write
let cypher = \"UNWIND \$rows AS row \\
    MERGE (n:SyncedEntity {name: row.name, source_dataset: \$source}) \\
    SET n += row.properties\";
let body = json!({
    \"statements\": [{
        \"statement\": cypher,
        \"parameters\": { \"rows\": rows, \"source\": dataset_name },
    }]
});
\`\`\`

### 2. Allowlist on \`dataset_name\` up front

ASCII alphanumeric + \`_\`, \`-\`, \`.\`, non-empty, ≤128 chars. Marketplace and platform dataset names are simple identifiers in practice; an exotic name from a peer is a red flag — refuse to sync rather than try to bind it.

Also tightened the \`results.as_array().unwrap()\` → \`let-else\` early return, same defensive cleanup as PR #71.

## Severity

**HIGH** — remote-attacker-controlled, results in local data destruction. Requires the local node to have an active subscription to a malicious peer (i.e. the user clicked \"subscribe\"), so it's not unauthenticated, but the trust model assumes peers can publish datasets without being able to nuke our local graph.

## Test plan

- [x] cargo check -p prism-mesh — clean
- [x] cargo clippy -p prism-mesh --all-targets -- -D warnings — clean
- [x] cargo test -p prism-mesh --lib — 80 passed
- [x] cargo fmt — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Dataset names are now validated to be 1-128 characters with alphanumeric characters, underscores, hyphens, and periods only.
  * Improved peer synchronization reliability and error handling.
  * Enhanced robustness of data processing operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Darth-Hidious/PRISM/pull/75)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->