### PR TITLE
chore(fmt): align main with rustfmt 1.8 (unblock CI)

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2572,7 +2572,8 @@ async fn main() -> Result<()> {
                     }
                 }
             }
-            let mut boot_checks = boot_checks::run_boot_checks(state.credentials.as_ref(), &endpoints).await;
+            let mut boot_checks =
+                boot_checks::run_boot_checks(state.credentials.as_ref(), &endpoints).await;
             let auth_rejected = boot_checks
                 .iter()
                 .any(|c| c.name == "Auth" && c.result.starts_with("token rejected"));
@@ -2584,7 +2585,8 @@ async fn main() -> Result<()> {
                 tracing::info!("access token refreshed after server-side rejection");
                 state.credentials = Some(new_creds);
                 let _ = paths.save_cli_state(&state);
-                boot_checks = boot_checks::run_boot_checks(state.credentials.as_ref(), &endpoints).await;
+                boot_checks =
+                    boot_checks::run_boot_checks(state.credentials.as_ref(), &endpoints).await;
             }
             boot::boot_sequence(&boot_checks);
             let _ = &python;

--- a/crates/server/src/ws.rs
+++ b/crates/server/src/ws.rs
@@ -224,7 +224,8 @@ mod tests {
 
     #[test]
     fn passes_audit_event_with_no_user() {
-        let event = r#"{"type":"AuditEntry","timestamp":"2026-05-09T00:00:00Z","action":"DataQuery"}"#;
+        let event =
+            r#"{"type":"AuditEntry","timestamp":"2026-05-09T00:00:00Z","action":"DataQuery"}"#;
         assert!(!audit_event_for_other_user(event, "alice"));
     }
 }


### PR DESCRIPTION
## Summary

CI's Rust Format job (\`cargo fmt --all --check\`) is currently failing on \`main\` because three long lines hadn't been wrapped to rustfmt 1.8's preferred form. Pure cosmetic — no semantic change.

Drift was on:
- \`crates/cli/src/main.rs:2572\` — \`run_boot_checks\` call
- \`crates/cli/src/main.rs:2584\` — same call site after refresh
- \`crates/server/src/ws.rs:224\` — \`audit_event_for_other_user\` test fixture string

## Test plan

- [x] \`cargo fmt --all --check\` clean locally on rustfmt 1.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted code for improved readability and consistency.

* **Tests**
  * Updated test code formatting.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Darth-Hidious/PRISM/pull/89)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->