### PR TITLE
fix(orch): pre-flight compaction — stop mid-turn context_length_exceeded

### DIFF
--- a/crates/forge_app/src/app.rs
+++ b/crates/forge_app/src/app.rs
@@ -10,8 +10,8 @@ use crate::apply_tunable_parameters::ApplyTunableParameters;
 use crate::changed_files::ChangedFiles;
 use crate::dto::ToolsOverview;
 use crate::hooks::{
-    CompactionHandler, DoomLoopDetector, PendingTodosHandler, TitleGenerationHandler,
-    TracingHandler,
+    CompactionHandler, DoomLoopDetector, PendingTodosHandler, PreflightCompactionHandler,
+    TitleGenerationHandler, TracingHandler,
 };
 use crate::init_conversation_metrics::InitConversationMetrics;
 use crate::orch::Orchestrator;
@@ -164,7 +164,19 @@ impl<S: Services + EnvironmentInfra<Config = forge_config::ForgeConfig>> ForgeAp
 
         let hook = Hook::default()
             .on_start(tracing_handler.clone().and(title_handler))
-            .on_request(tracing_handler.clone().and(DoomLoopDetector::default()))
+            .on_request(
+                tracing_handler
+                    .clone()
+                    .and(DoomLoopDetector::default())
+                    // Pre-flight compaction: shrink the context BEFORE we
+                    // send the next turn, so we don't 413 the LLM. Mirrors
+                    // CompactionHandler on the on_response side, which still
+                    // runs as the post-turn safety net.
+                    .and(PreflightCompactionHandler::new(
+                        agent.clone(),
+                        environment.clone(),
+                    )),
+            )
             .on_response(
                 tracing_handler
                     .clone()

--- a/crates/forge_app/src/hooks/mod.rs
+++ b/crates/forge_app/src/hooks/mod.rs
@@ -1,11 +1,13 @@
 mod compaction;
 mod doom_loop;
 mod pending_todos;
+mod preflight_compaction;
 mod title_generation;
 mod tracing;
 
 pub use compaction::CompactionHandler;
 pub use doom_loop::DoomLoopDetector;
 pub use pending_todos::PendingTodosHandler;
+pub use preflight_compaction::PreflightCompactionHandler;
 pub use title_generation::TitleGenerationHandler;
 pub use tracing::TracingHandler;

--- a/crates/forge_app/src/hooks/preflight_compaction.rs
+++ b/crates/forge_app/src/hooks/preflight_compaction.rs
@@ -1,0 +1,62 @@
+use async_trait::async_trait;
+use forge_domain::{Agent, Conversation, Environment, EventData, EventHandle, RequestPayload};
+use tracing::{debug, info};
+
+use crate::compact::Compactor;
+
+/// Hook handler that runs context compaction BEFORE each LLM request.
+///
+/// The sibling [`CompactionHandler`](super::CompactionHandler) runs on
+/// `Response` events — i.e. *after* a turn comes back. That's the wrong
+/// timing for the failure mode this handler exists to prevent: a turn
+/// whose outgoing context already exceeds the model window. By the
+/// time the response hook fires, the request has already been sent and
+/// either succeeded (no compaction needed yet) or 4xx'd with
+/// `context_length_exceeded` (compaction is now too late).
+///
+/// This handler runs on the `Request` event in `orch.rs::run`'s loop,
+/// just before `execute_chat_turn`. If `agent.compact.should_compact`
+/// returns true for the *current* context, it compacts in place. The
+/// orchestrator re-reads `conversation.context` after the hook chain
+/// completes so the compacted version is what hits the wire.
+///
+/// Logic is otherwise identical to `CompactionHandler` — same compactor,
+/// same agent config. They differ only in WHEN they run.
+#[derive(Clone)]
+pub struct PreflightCompactionHandler {
+    agent: Agent,
+    environment: Environment,
+}
+
+impl PreflightCompactionHandler {
+    pub fn new(agent: Agent, environment: Environment) -> Self {
+        Self { agent, environment }
+    }
+}
+
+#[async_trait]
+impl EventHandle<EventData<RequestPayload>> for PreflightCompactionHandler {
+    async fn handle(
+        &self,
+        _event: &EventData<RequestPayload>,
+        conversation: &mut Conversation,
+    ) -> anyhow::Result<()> {
+        if let Some(context) = &conversation.context {
+            let token_count = context.token_count();
+            if self.agent.compact.should_compact(context, *token_count) {
+                info!(
+                    agent_id = %self.agent.id,
+                    token_count = *token_count,
+                    "Pre-flight compaction triggered before request"
+                );
+                let compacted =
+                    Compactor::new(self.agent.compact.clone(), self.environment.clone())
+                        .compact(context.clone(), false)?;
+                conversation.context = Some(compacted);
+            } else {
+                debug!(agent_id = %self.agent.id, "Pre-flight compaction not needed");
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/forge_app/src/orch.rs
+++ b/crates/forge_app/src/orch.rs
@@ -279,6 +279,16 @@ impl<S: AgentService + EnvironmentInfra<Config = forge_config::ForgeConfig>> Orc
                 .handle(&request_event, &mut self.conversation)
                 .await?;
 
+            // Re-read context from the conversation in case a Request hook
+            // mutated it (e.g. PreflightCompactionHandler). The local
+            // `context` snapshot we took at the top of the loop is stale
+            // after compaction; if we kept using it we'd send the
+            // pre-compaction (oversized) context and defeat the point of
+            // running compaction pre-flight.
+            if let Some(updated) = self.conversation.context.clone() {
+                context = updated;
+            }
+
             let message = crate::retry::retry_with_config(
                 &self.config.clone().retry.unwrap_or_default(),
                 || {


### PR DESCRIPTION
## Summary

The existing CompactionHandler runs on `Response` events — *after* a turn round-trips. By then `context_length_exceeded` may have already happened. New `PreflightCompactionHandler` runs on `Request` events, just before `execute_chat_turn`. Plus a one-line orchestrator fix to re-read `context` from the conversation after the Request hook chain so a successful pre-flight compaction is visible to the chat call.

(Re-opens previous PR #97 — closed during a branch reorg, content unchanged.)

## Test plan

- [x] cargo test -p forge_app --lib — 700/700 pass
- [x] fmt + clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)