### PR TITLE
fix(ci): read prism version dynamically from Cargo.toml (unblocks #96/#98/#99/#100)

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -144,7 +144,15 @@ jobs:
           grep -q "Fe" /tmp/graph.out
 
       - name: Test version flag
-        run: ./target/debug/prism --version 2>&1 | grep "prism 2.7.0"
+        # Read the expected version from the workspace Cargo.toml so this
+        # check stays correct across patch bumps. Hardcoding to a specific
+        # version (was `prism 2.7.0`) silently broke every PR after the
+        # next release tag.
+        run: |
+          expected=$(grep -E '^version = "[0-9]+\.[0-9]+\.[0-9]+"' Cargo.toml \
+            | head -1 | sed -E 's/version = "([^"]+)"/\1/')
+          echo "Expecting: prism $expected"
+          ./target/debug/prism --version 2>&1 | grep -F "prism $expected"
 
       - name: Test node probe
         run: |


### PR DESCRIPTION
## Summary

The Ingest Pipeline integration test had a hardcoded grep for \`prism 2.7.0\` in the \`--version\` output. The v2.7.1 tag bumped the workspace version, so every PR opened after that release fails this check with exit code 1.

Same root-cause shape as PR #91's LLM stale-tool-name bug — a string literal in code that didn't get updated when the source of truth (Cargo.toml workspace.version) moved.

## Change

\`.github/workflows/integration-test.yml\` step \"Test version flag\" now reads the version from \`Cargo.toml\` at test time:

\`\`\`yaml
expected=$(grep -E '^version = "[0-9]+\.[0-9]+\.[0-9]+"' Cargo.toml | head -1 | sed -E 's/version = "([^"]+)"/\1/')
echo "Expecting: prism $expected"
./target/debug/prism --version 2>&1 | grep -F "prism $expected"
\`\`\`

Stays correct across every future patch / minor bump without anyone touching this file.

## Unblocks

All four currently-stuck PRs were failing on this single check:
- #96 compact over-eviction
- #98 pre-flight compaction
- #99 Bug #33 verify_peer middleware
- #100 agent platform tools

## Test plan

- [x] Verified locally: \`grep -E '^version = "[0-9]+\.[0-9]+\.[0-9]+"' Cargo.toml | head -1 | sed -E 's/version = "([^"]+)"/\1/'\` returns \`2.7.1\`
- [ ] Watch this PR's own Ingest Pipeline run go green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI integration testing workflow to improve maintainability and version verification processes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Darth-Hidious/PRISM/pull/101)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->