### PR TITLE
feat(tools): policy_evaluate / usage_status / billing_balance — close 3 GAP-HIGH platform endpoints

### DIFF
--- a/app/plugins/bootstrap.py
+++ b/app/plugins/bootstrap.py
@@ -25,6 +25,7 @@ def build_full_registry(
     from app.tools.bash import create_bash_tools
     from app.tools.capabilities import create_capabilities_tools
     from app.tools.dataset import create_dataset_tool
+    from app.tools.platform_status import create_platform_status_tools
 
     registry = ToolRegistry()
     create_system_tools(registry)
@@ -36,6 +37,10 @@ def build_full_registry(
     create_code_tools(registry)
     create_bash_tools(registry)
     create_capabilities_tools(registry)
+    # Platform-status tools (policy/usage/billing reads). Closes three
+    # GAP-HIGH endpoints from the v2.7.2 endpoint-coverage audit. All
+    # three are read-only — no approval gate.
+    create_platform_status_tools(registry)
     # Unified dataset tool — replaces VALIDATE_SKILL / REVIEW_SKILL /
     # VISUALIZE_SKILL Tool registrations. See app/tools/dataset.py.
     create_dataset_tool(registry)

--- a/app/tools/platform_status.py
+++ b/app/tools/platform_status.py
@@ -1,0 +1,265 @@
+"""Platform-status tools — thin wrappers over MARC27 platform read endpoints.
+
+Three high-leverage gaps from the v2.7.2 endpoint-coverage audit get
+filled here, all *read-only*:
+
+  - policy_evaluate  → POST /policy/evaluate    (audit gap: agent had no
+                                                 way to ask "am I allowed?")
+  - usage_status     → GET /usage/me + /usage/projects/{id}
+                                                (agent had no way to
+                                                 self-budget compute spend)
+  - billing_balance  → GET /billing/balance + /billing/usage + /billing/prices
+                                                (agent had no way to read
+                                                 wallet balance or prices)
+
+All three use the same auth path as `research.py` — `MARC27_API_KEY` env
+var or `~/.prism/credentials.json` access_token. None of them mutate
+platform state, so none are `requires_approval=True`.
+
+The matrix in the v2.7.2 endpoint-coverage audit lists more GAP-HIGH
+endpoints (compute/, jobs/, knowledge/embed, mcp-services, etc.) — those
+need their own tools and are tracked separately.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Optional
+
+import requests
+
+from app.tools.base import Tool, ToolRegistry
+
+
+# ---------------------------------------------------------------------------
+# Shared auth (mirror of research.py:_resolve_credentials, kept private here
+# so each tool module can evolve its own auth handling later if needed).
+# ---------------------------------------------------------------------------
+
+def _resolve_credentials() -> tuple[str, str]:
+    """Return (api_url, access_token) from env or `~/.prism/credentials.json`."""
+    api_url = os.environ.get(
+        "MARC27_API_URL", "https://api.marc27.com/api/v1"
+    ).rstrip("/")
+    api_key = os.environ.get("MARC27_API_KEY", "")
+
+    if not api_key:
+        try:
+            creds_path = Path.home() / ".prism" / "credentials.json"
+            if creds_path.exists():
+                creds = json.loads(creds_path.read_text())
+                api_key = creds.get("access_token", "")
+                if creds.get("platform_url"):
+                    api_url = creds["platform_url"].rstrip("/")
+                    if not api_url.endswith("/api/v1"):
+                        api_url = api_url + "/api/v1"
+        except Exception:
+            pass
+
+    return api_url, api_key
+
+
+def _get(path: str) -> dict:
+    """GET helper. Returns dict with 'error' on failure, parsed JSON otherwise."""
+    api_url, token = _resolve_credentials()
+    if not token:
+        return {
+            "error": "Not authenticated to the MARC27 platform.",
+            "hint": "Run `prism login` first, then retry.",
+        }
+    try:
+        resp = requests.get(
+            f"{api_url}{path}",
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=10,
+        )
+        if resp.status_code != 200:
+            return {
+                "error": f"platform returned HTTP {resp.status_code}",
+                "body": resp.text[:500],
+            }
+        return resp.json()
+    except requests.exceptions.RequestException as e:
+        return {"error": f"network error: {e}"}
+
+
+def _post(path: str, body: dict) -> dict:
+    api_url, token = _resolve_credentials()
+    if not token:
+        return {
+            "error": "Not authenticated to the MARC27 platform.",
+            "hint": "Run `prism login` first, then retry.",
+        }
+    try:
+        resp = requests.post(
+            f"{api_url}{path}",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+            },
+            json=body,
+            timeout=15,
+        )
+        if resp.status_code != 200:
+            return {
+                "error": f"platform returned HTTP {resp.status_code}",
+                "body": resp.text[:500],
+            }
+        return resp.json()
+    except requests.exceptions.RequestException as e:
+        return {"error": f"network error: {e}"}
+
+
+# ---------------------------------------------------------------------------
+# policy_evaluate
+# ---------------------------------------------------------------------------
+
+def _policy_evaluate(action: Optional[str] = None,
+                     resource: Optional[str] = None,
+                     context: Optional[dict] = None,
+                     **_kwargs: Any) -> dict:
+    if not action:
+        return {"error": "Missing required argument `action`."}
+    body: dict = {"action": action}
+    if resource is not None:
+        body["resource"] = resource
+    if context is not None:
+        body["context"] = context
+    return _post("/policy/evaluate", body)
+
+
+_POLICY_EVALUATE_DESCRIPTION = (
+    "Ask the MARC27 platform's policy engine whether a given action on a "
+    "given resource is permitted for the current user. Use this BEFORE "
+    "running anything privileged (compute submit, dataset publish, "
+    "cross-org access) so you don't waste a turn on a 403.\n"
+    "  • action: required. e.g. 'compute.submit', 'dataset.export', "
+    "'mesh.subscribe'.\n"
+    "  • resource: optional. e.g. 'gpu://provider/h100', "
+    "'dataset://tokyo/cfd-2024'.\n"
+    "  • context: optional dict of action-specific extras.\n"
+    "Returns `{allowed: bool, reason?: str, ...}`. No state change; "
+    "no approval gate."
+)
+
+
+# ---------------------------------------------------------------------------
+# usage_status
+# ---------------------------------------------------------------------------
+
+def _usage_status(project_id: Optional[str] = None, **_kwargs: Any) -> dict:
+    """Return either user-level usage (default) or project-level usage."""
+    if project_id:
+        return _get(f"/usage/projects/{project_id}")
+    return _get("/usage/me")
+
+
+_USAGE_STATUS_DESCRIPTION = (
+    "Read current MARC27 platform usage telemetry for the user or a "
+    "specific project. Useful for budgeting decisions BEFORE submitting "
+    "expensive compute jobs.\n"
+    "  • No args: returns the authenticated user's aggregate usage "
+    "(GET /usage/me).\n"
+    "  • project_id: returns usage scoped to that project "
+    "(GET /usage/projects/{id}).\n"
+    "Returns counters for tokens, compute time, dataset IO, etc. "
+    "depending on the platform's current schema. No state change."
+)
+
+
+# ---------------------------------------------------------------------------
+# billing_balance
+# ---------------------------------------------------------------------------
+
+def _billing_balance(action: str = "balance", **_kwargs: Any) -> dict:
+    """Read wallet balance, recent usage charges, or current prices."""
+    action = (action or "balance").lower()
+    if action == "balance":
+        return _get("/billing/balance")
+    if action == "usage":
+        return _get("/billing/usage")
+    if action == "prices":
+        return _get("/billing/prices")
+    return {
+        "error": f"Unknown action '{action}'. Valid: balance, usage, prices.",
+    }
+
+
+_BILLING_BALANCE_DESCRIPTION = (
+    "Read MARC27 platform billing state. Read-only — never tops up, "
+    "never charges. ONE tool, three actions:\n"
+    "  • action='balance' (default) — current wallet balance + plan tier "
+    "(GET /billing/balance).\n"
+    "  • action='usage' — historical usage charges (GET /billing/usage).\n"
+    "  • action='prices' — current per-unit prices for compute / inference "
+    "(GET /billing/prices). Useful before estimating job cost.\n"
+    "No state change; no approval gate. For top-up the human runs "
+    "`prism billing topup` interactively."
+)
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+def create_platform_status_tools(registry: ToolRegistry) -> None:
+    """Register the three platform-read tools (policy / usage / billing)."""
+    registry.register(Tool(
+        name="policy_evaluate",
+        description=_POLICY_EVALUATE_DESCRIPTION,
+        input_schema={
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "description": "Action verb to check, e.g. 'compute.submit'.",
+                },
+                "resource": {
+                    "type": "string",
+                    "description": "Optional resource handle.",
+                },
+                "context": {
+                    "type": "object",
+                    "description": "Optional action-specific context.",
+                    "additionalProperties": True,
+                },
+            },
+            "required": ["action"],
+            "additionalProperties": False,
+        },
+        func=_policy_evaluate,
+    ))
+
+    registry.register(Tool(
+        name="usage_status",
+        description=_USAGE_STATUS_DESCRIPTION,
+        input_schema={
+            "type": "object",
+            "properties": {
+                "project_id": {
+                    "type": "string",
+                    "description": "Optional project UUID to scope the query.",
+                },
+            },
+            "additionalProperties": False,
+        },
+        func=_usage_status,
+    ))
+
+    registry.register(Tool(
+        name="billing_balance",
+        description=_BILLING_BALANCE_DESCRIPTION,
+        input_schema={
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["balance", "usage", "prices"],
+                    "description": "Which billing read to perform.",
+                },
+            },
+            "additionalProperties": False,
+        },
+        func=_billing_balance,
+    ))

--- a/tests/test_platform_status_tools.py
+++ b/tests/test_platform_status_tools.py
@@ -1,0 +1,121 @@
+"""Tests for platform_status tools (policy_evaluate / usage_status / billing_balance).
+
+These tools wrap MARC27 platform read endpoints. The tests verify
+registration shape + that each dispatcher fails cleanly when no
+auth is configured (the most likely runtime error in development).
+
+Network-dependent behavior is mocked at the `requests` level; the
+underlying platform routes are tested in marc27-core's own suite.
+"""
+from unittest.mock import patch
+
+import pytest
+
+from app.tools.base import ToolRegistry
+from app.tools.platform_status import (
+    _billing_balance,
+    _policy_evaluate,
+    _usage_status,
+    create_platform_status_tools,
+)
+
+
+@pytest.fixture(autouse=True)
+def _no_credentials_env(monkeypatch, tmp_path):
+    """Run each test with empty creds env + a non-existent creds file
+    so the tools take the "not authenticated" branch deterministically."""
+    monkeypatch.delenv("MARC27_API_KEY", raising=False)
+    monkeypatch.delenv("MARC27_API_URL", raising=False)
+    # Point HOME at an empty tmpdir so credentials.json is missing.
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+
+class TestRegistration:
+    def test_registers_three_tools(self):
+        registry = ToolRegistry()
+        create_platform_status_tools(registry)
+        tools = registry.list_tools()
+        names = {t.name for t in tools}
+        assert names == {"policy_evaluate", "usage_status", "billing_balance"}
+
+    def test_no_approval_required(self):
+        """All three are read-only and should not be approval-gated."""
+        registry = ToolRegistry()
+        create_platform_status_tools(registry)
+        for name in ("policy_evaluate", "usage_status", "billing_balance"):
+            assert registry.get(name).requires_approval is False, (
+                f"{name} is read-only and must not be approval-gated"
+            )
+
+
+class TestPolicyEvaluate:
+    def test_missing_action_returns_clear_error(self):
+        result = _policy_evaluate()
+        assert "error" in result
+        assert "action" in result["error"].lower()
+
+    def test_no_credentials_returns_login_hint(self):
+        result = _policy_evaluate(action="compute.submit")
+        assert "error" in result
+        assert "Not authenticated" in result["error"]
+        assert "prism login" in result.get("hint", "")
+
+
+class TestUsageStatus:
+    def test_no_credentials_returns_login_hint(self):
+        result = _usage_status()
+        assert "error" in result
+        assert "Not authenticated" in result["error"]
+
+    def test_project_id_no_credentials(self):
+        # Same path; just exercises the project_id branch.
+        result = _usage_status(project_id="00000000-0000-4000-8000-000000000001")
+        assert "error" in result
+        assert "Not authenticated" in result["error"]
+
+
+class TestBillingBalance:
+    def test_default_action_balance(self):
+        # No credentials → still hits the error path (auth check before HTTP).
+        result = _billing_balance()
+        assert "error" in result
+        assert "Not authenticated" in result["error"]
+
+    def test_unknown_action_clear_error(self):
+        # Provide credentials so we get past the auth check, hit the
+        # action validation branch.
+        with patch.dict("os.environ", {"MARC27_API_KEY": "fake-token"}):
+            result = _billing_balance(action="topup")
+            assert "error" in result
+            assert "Unknown action" in result["error"]
+            assert "balance" in result["error"]
+
+    def test_valid_actions_call_correct_endpoint(self, monkeypatch):
+        """The three valid actions should hit distinct endpoints. Mock
+        `requests.get` so we don't depend on platform network reachability,
+        and inspect the URL each action targets."""
+        called_paths = []
+
+        class _StubResp:
+            status_code = 200
+
+            def json(self):
+                return {"ok": True}
+
+        def _stub_get(url, **_kwargs):
+            called_paths.append(url)
+            return _StubResp()
+
+        monkeypatch.setenv("MARC27_API_KEY", "fake-token")
+        monkeypatch.setenv("MARC27_API_URL", "https://example.invalid/api/v1")
+        monkeypatch.setattr("app.tools.platform_status.requests.get", _stub_get)
+
+        for action in ("balance", "usage", "prices"):
+            result = _billing_balance(action=action)
+            assert result == {"ok": True}, f"action={action} returned {result}"
+
+        assert called_paths == [
+            "https://example.invalid/api/v1/billing/balance",
+            "https://example.invalid/api/v1/billing/usage",
+            "https://example.invalid/api/v1/billing/prices",
+        ]


### PR DESCRIPTION
## Summary

Closes the three smallest GAP-HIGH endpoints from the v2.7.2 endpoint-coverage audit. New \`app/tools/platform_status.py\` module registers three read-only tools wrapping MARC27 platform endpoints. None of them require approval gates.

| Tool | Endpoint(s) | Why |
|---|---|---|
| \`policy_evaluate(action, resource?, context?)\` | POST /policy/evaluate | Audit: "agent has no way to ask 'am I allowed?'" — wastes a turn on each 403 |
| \`usage_status(project_id?)\` | GET /usage/me or /usage/projects/{id} | Audit: "agent has no way to self-budget" |
| \`billing_balance(action='balance'|'usage'|'prices')\` | GET /billing/{balance,usage,prices} | Read-only window onto wallet state. Top-up stays manual via \`prism billing topup\` |

## Auth

Reuses \`research.py:_resolve_credentials\` pattern — \`MARC27_API_KEY\` env var with \`~/.prism/credentials.json\` access_token fallback. No new auth surface.

## Tests

9 new tests (\`tests/test_platform_status_tools.py\`):
- Registration shape (3 names, all \`requires_approval=False\`)
- \`policy_evaluate\` missing-action error
- All three return clean \"Not authenticated. Run \`prism login\`.\" hints when no creds
- \`billing_balance\` unknown-action validation
- \`billing_balance\` valid actions hit the correct endpoint URLs (mocked \`requests.get\`)

\`tests/\` is gitignored (project convention for in-tree tests); added with \`-f\` matching existing pattern (e.g. \`test_calphad_tools.py\`).

## Out of scope (later v2.7.x)

- \`/compute/{submit,estimate,providers,gpus,...}\` — managed GPU broker
- \`/knowledge/{embed, graph/ingest, graph/seed, research/web-search}\` — KG write paths
- \`/jobs\` generic submit/SSE
- \`/workflows\` platform runner
- \`/projects/{pid}/mcp-services\` + \`/agent/capabilities\` discovery

Each is its own follow-up tool family.

## Test plan

- [x] \`pytest tests/test_platform_status_tools.py\` — 9/9 pass
- [x] \`pytest tests/test_bootstrap.py\` — 13/13 pass (registration doesn't disturb existing tools)

🤖 Generated with [Claude Code](https://claude.com/claude-code)