### PR TITLE
fix(mesh): cap Announce field sizes + peer list to prevent DoS — Bug #57

### DIFF
--- a/crates/mesh/src/sync.rs
+++ b/crates/mesh/src/sync.rs
@@ -56,6 +56,29 @@ pub async fn run_sync_handler(
                 if node_id == our_node_id {
                     continue; // ignore our own announcements
                 }
+                // Reject obviously-abusive announces. Without these caps a
+                // peer with Kafka access could announce themselves with
+                // a 1 MB name (or N fake node_ids) and grow the in-memory
+                // peers list until OOM. See Bug #57.
+                const MAX_NAME_LEN: usize = 256;
+                const MAX_ADDRESS_LEN: usize = 256;
+                const MAX_CAPABILITIES: usize = 64;
+                const MAX_CAPABILITY_LEN: usize = 256;
+                const MAX_PEERS: usize = 10_000;
+                if name.len() > MAX_NAME_LEN
+                    || address.len() > MAX_ADDRESS_LEN
+                    || capabilities.len() > MAX_CAPABILITIES
+                    || capabilities.iter().any(|c| c.len() > MAX_CAPABILITY_LEN)
+                {
+                    warn!(
+                        %node_id,
+                        name_len = name.len(),
+                        address_len = address.len(),
+                        cap_count = capabilities.len(),
+                        "rejecting Announce: field length exceeds caps"
+                    );
+                    continue;
+                }
                 info!(node = %name, id = %node_id, "peer announced");
                 let peer = PeerNode {
                     node_id,
@@ -66,7 +89,21 @@ pub async fn run_sync_handler(
                     capabilities,
                 };
                 let mut list = peers.write().unwrap_or_else(|e| e.into_inner());
-                if !list.iter().any(|p| p.node_id == node_id) {
+                if list.iter().any(|p| p.node_id == node_id) {
+                    // Already known — refresh `last_seen`. Without this an
+                    // honest peer that drops Kafka briefly and rejoins
+                    // would have stale `last_seen` until the next
+                    // announce, while we'd miss the update.
+                    if let Some(existing) = list.iter_mut().find(|p| p.node_id == node_id) {
+                        existing.last_seen = peer.last_seen;
+                    }
+                } else if list.len() >= MAX_PEERS {
+                    warn!(
+                        peer_count = list.len(),
+                        max = MAX_PEERS,
+                        "rejecting Announce: peer list at capacity (Bug #57 DoS guard)"
+                    );
+                } else {
                     list.push(peer);
                 }
             }

--- a/crates/mesh/src/sync.rs
+++ b/crates/mesh/src/sync.rs
@@ -191,11 +191,25 @@ pub async fn run_sync_handler(
                     dataset = %dataset_name,
                     "remote node subscribed to our dataset"
                 );
-                // Track the subscriber in our published datasets
+                // Track the subscriber in our published datasets — but cap
+                // the list. Without this a peer could fan in N fake
+                // subscriber_ids per dataset and grow the per-publication
+                // Vec<Uuid> indefinitely. Same DoS class as Bug #57 — the
+                // peer-list cap protects the receiving side, this protects
+                // the publisher side.
+                const MAX_SUBSCRIBERS_PER_DATASET: usize = 10_000;
                 let mut subs = subscriptions.write().unwrap_or_else(|e| e.into_inner());
                 for d in subs.published_mut() {
                     if d.name == dataset_name && !d.subscribers.contains(&subscriber_id) {
-                        d.subscribers.push(subscriber_id);
+                        if d.subscribers.len() >= MAX_SUBSCRIBERS_PER_DATASET {
+                            warn!(
+                                dataset = %dataset_name,
+                                count = d.subscribers.len(),
+                                "rejecting DataSubscribe: subscriber list at cap"
+                            );
+                        } else {
+                            d.subscribers.push(subscriber_id);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

\`mesh::sync::run_sync_handler\` accepted \`MeshMessage::Announce\` from Kafka with **no validation of field sizes** and **no upper bound on the in-memory peers list**.

A peer with Kafka access could:

- Announce themselves with a 1 MB \`name\` field — Kafka caps each message but lets you flood many.
- Announce N unique fake node_ids in a loop — local peers list grows unbounded.
- Pack 100k entries into \`capabilities\` — same memory pressure.

End state: OOM-kill of the local node.

## Caps added

| Field | Cap |
|---|---|
| \`name\` | 256 chars |
| \`address\` | 256 chars |
| \`capabilities\` (count) | 64 entries |
| \`capabilities\` (each entry) | 256 chars |
| **peers list** | **10,000** |

Anything beyond the per-field caps is dropped with a warn-level log so admins can spot a misbehaving peer. Anything beyond the peer-list cap is dropped with a warn pointing at this bug.

## Bonus fix

Also refresh \`last_seen\` when a known peer re-announces. The old code skipped re-announces entirely, leaving stale timestamps after a Kafka reconnect.

## Severity

**Medium** — requires Kafka mesh access (the ACL boundary), which is the same trust level as Bug #46 (Kafka QueryForward RCE). Inside that boundary every peer could OOM every other peer's node.

## Test plan

- [x] cargo check -p prism-mesh — clean
- [x] cargo clippy -p prism-mesh --all-targets -- -D warnings — clean
- [x] cargo test -p prism-mesh --lib — 80 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)