### PR TITLE
chore(release): v2.7.1 — bug-bounty + auth UX cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,101 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.1] - 2026-05-10
+
+Bug-bounty + UX cleanup release. 79 commits over v2.7.0 — no breaking changes,
+no new public surface area; all of it sands the rough edges off the 2.7.0
+release.
+
+### Fixed — LLM and tool calling
+- **Stale tool names in the system-prompt quick-reference** caused the LLM
+  to hallucinate calls to tools that no longer existed (e.g.
+  `search_materials` after the Round 7 rename to `materials_search`). The
+  curated list in `crates/llm/src/lib.rs` was 6-of-9 stale; LLM now sees
+  real names. Two pin-tests + a Python-registry cross-check guard
+  against recurrence.
+- **SSE chunk-buffer corruption on the platform LLM proxy** dropped bytes
+  mid-`function.arguments` JSON whenever an SSE event spanned a TCP
+  packet boundary, producing empty assistant messages on tool calls.
+  Fixed in marc27-core with a buffered line assembler (PR #8); 10 unit
+  tests cover the chunk-split scenarios. Verified live in `prism tui`.
+- **MARC27 streaming clean-up** removes a delta-emit echo so chat content
+  no longer renders twice in a single turn.
+
+### Fixed — auth UX
+- **Spurious org/project pickers on fresh login**: `prism login` now
+  auto-selects when the account has exactly one org or one project,
+  printing `Using organization: …` / `Using project: …` so the choice
+  isn't silent.
+- **Refresh-token expiry no longer drops the user mid-chat.** When both
+  proactive and reactive refresh fail, `prism tui` and `prism resume`
+  run the full device-flow login *inline* — the user stays in the same
+  shell, approves in the browser, and the TUI keeps loading. Falls back
+  to a clear `run prism login` message if the inline flow itself errors.
+- **Refresh-token failures surface platform error detail** instead of a
+  generic 401 — easier to tell expired-token from network-down.
+
+### Fixed — security and privacy (bug-bounty round)
+- **PRISM token egress to forgecode.dev blocked** (Bug #35).
+- **`credentials.json` now written 0600**, not world-readable (Bug #39).
+- **`open_browser` refuses non-`http(s)` URLs** (Bug #42, defense-in-depth).
+- **Cypher write-protection blocklist extended** (Bug #47).
+- **Mesh dataset-name Cypher injection** patched (Bug #45).
+- **Kafka `QueryForward` execution disabled** pending peer-verification
+  wiring (Bug #46) — see "Known issues" below.
+- **BYOC SSH shell injection via image / inputs** patched (Bug #54).
+- **Workflow `http` step SSRF-guarded** (Bug #56).
+- **Mesh `Announce` message sizes capped** to prevent DoS (Bug #57).
+- **WebSocket audit broadcasts scoped by user** (Bug #58).
+- **Marketplace install hardened** against silent overwrites and bad
+  downloads (Bug #34).
+- **RBAC: NodeAdmin no longer silently restored** after admin downgrade
+  (Bug #49).
+- **Dataset names validated** at publish/subscribe (Bug #51).
+- **Release archive binary names allowlisted** at install (Bug #59).
+
+### Fixed — TUI / CLI quality
+- **`prism --offline` localhost-only auth** (Bug #21) and **in-memory
+  `SubscriptionManager`** (Bug #20) now actually work without platform
+  connectivity.
+- **`prism resume`** subcommand with a truthful exit hint.
+- **`/update` no longer installs FORGE over PRISM** (Bug #31, critical).
+- **CPR-timeout** in forge_main produces a clear actionable error
+  instead of a silent crash (Bug #22).
+- **Boot status truthful** + stale forge creds cleared (Bug #23).
+- **TUI per-column word floor** stops `Stainless` → `Stainl` /
+  `ess` (Bug #28).
+- **Branding leaks**: dropped user-facing "forge" mentions from the
+  banner, `/info`, init flow, and status command (Bugs #36, #63).
+- **`prism status`** now reports `chat_surface: "prism"`, not `"forge"`.
+- **Workflow discovery** survives one bad YAML instead of crashing
+  the whole list (Bug #37).
+- **Mesh federated query unwrap** removed (Bug #38).
+- **Mesh `SubscriptionManager`** dedupes in memory like it already did
+  on disk (Bug #43).
+- **Mesh mDNS** uses 0.18 + explicit loopback so two `prism` processes
+  on the same host can find each other (Bug #19).
+- **Picker title salvage**: malformed-JSON fallback titles now render
+  human-readable in the conversation picker (Bug #30).
+
+### Changed
+- **Body cap on platform LLM/knowledge proxies** raised from 64 KiB
+  to 32 MiB (marc27-core PR #7), with a 413 PAYLOAD_TOO_LARGE response
+  for over-cap requests instead of silent truncation.
+- **Federation trust anchor**: marc27-core now exposes `/federation/
+  platform-pubkey` and signs cross-org requests with Ed25519
+  (marc27-core PR #6, slice 1 of PRISM Bug #27 path A).
+
+### Known issues
+- **Bug #33 — `verify_peer` not yet wired into the mesh sync path.**
+  The Kafka `QueryForward` consumer is currently disabled for safety
+  (Bug #46 above); re-enabling it requires (a) F1c4 `verify_peer`
+  wiring, (b) a read-only Cypher allow-list, (c) per-org policy
+  gating. Targeted for v2.7.2.
+- **Auth: dashboard "Create API Key" button** still missing (chicken-
+  and-egg for fresh users without a CLI session). Blocked on the
+  marc27-platform route-group refactor in flight; targeted for v2.7.2.
+
 ## [2.6.0] - 2026-04-04
 
 ## [2.6.1] - 2026-04-06

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2627,7 +2627,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "forge_api"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2646,7 +2646,7 @@ dependencies = [
 
 [[package]]
 name = "forge_app"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -2698,7 +2698,7 @@ dependencies = [
 
 [[package]]
 name = "forge_config"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "anyhow",
  "config",
@@ -2721,7 +2721,7 @@ dependencies = [
 
 [[package]]
 name = "forge_display"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "console",
  "derive_setters",
@@ -2738,7 +2738,7 @@ dependencies = [
 
 [[package]]
 name = "forge_domain"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2780,7 +2780,7 @@ dependencies = [
 
 [[package]]
 name = "forge_embed"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "anyhow",
  "handlebars",
@@ -2789,7 +2789,7 @@ dependencies = [
 
 [[package]]
 name = "forge_eventsource"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "forge_eventsource_stream",
  "futures",
@@ -2808,7 +2808,7 @@ dependencies = [
 
 [[package]]
 name = "forge_eventsource_stream"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "futures",
  "futures-core",
@@ -2822,7 +2822,7 @@ dependencies = [
 
 [[package]]
 name = "forge_fs"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "anyhow",
  "bstr",
@@ -2838,7 +2838,7 @@ dependencies = [
 
 [[package]]
 name = "forge_infra"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2889,7 +2889,7 @@ dependencies = [
 
 [[package]]
 name = "forge_json_repair"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "pretty_assertions",
  "regex",
@@ -2902,7 +2902,7 @@ dependencies = [
 
 [[package]]
 name = "forge_main"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "anyhow",
  "arboard",
@@ -2966,7 +2966,7 @@ dependencies = [
 
 [[package]]
 name = "forge_markdown_stream"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "colored",
  "insta",
@@ -2984,7 +2984,7 @@ dependencies = [
 
 [[package]]
 name = "forge_repo"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "anyhow",
  "async-openai",
@@ -3048,7 +3048,7 @@ dependencies = [
 
 [[package]]
 name = "forge_select"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "anyhow",
  "colored",
@@ -3061,7 +3061,7 @@ dependencies = [
 
 [[package]]
 name = "forge_services"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3120,7 +3120,7 @@ dependencies = [
 
 [[package]]
 name = "forge_snaps"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3135,7 +3135,7 @@ dependencies = [
 
 [[package]]
 name = "forge_spinner"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "anyhow",
  "colored",
@@ -3151,7 +3151,7 @@ dependencies = [
 
 [[package]]
 name = "forge_stream"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "futures",
  "tokio",
@@ -3159,7 +3159,7 @@ dependencies = [
 
 [[package]]
 name = "forge_template"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "html-escape",
  "pretty_assertions",
@@ -3167,7 +3167,7 @@ dependencies = [
 
 [[package]]
 name = "forge_test_kit"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -3176,7 +3176,7 @@ dependencies = [
 
 [[package]]
 name = "forge_tool_macros"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3185,7 +3185,7 @@ dependencies = [
 
 [[package]]
 name = "forge_tracker"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3204,7 +3204,7 @@ dependencies = [
 
 [[package]]
 name = "forge_walker"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "anyhow",
  "derive_setters",
@@ -7391,7 +7391,7 @@ dependencies = [
 
 [[package]]
 name = "prism-audit"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7409,7 +7409,7 @@ dependencies = [
 
 [[package]]
 name = "prism-cli"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7454,7 +7454,7 @@ dependencies = [
 
 [[package]]
 name = "prism-client"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "anyhow",
  "reqwest 0.12.28",
@@ -7467,7 +7467,7 @@ dependencies = [
 
 [[package]]
 name = "prism-compute"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7482,7 +7482,7 @@ dependencies = [
 
 [[package]]
 name = "prism-core"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7497,7 +7497,7 @@ dependencies = [
 
 [[package]]
 name = "prism-ingest"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7516,7 +7516,7 @@ dependencies = [
 
 [[package]]
 name = "prism-ipc"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "anyhow",
  "serde",
@@ -7527,7 +7527,7 @@ dependencies = [
 
 [[package]]
 name = "prism-llm"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -7540,7 +7540,7 @@ dependencies = [
 
 [[package]]
 name = "prism-mesh"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7570,7 +7570,7 @@ dependencies = [
 
 [[package]]
 name = "prism-node"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -7602,7 +7602,7 @@ dependencies = [
 
 [[package]]
 name = "prism-orch"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7618,7 +7618,7 @@ dependencies = [
 
 [[package]]
 name = "prism-policy"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7631,7 +7631,7 @@ dependencies = [
 
 [[package]]
 name = "prism-proto"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -7640,7 +7640,7 @@ dependencies = [
 
 [[package]]
 name = "prism-python-bridge"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -7651,7 +7651,7 @@ dependencies = [
 
 [[package]]
 name = "prism-runtime"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "chrono",
  "directories",
@@ -7662,7 +7662,7 @@ dependencies = [
 
 [[package]]
 name = "prism-server"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -7684,7 +7684,7 @@ dependencies = [
 
 [[package]]
 name = "prism-workflows"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7699,7 +7699,7 @@ dependencies = [
 
 [[package]]
 name = "prism_tool_router"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "2.7.0"
+version = "2.7.1"
 rust-version = "1.92"
 edition = "2024"
 license = "LicenseRef-MARC27-Dual"


### PR DESCRIPTION
## Summary

Cuts the v2.7.1 release. 79 commits over v2.7.0. No breaking changes; no new public surface area.

- Bumps \`workspace.package.version\` 2.7.0 → 2.7.1 in \`Cargo.toml\` (every workspace crate inherits via \`version.workspace = true\`).
- Updates \`Cargo.lock\` to match.
- Adds a fresh \`[2.7.1] - 2026-05-10\` entry to \`CHANGELOG.md\` covering: LLM tool-calling fixes (SSE chunk buffer, stale tool names), auth UX (auto-select single org/project, inline relogin on expired refresh), 12 security/privacy bug-bounty fixes, TUI polish.
- Calls out two known-issues for v2.7.2: Bug #33 (\`verify_peer\` wiring on the mesh sync path) and the dashboard \"Create API Key\" button (blocked on the marc27-platform route-group refactor).

## Release flow

After this merges, push the \`v2.7.1\` tag — \`.github/workflows/native-release.yml\` triggers on \`v*\`, builds Linux/macOS/Windows binaries, and publishes a GitHub release with the tarballs/zip.

## Test plan

- [x] \`cargo check --workspace\` clean at 2.7.1
- [ ] CI green on this PR (Rust Backbone + Integration Test)
- [ ] After merge: \`git tag v2.7.1 && git push origin v2.7.1\` — release workflow runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)