### PR TITLE
fix(privacy): scope WebSocket audit broadcasts by user — Bug #58

### DIFF
--- a/crates/server/src/ws.rs
+++ b/crates/server/src/ws.rs
@@ -92,19 +92,33 @@ pub async fn ws_upgrade(
         .ws_connections
         .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
+    // Look up the connected user's role to scope audit-event broadcasts.
+    // Without this, every WS client (Engineer, Analyst, Viewer) saw every
+    // OTHER user's AuditEntry events — leaking who ran what query, when.
+    // See Bug #58. Default to non-admin if RBAC isn't configured or the
+    // user has no role yet.
+    let is_admin = state
+        .rbac_db_path
+        .as_ref()
+        .and_then(|p| prism_core::rbac::RbacEngine::new(p).ok())
+        .and_then(|e| e.get_role(&user_id).ok().flatten())
+        .map(|role| role == prism_core::rbac::LocalRole::NodeAdmin)
+        .unwrap_or(false);
+
     let rx = state.ws_broadcast.subscribe();
     let ws_state = state.clone();
     ws.max_message_size(MAX_MESSAGE_SIZE)
-        .on_upgrade(move |socket| handle_socket(socket, user_id, rx, ws_state))
+        .on_upgrade(move |socket| handle_socket(socket, user_id, is_admin, rx, ws_state))
 }
 
 async fn handle_socket(
     mut socket: WebSocket,
     user_id: String,
+    is_admin: bool,
     mut rx: broadcast::Receiver<String>,
     state: Arc<NodeState>,
 ) {
-    debug!(user_id = %user_id, "WebSocket connection established");
+    debug!(user_id = %user_id, is_admin, "WebSocket connection established");
 
     loop {
         tokio::select! {
@@ -112,6 +126,15 @@ async fn handle_socket(
             result = rx.recv() => {
                 match result {
                     Ok(json) => {
+                        // Filter audit events by user — every non-admin
+                        // WS client used to see every other user's
+                        // AuditEntry events (Bug #58). Now: NodeAdmin
+                        // sees all; non-admins see only their own.
+                        // Other event types (NodeStatusUpdate,
+                        // MeshPeerChange) are unfiltered — public.
+                        if !is_admin && audit_event_for_other_user(&json, &user_id) {
+                            continue;
+                        }
                         if socket.send(Message::Text(json.into())).await.is_err() {
                             break;
                         }
@@ -148,4 +171,60 @@ async fn handle_socket(
         .ws_connections
         .fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
     debug!(user_id = %user_id, "WebSocket connection closed");
+}
+
+/// Returns true when the JSON event is an `AuditEntry` whose `user`
+/// field is set to someone other than `connected_user`. Used to
+/// scope audit broadcasts to non-admin clients.
+///
+/// Non-AuditEntry events (NodeStatusUpdate, MeshPeerChange) always
+/// return false — they're public. Malformed JSON also returns false
+/// (drop nothing extra).
+fn audit_event_for_other_user(json: &str, connected_user: &str) -> bool {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(json) else {
+        return false;
+    };
+    if value.get("type").and_then(|v| v.as_str()) != Some("AuditEntry") {
+        return false;
+    }
+    match value.get("user").and_then(|v| v.as_str()) {
+        Some(u) => u != connected_user,
+        None => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn passes_non_audit_events() {
+        let event = r#"{"type":"NodeStatusUpdate","uptime_secs":42,"services":[]}"#;
+        assert!(!audit_event_for_other_user(event, "alice"));
+    }
+
+    #[test]
+    fn passes_audit_event_for_self() {
+        let event = r#"{"type":"AuditEntry","timestamp":"2026-05-09T00:00:00Z","user":"alice","action":"DataQuery"}"#;
+        assert!(!audit_event_for_other_user(event, "alice"));
+    }
+
+    #[test]
+    fn drops_audit_event_for_other_user() {
+        let event = r#"{"type":"AuditEntry","timestamp":"2026-05-09T00:00:00Z","user":"bob","action":"DataQuery"}"#;
+        assert!(audit_event_for_other_user(event, "alice"));
+    }
+
+    #[test]
+    fn passes_malformed_json() {
+        // Better to forward than to silently drop — malformed events
+        // are a separate bug.
+        assert!(!audit_event_for_other_user("not json", "alice"));
+    }
+
+    #[test]
+    fn passes_audit_event_with_no_user() {
+        let event = r#"{"type":"AuditEntry","timestamp":"2026-05-09T00:00:00Z","action":"DataQuery"}"#;
+        assert!(!audit_event_for_other_user(event, "alice"));
+    }
 }


### PR DESCRIPTION
## Summary

\`audit_and_broadcast\` sent every audit entry to every connected WebSocket client. The event payload includes the audit entry's \`user\` field, so on a multi-user node:

- Bob (Engineer role) connects to \`/ws\`
- Alice (NodeAdmin) runs a Cypher query  
- Bob's WS receives \`{\"type\":\"AuditEntry\",\"user\":\"alice\",\"action\":\"DataQuery\"}\`

Bob can build a who-did-what timeline of every other user on the node — privacy leak that breaks the role model.

The \`/api/audit\` endpoint correctly gates this with \`ViewAudit\` permission. The WS path didn't.

## Fix

At connect time, look up the WS user's role from RBAC. If \`NodeAdmin\`, see all events (matches \`/api/audit\` role gate). If not, see only audit entries for their own user_id; entries for other users are dropped at \`handle_socket\`.

Non-audit events (\`NodeStatusUpdate\`, \`MeshPeerChange\`) are unfiltered — those aren't user-scoped.

\`audit_event_for_other_user(json, connected_user)\` does the parse + compare cheaply on receive. Malformed JSON or missing \`user\` field defaults to \"forward\" (don't silently drop benign events on parse error).

## Tests

5 new tests cover:
- non-audit events pass through
- audit-for-self passes through
- audit-for-other dropped
- malformed JSON passes through (separate bug if any)
- missing-user field passes through

## Severity

**Medium privacy** — local-only attack surface (server is 127.0.0.1), but multi-user PRISM nodes do exist. Exposes who-did-what to non-admin users with WS access.

## Test plan

- [x] cargo check -p prism-server — clean
- [x] cargo clippy -p prism-server --all-targets -- -D warnings — clean
- [x] cargo test -p prism-server --lib — 13 passed (5 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Audit event visibility is now role-based: non-admin users only see events from their own actions, while administrators see all audit events across the system.
  * Enhanced security and privacy through improved audit log filtering.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Darth-Hidious/PRISM/pull/83)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->