### PR TITLE
fix(search_engine): run sync OptimadeClient in thread pool — 100s → ≤15s

### DIFF
--- a/app/tools/search_engine/providers/optimade.py
+++ b/app/tools/search_engine/providers/optimade.py
@@ -29,7 +29,23 @@ class OptimadeProvider(Provider):
         )
 
     async def search(self, query: MaterialSearchQuery) -> list[Material]:
-        """Query this OPTIMADE endpoint and return normalized materials."""
+        """Query this OPTIMADE endpoint and return normalized materials.
+
+        Uses ``asyncio.to_thread`` to run the synchronous OptimadeClient
+        in a thread-pool worker. Without this, ``use_async=False`` on
+        OptimadeClient blocks the event loop for the duration of every
+        HTTP roundtrip — so a fan-out across 17 providers via
+        ``asyncio.gather`` ends up effectively sequential and
+        ``asyncio.wait_for`` timeouts in the engine never fire (timeouts
+        only trigger at ``await`` points, of which there are none inside
+        the sync C library underneath OptimadeClient).
+
+        Net effect of the previous code on a single
+        ``materials_search(elements=['Ni','Cr','Al'], limit=3)``:
+        103 seconds wall-clock for 3 results. After this fix: bounded by
+        the per-provider timeout (15 s default).
+        """
+        import asyncio
         import contextlib
         import io
         from optimade.client import OptimadeClient
@@ -39,27 +55,37 @@ class OptimadeProvider(Provider):
         if not base_url:
             return []
 
-        try:
+        max_results = min(query.limit, self._endpoint.behavior.max_results)
+
+        def _run_sync_search() -> dict:
             client = OptimadeClient(
                 base_urls=[base_url],
-                max_results_per_provider=min(query.limit, self._endpoint.behavior.max_results),
+                max_results_per_provider=max_results,
                 use_async=False,
                 silent=True,
             )
-            # Suppress optimade-python's own console output (error messages,
-            # progress boxes) so it doesn't leak into the Ink TUI or corrupt
-            # the JSON-RPC stdio stream.
-            with contextlib.redirect_stdout(io.StringIO()), \
-                 contextlib.redirect_stderr(io.StringIO()):
-                results = client.structures.get(filter=filter_string) if filter_string else client.structures.get()
+            # Suppress optimade-python's own console output (error
+            # messages, progress boxes) so it doesn't leak into the
+            # Ink TUI or corrupt the JSON-RPC stdio stream.
+            with (
+                contextlib.redirect_stdout(io.StringIO()),
+                contextlib.redirect_stderr(io.StringIO()),
+            ):
+                return (
+                    client.structures.get(filter=filter_string)
+                    if filter_string
+                    else client.structures.get()
+                )
+
+        try:
+            results = await asyncio.to_thread(_run_sync_search)
         except Exception as e:
             logger.warning("OPTIMADE query failed for %s: %s", self.id, e)
             raise
 
         materials = self._parse_response(results, filter_string)
         # Hard cap to requested limit (OptimadeClient may over-fetch)
-        limit = min(query.limit, self._endpoint.behavior.max_results)
-        return materials[:limit]
+        return materials[:max_results]
 
     def _parse_response(self, results: dict, filter_string: str) -> list[Material]:
         """Parse the nested OptimadeClient response into Material objects.

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2572,7 +2572,8 @@ async fn main() -> Result<()> {
                     }
                 }
             }
-            let mut boot_checks = boot_checks::run_boot_checks(state.credentials.as_ref(), &endpoints).await;
+            let mut boot_checks =
+                boot_checks::run_boot_checks(state.credentials.as_ref(), &endpoints).await;
             let auth_rejected = boot_checks
                 .iter()
                 .any(|c| c.name == "Auth" && c.result.starts_with("token rejected"));
@@ -2584,7 +2585,8 @@ async fn main() -> Result<()> {
                 tracing::info!("access token refreshed after server-side rejection");
                 state.credentials = Some(new_creds);
                 let _ = paths.save_cli_state(&state);
-                boot_checks = boot_checks::run_boot_checks(state.credentials.as_ref(), &endpoints).await;
+                boot_checks =
+                    boot_checks::run_boot_checks(state.credentials.as_ref(), &endpoints).await;
             }
             boot::boot_sequence(&boot_checks);
             let _ = &python;

--- a/crates/server/src/ws.rs
+++ b/crates/server/src/ws.rs
@@ -224,7 +224,8 @@ mod tests {
 
     #[test]
     fn passes_audit_event_with_no_user() {
-        let event = r#"{"type":"AuditEntry","timestamp":"2026-05-09T00:00:00Z","action":"DataQuery"}"#;
+        let event =
+            r#"{"type":"AuditEntry","timestamp":"2026-05-09T00:00:00Z","action":"DataQuery"}"#;
         assert!(!audit_event_for_other_user(event, "alice"));
     }
 }


### PR DESCRIPTION
## Summary

\`OptimadeProvider.search\` called the synchronous \`OptimadeClient.structures.get(...)\` directly inside an \`async def\`. Sync HTTP doesn't yield, so:

1. Blocking call held the event loop for its full duration.
2. \`asyncio.gather\` over 17 OPTIMADE providers ran effectively **sequential** — every provider blocked the loop in turn.
3. The engine's \`asyncio.wait_for(provider.search(...), timeout=15)\` never fired — \`wait_for\` only triggers at await points, and there are none inside the sync C library underneath OptimadeClient.

**Net effect:** \`materials_search(elements=['Ni','Cr','Al'], limit=3)\` took **103 seconds wall-clock for 3 results**.

If the LLM tool-calls \`materials_search\` during chat, the chat hangs for 100+ seconds. Forge / MARC27's request timeout fires before the search returns, the LLM thinks the tool is broken — or hallucinates from training data instead of waiting for real provider data. **That defeats the entire grounding-via-tools architecture.**

## Fix

Wrap the sync OptimadeClient call in \`asyncio.to_thread(...)\`:

\`\`\`python
async def search(self, query):
    def _run_sync_search():
        client = OptimadeClient(base_urls=[base_url], use_async=False, ...)
        with redirect_stdout(StringIO()), redirect_stderr(StringIO()):
            return client.structures.get(filter=filter_string)
    results = await asyncio.to_thread(_run_sync_search)
    ...
\`\`\`

Now:
- Each provider runs on its own OS thread.
- Event loop stays free → 17 providers fan out genuinely in parallel.
- Engine's \`wait_for(timeout=15)\` works — slow providers get cancelled.
- Total wall-clock bounded by the slowest *individual* provider's cap (15 s default), not the sum.

## Found via

Direct invocation of the tool surface (no LLM, no chat) while prepping the materials-science end-to-end test. The user keeps saying: **trust the real run, not unit tests**. This bug never showed up in any \`cargo test\` — a single direct call surfaced it.

## Bonus: fmt-drift fix

Also fmt-cleans \`crates/cli/src/main.rs\` and \`crates/server/src/ws.rs\` so CI's stricter rustfmt version passes. Pre-existing drift, not from my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)