### PR TITLE
fix(picker): salvage malformed titles at display time — Bug #60 follow-up

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2572,7 +2572,8 @@ async fn main() -> Result<()> {
                     }
                 }
             }
-            let mut boot_checks = boot_checks::run_boot_checks(state.credentials.as_ref(), &endpoints).await;
+            let mut boot_checks =
+                boot_checks::run_boot_checks(state.credentials.as_ref(), &endpoints).await;
             let auth_rejected = boot_checks
                 .iter()
                 .any(|c| c.name == "Auth" && c.result.starts_with("token rejected"));
@@ -2584,7 +2585,8 @@ async fn main() -> Result<()> {
                 tracing::info!("access token refreshed after server-side rejection");
                 state.credentials = Some(new_creds);
                 let _ = paths.save_cli_state(&state);
-                boot_checks = boot_checks::run_boot_checks(state.credentials.as_ref(), &endpoints).await;
+                boot_checks =
+                    boot_checks::run_boot_checks(state.credentials.as_ref(), &endpoints).await;
             }
             boot::boot_sequence(&boot_checks);
             let _ = &python;

--- a/crates/forge_app/src/lib.rs
+++ b/crates/forge_app/src/lib.rs
@@ -27,7 +27,7 @@ mod set_conversation_id;
 pub mod system_prompt;
 mod template_engine;
 mod terminal_context;
-mod title_generator;
+pub mod title_generator;
 mod tool_executor;
 mod tool_registry;
 mod tool_resolver;

--- a/crates/forge_app/src/title_generator.rs
+++ b/crates/forge_app/src/title_generator.rs
@@ -109,7 +109,12 @@ impl<S: AS> TitleGenerator<S> {
 /// `{"title<value>"}` (no `:` separator, value not quoted). Strips the
 /// JSON-object braces, the `"title"` key, residual quotes, and
 /// surrounding whitespace.
-fn salvage_title_from_malformed(content: &str) -> String {
+///
+/// Idempotent — already-clean titles pass through unchanged. Made
+/// pub so the conversation picker can apply the same salvage at
+/// render time, since titles persisted before this fix landed are
+/// still in users' SQLite stores.
+pub fn salvage_title_from_malformed(content: &str) -> String {
     let s = content.trim();
     // 1. Drop leading "{ and trailing }" if present.
     let s = s.trim_start_matches('{').trim_end_matches('}').trim();

--- a/crates/forge_main/src/conversation_selector.rs
+++ b/crates/forge_main/src/conversation_selector.rs
@@ -44,10 +44,17 @@ impl ConversationSelector {
         let mut info = Info::new();
 
         for conv in &valid_conversations {
+            // Apply title salvage at display time. Pre-PR #60 conversations
+            // have raw `{"title":"..."}` JSON sitting in their `title`
+            // column; the salvager now runs on every render so historical
+            // bad data shows clean text without a DB migration. New
+            // conversations already get salvaged at write time, so applying
+            // here is idempotent. See Bug #60 follow-up.
             let title = conv
                 .title
                 .as_deref()
-                .map(|t| t.to_string())
+                .map(forge_app::title_generator::salvage_title_from_malformed)
+                .filter(|s| !s.is_empty())
                 .unwrap_or_else(|| markers::EMPTY.to_string());
 
             let duration = now.signed_duration_since(

--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -2006,10 +2006,14 @@ impl<A: API + ConsoleWriter + 'static, F: Fn(ForgeConfig) -> A + Send + Sync> UI
                 continue;
             }
 
+            // Salvage historical malformed titles at render time (Bug #60
+            // follow-up). New conversations are already clean; applying
+            // here is idempotent for them.
             let title = conv
                 .title
                 .as_deref()
-                .map(|t| t.to_string())
+                .map(forge_app::title_generator::salvage_title_from_malformed)
+                .filter(|s| !s.is_empty())
                 .unwrap_or_else(|| markers::EMPTY.to_string());
 
             // Format time using humantime library (same as conversation_selector.rs)

--- a/crates/server/src/ws.rs
+++ b/crates/server/src/ws.rs
@@ -224,7 +224,8 @@ mod tests {
 
     #[test]
     fn passes_audit_event_with_no_user() {
-        let event = r#"{"type":"AuditEntry","timestamp":"2026-05-09T00:00:00Z","action":"DataQuery"}"#;
+        let event =
+            r#"{"type":"AuditEntry","timestamp":"2026-05-09T00:00:00Z","action":"DataQuery"}"#;
         assert!(!audit_event_for_other_user(event, "alice"));
     }
 }


### PR DESCRIPTION
## Found by end-to-end TUI driving (not unit tests)

PR #60 fixed `salvage_title_from_malformed` so NEW conversations get clean titles when the LLM emits broken JSON. But the picker reads `conv.title` raw from the SQLite store. Conversations created **before** PR #60 landed still have broken titles in their `title` column, and they showed up literally in `prism resume`:

\`\`\`
{\"title\":\"Hello World Program                              23h ago
{\"titleInel 718 Overview\"}                                 1day ago
titleInconel718 Overview\"}                                  1day ago
\`\`\`

`cargo test` said everything was fine. The real TUI said otherwise. Found by driving the picker live via `iterm-tmux` MCP (since `pty-debug` and `terminalcp` can't drive reedline through CPR — Bug #22 fail-fast fires correctly there, which is itself a verification win).

## Fix

- Made `salvage_title_from_malformed` pub in `forge_app::title_generator`.
- Applied at both display sites:
  - `conversation_selector.rs` (the `prism resume` picker)
  - `ui.rs::on_show_conversations` (the `/conversation` listing)
- Idempotent — clean titles pass through unchanged. Empty post-salvage falls back to `markers::EMPTY` like before.

No DB migration needed; salvage runs every render.

## Live verification (same DB, before vs after)

| Before | After |
|---|---|
| `{\"title\":\"Hello World Program` | `Hello World Program` |
| `{\"titleInel 718 Overview\"}` | `Inel 718 Overview` |
| `titleInconel718 Overview\"}` | `Inconel718 Overview` |

## Test plan

- [x] cargo check -p forge_app -p forge_main — clean
- [x] cargo clippy -p forge_app -p forge_main --all-targets -- -D warnings — clean
- [x] cargo test -p forge_main --lib — 329 passed
- [x] cargo test -p forge_app --lib — 700 passed
- [x] Live verified via iterm-tmux: 4 historical malformed titles now render clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Improved display of conversation titles that were corrupted or damaged. Historical conversations now show properly restored titles in the conversation selector and history views.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Darth-Hidious/PRISM/pull/85)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->