### PR TITLE
fix(install): allowlist binary names from release archive — Bug #59

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -62,13 +62,45 @@ if ! curl -fSL "$URL" -o "${TMPDIR}/${ARCHIVE}"; then
 fi
 
 # --- Extract ---
+#
+# Extract to a staging dir inside TMPDIR first, then move ONLY the
+# expected binary names to INSTALL_DIR. This stops a malicious or
+# malformed archive from:
+#   1. Writing outside INSTALL_DIR via `../` paths or absolute paths
+#      (BSD tar on older macOS doesn't reject these by default).
+#   2. Dropping arbitrary files into INSTALL_DIR alongside the
+#      expected binaries (e.g. an extra .sh that gets sourced by
+#      a careless user later).
 echo "Extracting to ${INSTALL_DIR}..."
 mkdir -p "$INSTALL_DIR"
+STAGE="${TMPDIR}/stage"
+mkdir -p "$STAGE"
 
 if [ "$PLATFORM" = "windows" ]; then
-    unzip -o "${TMPDIR}/${ARCHIVE}" -d "$INSTALL_DIR"
+    unzip -o "${TMPDIR}/${ARCHIVE}" -d "$STAGE"
 else
-    tar -xzf "${TMPDIR}/${ARCHIVE}" -C "$INSTALL_DIR"
+    tar -xzf "${TMPDIR}/${ARCHIVE}" -C "$STAGE"
+fi
+
+# Move ONLY the expected binaries — anything else in the archive is
+# silently dropped. Add to this list if a future release legitimately
+# ships more files.
+EXTRACTED_ANY=0
+for bin in prism prism-node; do
+    if [ -f "${STAGE}/${bin}" ]; then
+        mv "${STAGE}/${bin}" "${INSTALL_DIR}/${bin}"
+        EXTRACTED_ANY=1
+    elif [ "$PLATFORM" = "windows" ] && [ -f "${STAGE}/${bin}.exe" ]; then
+        mv "${STAGE}/${bin}.exe" "${INSTALL_DIR}/${bin}.exe"
+        EXTRACTED_ANY=1
+    fi
+done
+
+if [ $EXTRACTED_ANY -eq 0 ]; then
+    echo "Error: archive did not contain expected binary (prism)." >&2
+    echo "Listing what we got:" >&2
+    ls -la "$STAGE" >&2 || true
+    exit 1
 fi
 
 chmod +x "${INSTALL_DIR}/prism" 2>/dev/null || true


### PR DESCRIPTION
## Summary

\`install.sh\` extracted the GitHub-release tarball directly into \`\$INSTALL_DIR\` with a single \`tar -xzf\` (or \`unzip -o\`).

Two problems:

### 1. Path traversal via tar

BSD tar on older macOS does not reject entries with \`../\` paths by default. A malicious or malformed archive could write outside \`\$INSTALL_DIR\` (the installer runs in the user's shell, so it inherits write permission to anywhere reachable by their UID).

### 2. Unrestricted file drop

The installer accepted **any** file in the archive — extra \`.sh\` scripts, a \`~/.zshrc\` patch, a stray \`.cargo/config.toml\`, anything. PRISM releases only ship \`prism\` (and \`prism-node\`); extra files are at best garbage and at worst attacker-supplied surprises.

## Fix

Extract to a staging dir inside \`\$TMPDIR\`, then \`mv\` ONLY the expected binary names (\`prism\`, \`prism-node\`, plus \`.exe\` on Windows) into \`\$INSTALL_DIR\`. Anything else is silently dropped when the staging dir gets cleaned up by the EXIT trap. Bail with a clear error if the expected binary is missing entirely.

\`\`\`bash
STAGE=\"\${TMPDIR}/stage\"
mkdir -p \"\$STAGE\"
tar -xzf \"\${TMPDIR}/\${ARCHIVE}\" -C \"\$STAGE\"

for bin in prism prism-node; do
    if [ -f \"\${STAGE}/\${bin}\" ]; then
        mv \"\${STAGE}/\${bin}\" \"\${INSTALL_DIR}/\${bin}\"
        EXTRACTED_ANY=1
    fi
done
\`\`\`

## What this doesn't do

- **Archive integrity verification.** Real fix is publishing a checksums file alongside the release and verifying here. Tracked separately as a release-pipeline change. This PR closes the in-installer attack surface; checksum verification needs the release pipeline first.

## Severity

**Medium** — the curl-pipe-bash install pattern is already a trust assumption that GitHub releases are honest. Once you accept that, in-installer hardening still matters because mirrors/proxies between user and GitHub aren't all trustworthy, and defense in depth here is cheap.

## Test plan

- [x] \`bash -n install.sh\` — syntax OK
- [ ] Live install once a release exists with the new layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)