### PR TITLE
fix(security): extend Cypher write-protection blocklist — Bug #47

### DIFF
--- a/crates/server/src/handlers/query.rs
+++ b/crates/server/src/handlers/query.rs
@@ -210,19 +210,36 @@ async fn handle_cypher_query(
         return Err(service_unavailable("Neo4j not configured."));
     };
 
-    // Basic safety: reject write operations in the query endpoint
+    // Substring-based write protection. Imperfect — the only correct
+    // long-term fix is connecting to Neo4j as a READ-ONLY role — but
+    // closes the obvious bypasses. See Bug #47.
+    //
+    // What's caught: any literal occurrence of DELETE / CREATE /
+    // MERGE / SET / REMOVE / DROP / LOAD / USE / CALL anywhere in
+    // the query, after uppercase. Some of these (LOAD, USE, CALL)
+    // weren't on the original blocklist, so a peer or user could
+    // exfiltrate via `LOAD CSV`, switch databases via `USE`, or
+    // run arbitrary procedures via `CALL apoc.*`. CALL is a hard
+    // deny because *any* APOC procedure could be a write.
+    //
+    // What's NOT caught: APOC string concatenation tricks like
+    // `CALL apoc.cypher.run('DEL' + 'ETE n')`. The outer CALL is
+    // already blocked, so the trick is moot today. If a future
+    // change wants to allow specific read-only procedures it
+    // must replace this whole block with a real allowlist.
     let upper = body.query.to_uppercase();
-    if upper.contains("DELETE")
-        || upper.contains("CREATE")
-        || upper.contains("MERGE")
-        || upper.contains("SET ")
-        || upper.contains("REMOVE ")
-        || upper.contains("DROP ")
-    {
+    const BLOCKED_KEYWORDS: &[&str] = &[
+        "DELETE", "CREATE", "MERGE", "SET ", "REMOVE ", "DROP ", "LOAD ", "USE ", "CALL ",
+    ];
+    if let Some(found) = BLOCKED_KEYWORDS.iter().find(|kw| upper.contains(*kw)) {
         return Err((
             StatusCode::FORBIDDEN,
             Json(ErrorResponse {
-                error: "Write operations not allowed via the query API.".into(),
+                error: format!(
+                    "Write/admin operations not allowed via the query API (matched: {}). \
+                     Use the dedicated ingest / admin endpoints instead.",
+                    found.trim()
+                ),
             }),
         ));
     }

--- a/crates/server/src/handlers/query.rs
+++ b/crates/server/src/handlers/query.rs
@@ -161,6 +161,28 @@ async fn handle_nl_query(
         "NL query translated"
     );
 
+    // Same write protection as direct cypher mode. The LLM can produce
+    // destructive Cypher accidentally (a user asking "delete my old
+    // experiments" politely), or via prompt injection (an entity name
+    // in the corpus reads `MATCH (n) DETACH DELETE n` and the LLM
+    // echoes it). Bug #48 — NL mode bypassed the cypher-mode blocklist.
+    //
+    // Reject with a clear message; the user can switch to a write-aware
+    // endpoint if they actually want destructive behavior.
+    if let Some(found) = detect_blocked_cypher_keyword(&translation.cypher) {
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse {
+                error: format!(
+                    "Generated Cypher contains a write/admin keyword ({}); the query API is \
+                     read-only. Generated: {}",
+                    found.trim(),
+                    translation.cypher
+                ),
+            }),
+        ));
+    }
+
     // Execute the generated Cypher
     let results = store
         .query_cypher(&translation.cypher, None)
@@ -210,28 +232,7 @@ async fn handle_cypher_query(
         return Err(service_unavailable("Neo4j not configured."));
     };
 
-    // Substring-based write protection. Imperfect — the only correct
-    // long-term fix is connecting to Neo4j as a READ-ONLY role — but
-    // closes the obvious bypasses. See Bug #47.
-    //
-    // What's caught: any literal occurrence of DELETE / CREATE /
-    // MERGE / SET / REMOVE / DROP / LOAD / USE / CALL anywhere in
-    // the query, after uppercase. Some of these (LOAD, USE, CALL)
-    // weren't on the original blocklist, so a peer or user could
-    // exfiltrate via `LOAD CSV`, switch databases via `USE`, or
-    // run arbitrary procedures via `CALL apoc.*`. CALL is a hard
-    // deny because *any* APOC procedure could be a write.
-    //
-    // What's NOT caught: APOC string concatenation tricks like
-    // `CALL apoc.cypher.run('DEL' + 'ETE n')`. The outer CALL is
-    // already blocked, so the trick is moot today. If a future
-    // change wants to allow specific read-only procedures it
-    // must replace this whole block with a real allowlist.
-    let upper = body.query.to_uppercase();
-    const BLOCKED_KEYWORDS: &[&str] = &[
-        "DELETE", "CREATE", "MERGE", "SET ", "REMOVE ", "DROP ", "LOAD ", "USE ", "CALL ",
-    ];
-    if let Some(found) = BLOCKED_KEYWORDS.iter().find(|kw| upper.contains(*kw)) {
+    if let Some(found) = detect_blocked_cypher_keyword(&body.query) {
         return Err((
             StatusCode::FORBIDDEN,
             Json(ErrorResponse {
@@ -472,6 +473,26 @@ fn service_unavailable(msg: &str) -> (StatusCode, Json<ErrorResponse>) {
         StatusCode::SERVICE_UNAVAILABLE,
         Json(ErrorResponse { error: msg.into() }),
     )
+}
+
+/// Substring-based write/admin keyword detection. Imperfect — the
+/// only correct long-term fix is connecting to Neo4j as a READ-ONLY
+/// role — but closes the obvious bypasses for both direct cypher
+/// queries and LLM-generated NL→cypher.
+///
+/// Returns the matched keyword (for the error message) when the
+/// query contains any forbidden verb. Tested via cypher-mode unit
+/// tests; reused by NL mode so the LLM can't accidentally — or via
+/// prompt injection — emit destructive Cypher and have it run.
+fn detect_blocked_cypher_keyword(query: &str) -> Option<&'static str> {
+    let upper = query.to_uppercase();
+    const BLOCKED_KEYWORDS: &[&str] = &[
+        "DELETE", "CREATE", "MERGE", "SET ", "REMOVE ", "DROP ", "LOAD ", "USE ", "CALL ",
+    ];
+    BLOCKED_KEYWORDS
+        .iter()
+        .find(|kw| upper.contains(*kw))
+        .copied()
 }
 
 fn internal_error(msg: &str) -> (StatusCode, Json<ErrorResponse>) {

--- a/crates/server/src/handlers/query.rs
+++ b/crates/server/src/handlers/query.rs
@@ -170,6 +170,21 @@ async fn handle_nl_query(
     // Reject with a clear message; the user can switch to a write-aware
     // endpoint if they actually want destructive behavior.
     if let Some(found) = detect_blocked_cypher_keyword(&translation.cypher) {
+        // Audit the LLM-generated denial — distinguishes prompt-injection
+        // attempts from genuine user write requests. See Bug #55.
+        state.audit_and_broadcast(&prism_core::audit::AuditEntry {
+            id: 0,
+            timestamp: chrono::Utc::now(),
+            user_id: user_id.to_string(),
+            action: prism_core::audit::AuditAction::DataQuery,
+            target: "nl".into(),
+            detail: Some(format!(
+                "LLM emitted blocked keyword: {} (cypher={})",
+                found.trim(),
+                translation.cypher
+            )),
+            outcome: prism_core::audit::AuditOutcome::Denied,
+        });
         return Err((
             StatusCode::FORBIDDEN,
             Json(ErrorResponse {
@@ -233,6 +248,19 @@ async fn handle_cypher_query(
     };
 
     if let Some(found) = detect_blocked_cypher_keyword(&body.query) {
+        // Audit the denial — failed/blocked operations are at least as
+        // important to log as successes for security review. Without
+        // this, admins reviewing the audit log can't see attack
+        // attempts. See Bug #55.
+        state.audit_and_broadcast(&prism_core::audit::AuditEntry {
+            id: 0,
+            timestamp: chrono::Utc::now(),
+            user_id: user_id.to_string(),
+            action: prism_core::audit::AuditAction::DataQuery,
+            target: "cypher".into(),
+            detail: Some(format!("blocked keyword: {}", found.trim())),
+            outcome: prism_core::audit::AuditOutcome::Denied,
+        });
         return Err((
             StatusCode::FORBIDDEN,
             Json(ErrorResponse {
@@ -250,6 +278,19 @@ async fn handle_cypher_query(
 
     let results = store.query_cypher(&body.query, None).await.map_err(|e| {
         tracing::error!(error = %e, "Cypher query failed");
+        // Failed query — log as Failure for the audit trail. Surface to
+        // admins reviewing security: a Cypher syntax error from a real
+        // user is benign noise, but the same error from a probe trying
+        // to fingerprint the schema is signal.
+        state.audit_and_broadcast(&prism_core::audit::AuditEntry {
+            id: 0,
+            timestamp: chrono::Utc::now(),
+            user_id: user_id.to_string(),
+            action: prism_core::audit::AuditAction::DataQuery,
+            target: "cypher".into(),
+            detail: Some(format!("execution error: {e}")),
+            outcome: prism_core::audit::AuditOutcome::Failure,
+        });
         internal_error("Cypher execution failed.")
     })?;
 


### PR DESCRIPTION
## Summary

\`/api/query\` cypher-mode write protection blocked DELETE/CREATE/MERGE/SET/REMOVE/DROP via substring match. **Three write/admin verbs were missing**:

- **LOAD** — \`LOAD CSV FROM 'file:///etc/passwd' AS line MATCH (n) ...\` reads server-side files into the query result; effective data exfiltration even without writes.
- **USE** — \`USE system MATCH (u) RETURN u\` switches to the system database, exposing user/role metadata that the read-protection was meant to gate.
- **CALL** — APOC procedures can do anything (writes, exports, shell-out via \`apoc.systemdb\`, key extraction). Blocking the literal \`CALL \` keyword denies the entire category, which is the right default. A future allowlist can re-enable specific read-only procedures.

## What's still imperfect

The substring-blocklist pattern is **fundamentally fragile**. APOC string-concat tricks like \`CALL apoc.cypher.run('DEL' + 'ETE n')\` would slip past — but \`CALL\` is now blocked outright, so the trick is moot today. The function comment now spells out that the correct long-term fix is connecting to Neo4j as a READ-ONLY role; this PR is interim hardening.

## Test plan

- [x] cargo check -p prism-server — clean
- [x] cargo clippy -p prism-server --all-targets -- -D warnings — clean
- [x] cargo test -p prism-server --lib — 8 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)