### PR TITLE
fix(rbac): don't silently restore NodeAdmin if admin downgraded user — Bug #49

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -5109,11 +5109,22 @@ async fn create_dashboard_session(
         anyhow::anyhow!("Stored credentials are missing user_id. Run `prism login` again.")
     })?;
 
-    // The local CLI is the node operator on this machine, so it should be able
-    // to manage its own dashboard routes without a separate bootstrap dance.
+    // The local CLI is the node operator on this machine, so the FIRST
+    // user to run it gets bootstrapped as NodeAdmin to manage their
+    // own dashboard routes without a separate bootstrap dance.
+    //
+    // **Only assign if no role already exists** — see Bug #49. The
+    // earlier code unconditionally `assign_role(NodeAdmin)`, which
+    // uses `INSERT ... ON CONFLICT DO UPDATE`, so any explicit
+    // downgrade by an admin (e.g. someone running an admin tool to
+    // demote user-X to Viewer) would be silently undone the next
+    // time user-X ran any CLI command that called this function.
+    // That defeats the RBAC model on shared machines.
     let rbac_db_path = paths.state_dir.join("rbac.db");
     let rbac_engine = prism_core::rbac::RbacEngine::new(&rbac_db_path)?;
-    rbac_engine.assign_role(user_id, prism_core::rbac::LocalRole::NodeAdmin)?;
+    if rbac_engine.get_role(user_id)?.is_none() {
+        rbac_engine.assign_role(user_id, prism_core::rbac::LocalRole::NodeAdmin)?;
+    }
 
     create_dashboard_session_for_user(dashboard_url, user_id, creds.display_name.as_deref()).await
 }


### PR DESCRIPTION
## Summary

\`create_dashboard_session\` ran on every CLI call that needs a local session token (\`prism federation query\`, \`prism mesh query\`, \`/info\` when offline, etc.). It unconditionally called:

\`\`\`rust
rbac_engine.assign_role(user_id, NodeAdmin)?;
\`\`\`

And \`RbacEngine::assign_role\` uses \`INSERT ... ON CONFLICT(user_id) DO UPDATE SET role = excluded.role\` — it always overwrites.

So any explicit downgrade an admin made (e.g. demoting \`user-X\` from \`NodeAdmin\` → \`Viewer\` via an admin tool) was **silently undone** the next time \`user-X\` ran any CLI command that hit this path. The RBAC model couldn't actually enforce restrictions on a user with CLI access — they'd auto-promote back to admin.

## Fix

Only auto-assign \`NodeAdmin\` when the user has no role yet:

\`\`\`rust
if rbac_engine.get_role(user_id)?.is_none() {
    rbac_engine.assign_role(user_id, NodeAdmin)?;
}
\`\`\`

Bootstrap-on-first-launch keeps working (the original design intent: \"local CLI = node admin\" for single-user laptops). Explicit downgrades now stick.

## Severity

**Medium**. Single-user laptop deployments are unaffected. Shared deployments with policy-set roles were having their RBAC model silently invalidated.

## Test plan

- [x] cargo check -p prism-cli — clean
- [x] cargo clippy -p prism-cli --all-targets -- -D warnings — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)