### PR TITLE
fix(auth): fail fast on expired refresh instead of launching dead TUI

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2533,6 +2533,26 @@ async fn main() -> Result<()> {
                 boot_checks =
                     boot_checks::run_boot_checks(state.credentials.as_ref(), &endpoints).await;
             }
+            // Both proactive AND reactive refresh have failed → the
+            // refresh token itself is expired. Launching the TUI on
+            // dead creds drops the user into a 401 mid-chat with the
+            // platform_bridge.rs "open a new terminal" interceptor —
+            // confusing and easy to miss. Fail fast here with a single
+            // actionable message instead.
+            if boot_checks
+                .iter()
+                .any(|c| c.name == "Auth" && c.result.starts_with("token rejected"))
+            {
+                eprintln!();
+                eprintln!("\x1b[33mYour MARC27 session has expired.\x1b[0m");
+                eprintln!();
+                eprintln!("  To re-authenticate, run:");
+                eprintln!("    \x1b[1mprism login\x1b[0m");
+                eprintln!();
+                eprintln!("  Then start the TUI again with \x1b[1mprism tui\x1b[0m.");
+                eprintln!();
+                return Ok(());
+            }
             boot::boot_sequence(&boot_checks);
             // Splash skipped — see note in default chat path.
             let _ = &python;
@@ -2587,6 +2607,26 @@ async fn main() -> Result<()> {
                 let _ = paths.save_cli_state(&state);
                 boot_checks =
                     boot_checks::run_boot_checks(state.credentials.as_ref(), &endpoints).await;
+            }
+            // Same fail-fast as the Tui branch — see comment there.
+            // Resuming on dead creds is even more confusing because
+            // the user expects their old conversation to load.
+            if boot_checks
+                .iter()
+                .any(|c| c.name == "Auth" && c.result.starts_with("token rejected"))
+            {
+                eprintln!();
+                eprintln!("\x1b[33mYour MARC27 session has expired.\x1b[0m");
+                eprintln!();
+                eprintln!("  To re-authenticate, run:");
+                eprintln!("    \x1b[1mprism login\x1b[0m");
+                eprintln!();
+                eprintln!(
+                    "  Then resume with \x1b[1mprism resume{}\x1b[0m.",
+                    id.as_deref().map(|s| format!(" {s}")).unwrap_or_default()
+                );
+                eprintln!();
+                return Ok(());
             }
             boot::boot_sequence(&boot_checks);
             let _ = &python;


### PR DESCRIPTION
## Summary

\`prism tui\` and \`prism resume\` both run proactive refresh → boot-checklist auth check → reactive refresh on rejection, **then launch forge_chat regardless of whether either refresh succeeded**. When the refresh token itself has expired (90-day TTL), both refreshes fail and the user lands in the chat UI on dead creds. Their first message then hits the \`platform_bridge.rs:799-820\` interceptor with:

> Your MARC27 session has expired. Open a new terminal and run \`prism login\`.

That's the dead end the user complained about: type out a prompt, send it, *then* discover the session was broken before they ever started.

## Change

In both \`Commands::Tui\` and \`Commands::Resume\` (\`crates/cli/src/main.rs\`), after the reactive refresh attempt, check whether the boot \`Auth\` line still says \"token rejected\". If so, print:

\`\`\`
Your MARC27 session has expired.

  To re-authenticate, run:
    prism login

  Then start the TUI again with \`prism tui\`.
\`\`\`

…and \`return Ok(())\` instead of launching the TUI. \`Resume\` includes the conversation id in the suggested command.

## Why not full inline relogin?

The audit recommended calling \`run_device_login_with_opts\` inline. That's the right end-state, but it requires mirroring the full \`Commands::Login\` path: device flow + \`fetch_current_user\` + \`select_project\` + save \`StoredCredentials\` + sync to \`~/.prism/credentials.json\` (for the Python SDK). That's a 50-line refactor at two call sites and a separate concern.

This PR ships the smaller honest fix that removes the broken UX *now*. Tracked as a followup TODO in the commit body.

## Test plan

- [x] \`cargo check -p prism-cli\` clean
- [x] \`cargo clippy -p prism-cli --bins -- -D warnings\` clean
- [x] \`cargo fmt -p prism-cli -- --check\` clean
- [ ] Manual: corrupt \`refresh_token\` in \`~/.prism/cli_state.json\`, run \`prism tui\` → should print the expiry message and exit, **not** launch the TUI

🤖 Generated with [Claude Code](https://claude.com/claude-code)