### PR TITLE
fix(auth): auto-select single org/project — drop spurious post-login pickers

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -5769,9 +5769,17 @@ async fn select_project(
         });
     }
 
-    let selected_org = prompt_select("Select organization", &orgs, |org| {
-        format!("{} ({})", org.name, org.slug)
-    })?;
+    // Skip the picker when there's only one choice — silent prompts on a
+    // single-org/single-project account were the loudest auth friction.
+    let selected_org = if orgs.len() == 1 {
+        let only = &orgs[0];
+        println!("Using organization: {} ({})", only.name, only.slug);
+        only
+    } else {
+        prompt_select("Select organization", &orgs, |org| {
+            format!("{} ({})", org.name, org.slug)
+        })?
+    };
 
     let projects = platform.list_projects_for_org(&selected_org.id).await?;
 
@@ -5797,9 +5805,15 @@ async fn select_project(
         });
     }
 
-    let selected_project = prompt_select("Select project", &projects, |project| {
-        format!("{} ({})", project.name, project.slug)
-    })?;
+    let selected_project = if projects.len() == 1 {
+        let only = &projects[0];
+        println!("Using project: {} ({})", only.name, only.slug);
+        only
+    } else {
+        prompt_select("Select project", &projects, |project| {
+            format!("{} ({})", project.name, project.slug)
+        })?
+    };
 
     Ok(SelectedContext {
         org_id: Some(selected_org.id.clone()),


### PR DESCRIPTION
## Summary

\`prism login\` ran device-flow, then unconditionally fired \`select_project\`'s CLI picker for the org **and** another for the project — even when the user had exactly one of each. Net effect: after authorizing the device in the browser, a fresh user got two terminal prompts where the answer was foregone. That was the loudest "auth flow feels clunky" complaint.

## Change

In \`crates/cli/src/main.rs:select_project\`:

- When \`orgs.len() == 1\` → use it; print \`Using organization: <name> (<slug>)\`.
- When \`projects.len() == 1\` → use it; print \`Using project: <name> (<slug>)\`.
- Picker still fires when there are 2+ choices.

The print lines mean the choice isn't *silent* — user can see exactly which workspace they landed in.

## Out of scope (followups)

- Embedding the org/project picker on the device-authorize web page so multi-workspace users pick once in the browser instead of twice in the terminal.
- Refresh-token expiry now still drops the user with "open a new terminal and run \`prism login\`" — fix coming in a separate PR.

## Test plan

- [x] \`cargo check -p prism-cli\` clean
- [x] \`cargo clippy -p prism-cli --bins -- -D warnings\` clean
- [ ] Manual: \`prism login\` on a single-org/single-project account skips both pickers and prints the two "Using" lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)