### PR TITLE
feat(tools): close remaining 5 GAP-HIGH endpoint coverage gaps (8 tools)

### DIFF
--- a/app/plugins/bootstrap.py
+++ b/app/plugins/bootstrap.py
@@ -26,6 +26,11 @@ def build_full_registry(
     from app.tools.capabilities import create_capabilities_tools
     from app.tools.dataset import create_dataset_tool
     from app.tools.platform_status import create_platform_status_tools
+    from app.tools.agent_capabilities import create_agent_capabilities_tool
+    from app.tools.knowledge_write import create_knowledge_write_tool
+    from app.tools.platform_jobs import create_platform_jobs_tools
+    from app.tools.platform_workflows import create_platform_workflows_tools
+    from app.tools.mcp_services import create_mcp_services_tools
 
     registry = ToolRegistry()
     create_system_tools(registry)
@@ -41,6 +46,20 @@ def build_full_registry(
     # GAP-HIGH endpoints from the v2.7.2 endpoint-coverage audit. All
     # three are read-only — no approval gate.
     create_platform_status_tools(registry)
+    # Self-discovery: GET /agent/capabilities. Read-only.
+    create_agent_capabilities_tool(registry)
+    # Knowledge graph WRITE side (embed/seed/ingest/research-web-search).
+    # Closes the read/write asymmetry. Approval-gated as a single tool.
+    create_knowledge_write_tool(registry)
+    # Platform jobs — generic submit/SSE. Read+cancel in `platform_jobs`,
+    # money-spending submit isolated in `platform_jobs_submit`.
+    create_platform_jobs_tools(registry)
+    # Platform workflows runner. Read+cancel in `platform_workflows`,
+    # money-spending start + spec-register in `platform_workflows_run`.
+    create_platform_workflows_tools(registry)
+    # Platform-hosted MCP service discovery + invocation. Read in
+    # `mcp_services`, proxy/scale state-changes in `mcp_services_invoke`.
+    create_mcp_services_tools(registry)
     # Unified dataset tool — replaces VALIDATE_SKILL / REVIEW_SKILL /
     # VISUALIZE_SKILL Tool registrations. See app/tools/dataset.py.
     create_dataset_tool(registry)

--- a/app/tools/agent_capabilities.py
+++ b/app/tools/agent_capabilities.py
@@ -1,0 +1,118 @@
+"""agent_capabilities tool — wrapper over MARC27 platform self-discovery.
+
+Closes the `/agent/capabilities` GAP-HIGH item from the v2.7.2
+endpoint-coverage audit. One read-only tool, no approval gate.
+
+  - agent_capabilities  → GET /agent/capabilities
+                          (returns the platform's self-describing
+                           descriptor: route names, models, services,
+                           GraphQL schema hints, auth options, etc.)
+
+Auth path mirrors `platform_status.py` — `MARC27_API_KEY` env var or
+`~/.prism/credentials.json` access_token. The platform endpoint itself
+requires no auth (see marc27-core/.../agent_guide.rs), but we still
+attach the bearer token when one is present so the tool behaves
+identically to its sibling tools, and we surface a clean "Not
+authenticated" hint when no creds are configured at all.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import requests
+
+from app.tools.base import Tool, ToolRegistry
+
+
+# ---------------------------------------------------------------------------
+# Shared auth (mirror of platform_status.py:_resolve_credentials, kept
+# private here so each tool module can evolve its own auth handling later
+# if needed).
+# ---------------------------------------------------------------------------
+
+def _resolve_credentials() -> tuple[str, str]:
+    """Return (api_url, access_token) from env or `~/.prism/credentials.json`."""
+    api_url = os.environ.get(
+        "MARC27_API_URL", "https://api.marc27.com/api/v1"
+    ).rstrip("/")
+    api_key = os.environ.get("MARC27_API_KEY", "")
+
+    if not api_key:
+        try:
+            creds_path = Path.home() / ".prism" / "credentials.json"
+            if creds_path.exists():
+                creds = json.loads(creds_path.read_text())
+                api_key = creds.get("access_token", "")
+                if creds.get("platform_url"):
+                    api_url = creds["platform_url"].rstrip("/")
+                    if not api_url.endswith("/api/v1"):
+                        api_url = api_url + "/api/v1"
+        except Exception:
+            pass
+
+    return api_url, api_key
+
+
+def _get(path: str) -> dict:
+    """GET helper. Returns dict with 'error' on failure, parsed JSON otherwise."""
+    api_url, token = _resolve_credentials()
+    if not token:
+        return {
+            "error": "Not authenticated to the MARC27 platform.",
+            "hint": "Run `prism login` first, then retry.",
+        }
+    try:
+        resp = requests.get(
+            f"{api_url}{path}",
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=10,
+        )
+        if resp.status_code != 200:
+            return {
+                "error": f"platform returned HTTP {resp.status_code}",
+                "body": resp.text[:500],
+            }
+        return resp.json()
+    except requests.exceptions.RequestException as e:
+        return {"error": f"network error: {e}"}
+
+
+# ---------------------------------------------------------------------------
+# agent_capabilities
+# ---------------------------------------------------------------------------
+
+def _agent_capabilities(**_kwargs: Any) -> dict:
+    """Fetch the platform's self-discovery descriptor."""
+    return _get("/agent/capabilities")
+
+
+_AGENT_CAPABILITIES_DESCRIPTION = (
+    "Ask the MARC27 platform to describe itself. Returns a structured "
+    "self-discovery descriptor: which REST routes exist (grouped by "
+    "service), which auth methods are accepted, which GraphQL queries "
+    "and mutations are available, and CLI quick-start hints.\n"
+    "Use this when you need to discover whether a capability exists "
+    "before crafting a request — it's cheaper than guessing and "
+    "handling a 404. No arguments. Read-only; no approval gate."
+)
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+def create_agent_capabilities_tool(registry: ToolRegistry) -> None:
+    """Register the agent_capabilities self-discovery tool."""
+    registry.register(Tool(
+        name="agent_capabilities",
+        description=_AGENT_CAPABILITIES_DESCRIPTION,
+        input_schema={
+            "type": "object",
+            "properties": {},
+            "additionalProperties": False,
+        },
+        func=_agent_capabilities,
+    ))

--- a/app/tools/knowledge_write.py
+++ b/app/tools/knowledge_write.py
@@ -1,0 +1,433 @@
+"""Knowledge-write tools — wrap the MARC27 Knowledge Service WRITE endpoints.
+
+The agent already has READ access to the knowledge graph (`research`, the
+`/knowledge/graph/search`, `/graph/entity`, `/graph/paths`, `/graph/stats`
+GET routes). It had no way to *contribute* — embed text, batch-embed
+docs, seed the graph from CSV, ingest a structured doc, or call the
+platform's web-search service. This module closes that asymmetry.
+
+ONE dispatcher tool, five actions, mirroring `calphad_compute`:
+
+  • action='embed'             → POST /knowledge/embed
+  • action='embed_bulk'        → POST /knowledge/embed/bulk
+  • action='graph_seed'        → POST /knowledge/graph/seed
+  • action='graph_ingest'      → POST /knowledge/graph/ingest
+  • action='research_web_search' → POST /knowledge/research/web-search
+
+ALL of these mutate platform state and/or spend compute (embeddings cost
+money, web-search hits external academic APIs, graph writes are
+durable). The tool is `requires_approval=True` — the harness prompts
+once per call.
+
+Auth path mirrors `app/tools/research.py:_resolve_credentials` and
+`app/tools/platform_status.py:_resolve_credentials` — `MARC27_API_KEY`
+env var with `~/.prism/credentials.json` access_token fallback.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Optional
+
+import requests
+
+from app.tools.base import Tool, ToolRegistry
+
+
+# ---------------------------------------------------------------------------
+# Shared auth (mirror of platform_status.py:_resolve_credentials, kept
+# private here so each tool module can evolve its own auth handling later
+# if needed).
+# ---------------------------------------------------------------------------
+
+def _resolve_credentials() -> tuple[str, str]:
+    """Return (api_url, access_token) from env or `~/.prism/credentials.json`."""
+    api_url = os.environ.get(
+        "MARC27_API_URL", "https://api.marc27.com/api/v1"
+    ).rstrip("/")
+    api_key = os.environ.get("MARC27_API_KEY", "")
+
+    if not api_key:
+        try:
+            creds_path = Path.home() / ".prism" / "credentials.json"
+            if creds_path.exists():
+                creds = json.loads(creds_path.read_text())
+                api_key = creds.get("access_token", "")
+                if creds.get("platform_url"):
+                    api_url = creds["platform_url"].rstrip("/")
+                    if not api_url.endswith("/api/v1"):
+                        api_url = api_url + "/api/v1"
+        except Exception:
+            pass
+
+    return api_url, api_key
+
+
+def _get(path: str) -> dict:
+    """GET helper. Returns dict with 'error' on failure, parsed JSON otherwise."""
+    api_url, token = _resolve_credentials()
+    if not token:
+        return {
+            "error": "Not authenticated to the MARC27 platform.",
+            "hint": "Run `prism login` first, then retry.",
+        }
+    try:
+        resp = requests.get(
+            f"{api_url}{path}",
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=10,
+        )
+        if resp.status_code != 200:
+            return {
+                "error": f"platform returned HTTP {resp.status_code}",
+                "body": resp.text[:500],
+            }
+        return resp.json()
+    except requests.exceptions.RequestException as e:
+        return {"error": f"network error: {e}"}
+
+
+def _post(path: str, body: dict) -> dict:
+    api_url, token = _resolve_credentials()
+    if not token:
+        return {
+            "error": "Not authenticated to the MARC27 platform.",
+            "hint": "Run `prism login` first, then retry.",
+        }
+    try:
+        resp = requests.post(
+            f"{api_url}{path}",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+            },
+            json=body,
+            timeout=30,
+        )
+        if resp.status_code != 200:
+            return {
+                "error": f"platform returned HTTP {resp.status_code}",
+                "body": resp.text[:500],
+            }
+        return resp.json()
+    except requests.exceptions.RequestException as e:
+        return {"error": f"network error: {e}"}
+
+
+# ---------------------------------------------------------------------------
+# Per-action handlers
+# ---------------------------------------------------------------------------
+
+_VALID_ACTIONS = (
+    "embed",
+    "embed_bulk",
+    "graph_seed",
+    "graph_ingest",
+    "research_web_search",
+)
+
+
+def _do_embed(**kwargs: Any) -> dict:
+    """POST /knowledge/embed — embed a single text and store the vector.
+
+    Request body (per knowledge-service `EmbedRequest`):
+      doc_id   (required, str)
+      content  (required, str)
+      corpus_id (optional, uuid str)
+      metadata (optional, object)
+    """
+    doc_id = kwargs.get("doc_id")
+    content = kwargs.get("content")
+    if not doc_id:
+        return {"error": "Action 'embed' requires `doc_id`."}
+    if not content:
+        return {"error": "Action 'embed' requires `content`."}
+    body: dict = {"doc_id": doc_id, "content": content}
+    if kwargs.get("corpus_id"):
+        body["corpus_id"] = kwargs["corpus_id"]
+    if kwargs.get("metadata") is not None:
+        body["metadata"] = kwargs["metadata"]
+    return _post("/knowledge/embed", body)
+
+
+def _do_embed_bulk(**kwargs: Any) -> dict:
+    """POST /knowledge/embed/bulk — kick off background batch embedding.
+
+    Request body (per knowledge-service `BulkEmbedRequest`):
+      corpus_id  (required, uuid str)
+      documents  (required, list of {doc_id, content, metadata?})
+    """
+    corpus_id = kwargs.get("corpus_id")
+    documents = kwargs.get("documents")
+    if not corpus_id:
+        return {"error": "Action 'embed_bulk' requires `corpus_id`."}
+    if not documents or not isinstance(documents, list):
+        return {
+            "error": "Action 'embed_bulk' requires `documents` (non-empty list)."
+        }
+    body = {"corpus_id": corpus_id, "documents": documents}
+    return _post("/knowledge/embed/bulk", body)
+
+
+def _do_graph_seed(**kwargs: Any) -> dict:
+    """POST /knowledge/graph/seed — seed the graph from nodes/edges CSV URLs.
+
+    Admin-only on the server. The 403 surfaces here as an HTTP error.
+
+    Request body (per knowledge-service `SeedRequest`):
+      nodes_url  (required, str)
+      edges_url  (required, str)
+    """
+    nodes_url = kwargs.get("nodes_url")
+    edges_url = kwargs.get("edges_url")
+    if not nodes_url:
+        return {"error": "Action 'graph_seed' requires `nodes_url`."}
+    if not edges_url:
+        return {"error": "Action 'graph_seed' requires `edges_url`."}
+    return _post(
+        "/knowledge/graph/seed",
+        {"nodes_url": nodes_url, "edges_url": edges_url},
+    )
+
+
+def _do_graph_ingest(**kwargs: Any) -> dict:
+    """POST /knowledge/graph/ingest — ingest entities + relationships.
+
+    Request body (per `marc27_core::graph::ingest::GraphIngestInput`):
+      entities       (required, list of {name, entity_type, label, properties?})
+      relationships  (required, list of {from_name, to_name, rel_type, properties?})
+
+    Server overrides `tenant` from auth — caller does not need to set it.
+    """
+    entities = kwargs.get("entities")
+    relationships = kwargs.get("relationships")
+    if entities is None or not isinstance(entities, list):
+        return {"error": "Action 'graph_ingest' requires `entities` (list)."}
+    if relationships is None or not isinstance(relationships, list):
+        return {
+            "error": "Action 'graph_ingest' requires `relationships` (list, may be empty)."
+        }
+    return _post(
+        "/knowledge/graph/ingest",
+        {"entities": entities, "relationships": relationships},
+    )
+
+
+def _do_research_web_search(**kwargs: Any) -> dict:
+    """POST /knowledge/research/web-search — platform web-search across
+    Semantic Scholar / arXiv / PubMed / OpenAlex.
+
+    Request body (per knowledge-service `WebSearchQuery`):
+      query  (required, str)
+      limit  (optional, int — server default 5)
+    """
+    query = kwargs.get("query")
+    if not query:
+        return {"error": "Action 'research_web_search' requires `query`."}
+    body: dict = {"query": query}
+    if "limit" in kwargs and kwargs["limit"] is not None:
+        body["limit"] = kwargs["limit"]
+    return _post("/knowledge/research/web-search", body)
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher
+# ---------------------------------------------------------------------------
+
+_DISPATCH = {
+    "embed": _do_embed,
+    "embed_bulk": _do_embed_bulk,
+    "graph_seed": _do_graph_seed,
+    "graph_ingest": _do_graph_ingest,
+    "research_web_search": _do_research_web_search,
+}
+
+
+def _knowledge_write(**kwargs: Any) -> dict:
+    """Dispatch a knowledge-write action. Approval-gated upstream."""
+    action = kwargs.pop("action", None)
+    if not action:
+        return {
+            "error": (
+                "Missing 'action'. Valid: "
+                + ", ".join(_VALID_ACTIONS)
+            ),
+            "hint": (
+                "knowledge_write(action='embed', doc_id='...', content='...') / "
+                "knowledge_write(action='embed_bulk', corpus_id='...', documents=[...]) / "
+                "knowledge_write(action='graph_seed', nodes_url='...', edges_url='...') / "
+                "knowledge_write(action='graph_ingest', entities=[...], relationships=[...]) / "
+                "knowledge_write(action='research_web_search', query='...')"
+            ),
+        }
+    handler = _DISPATCH.get(action)
+    if handler is None:
+        return {
+            "error": (
+                f"Unknown action '{action}'. Valid: "
+                + ", ".join(_VALID_ACTIONS)
+            )
+        }
+    return handler(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Tool description + registration
+# ---------------------------------------------------------------------------
+
+_KNOWLEDGE_WRITE_DESCRIPTION = (
+    "WRITE side of the MARC27 Knowledge Service — closes the agent's "
+    "read/write asymmetry. Read paths live in the `research` tool and "
+    "the platform's GET endpoints. ONE tool, five actions. "
+    "MUTATING/COMPUTE-SPENDING — requires_approval=True; the harness "
+    "will prompt before each call.\n"
+    "  • action='embed' — embed a single text and store the vector. "
+    "Required: `doc_id`, `content`. Optional: `corpus_id` (uuid), "
+    "`metadata` (object).\n"
+    "  • action='embed_bulk' — kick off a background batch embed for a "
+    "whole corpus. Required: `corpus_id` (uuid), `documents` "
+    "(list of {doc_id, content, metadata?}). Returns immediately; "
+    "monitor via /embeddings/stats.\n"
+    "  • action='graph_seed' — admin-only. Seed the knowledge graph "
+    "from CSV files via presigned URLs. Required: `nodes_url`, "
+    "`edges_url`. Non-admins receive 403 from the server.\n"
+    "  • action='graph_ingest' — ingest a structured set of entities "
+    "and relationships into the graph. Required: `entities` "
+    "(list of {name, entity_type, label, properties?}), `relationships` "
+    "(list of {from_name, to_name, rel_type, properties?}). The server "
+    "overrides `tenant` from auth — do not set it client-side.\n"
+    "  • action='research_web_search' — query the platform's academic "
+    "web-search service (Semantic Scholar, arXiv, PubMed, OpenAlex). "
+    "Required: `query`. Optional: `limit` (server default 5). This is "
+    "the platform-hosted variant; the local `web` tool only does "
+    "single-page fetch."
+)
+
+
+def create_knowledge_write_tool(registry: ToolRegistry) -> None:
+    """Register the unified `knowledge_write` dispatcher tool.
+
+    Approval-gated like `calphad_compute` — every action either spends
+    compute (embeddings, web-search) or persists state to the graph.
+    """
+    registry.register(Tool(
+        name="knowledge_write",
+        description=_KNOWLEDGE_WRITE_DESCRIPTION,
+        input_schema={
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": list(_VALID_ACTIONS),
+                    "description": "Which knowledge-write operation to run.",
+                },
+                # embed / embed_bulk
+                "doc_id": {
+                    "type": "string",
+                    "description": "Document id for action='embed'. Required for 'embed'.",
+                },
+                "content": {
+                    "type": "string",
+                    "description": "Text to embed for action='embed'. Required for 'embed'.",
+                },
+                "corpus_id": {
+                    "type": "string",
+                    "description": (
+                        "Corpus UUID. Optional for action='embed', "
+                        "required for action='embed_bulk'."
+                    ),
+                },
+                "metadata": {
+                    "type": "object",
+                    "description": "Optional metadata object for action='embed'.",
+                    "additionalProperties": True,
+                },
+                "documents": {
+                    "type": "array",
+                    "description": (
+                        "Documents for action='embed_bulk', each "
+                        "{doc_id, content, metadata?}."
+                    ),
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "doc_id": {"type": "string"},
+                            "content": {"type": "string"},
+                            "metadata": {"type": "object", "additionalProperties": True},
+                        },
+                        "required": ["doc_id", "content"],
+                        "additionalProperties": True,
+                    },
+                },
+                # graph_seed
+                "nodes_url": {
+                    "type": "string",
+                    "description": "Nodes CSV URL for action='graph_seed'.",
+                },
+                "edges_url": {
+                    "type": "string",
+                    "description": "Edges CSV URL for action='graph_seed'.",
+                },
+                # graph_ingest
+                "entities": {
+                    "type": "array",
+                    "description": (
+                        "Entities for action='graph_ingest'. Each item: "
+                        "{name, entity_type, label, properties?}."
+                    ),
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "entity_type": {"type": "string"},
+                            "label": {"type": "string"},
+                            "properties": {
+                                "type": "object",
+                                "additionalProperties": {"type": "string"},
+                            },
+                        },
+                        "required": ["name", "entity_type", "label"],
+                        "additionalProperties": True,
+                    },
+                },
+                "relationships": {
+                    "type": "array",
+                    "description": (
+                        "Relationships for action='graph_ingest'. Each item: "
+                        "{from_name, to_name, rel_type, properties?}. May be empty."
+                    ),
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "from_name": {"type": "string"},
+                            "to_name": {"type": "string"},
+                            "rel_type": {"type": "string"},
+                            "properties": {
+                                "type": "object",
+                                "additionalProperties": {"type": "string"},
+                            },
+                        },
+                        "required": ["from_name", "to_name", "rel_type"],
+                        "additionalProperties": True,
+                    },
+                },
+                # research_web_search
+                "query": {
+                    "type": "string",
+                    "description": "Search query for action='research_web_search'.",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": (
+                        "Max results for action='research_web_search'. "
+                        "Server default 5."
+                    ),
+                },
+            },
+            "required": ["action"],
+            "additionalProperties": False,
+        },
+        func=_knowledge_write,
+        requires_approval=True,
+    ))

--- a/app/tools/mcp_services.py
+++ b/app/tools/mcp_services.py
@@ -1,0 +1,375 @@
+"""MCP-services tools — thin wrappers over MARC27 platform
+`/projects/{project_id}/mcp-services` endpoints.
+
+Closes the GAP-HIGH `/mcp-services` family from the v2.7.2
+endpoint-coverage audit. These endpoints expose platform-hosted MCP server
+instances (running in the platform, not locally) so agents can list them,
+proxy requests through them, and scale them up/down.
+
+Two tools, mirroring the compute / compute_submit and calphad /
+calphad_compute split:
+
+  - `mcp_services`        — list + get instance info. Read-only.
+                            No approval gate.
+                            Actions: 'list', 'get'.
+
+  - `mcp_services_invoke` — proxy a request through an instance, or scale
+                            an instance up/down. BOTH state-changing and
+                            potentially money-spending. requires_approval=True.
+                            Actions: 'proxy', 'scale'.
+
+`project_id` is required for all four actions. Default resolution order:
+  1. explicit `project_id` arg
+  2. `MARC27_PROJECT_ID` env var
+  3. `~/.prism/credentials.json` `project_id` field
+
+Endpoint coverage:
+  - GET  /projects/{project_id}/mcp-services
+       → mcp_services(action='list')
+  - GET  /projects/{project_id}/mcp-services/{instance_id}
+       → mcp_services(action='get')
+  - POST /projects/{project_id}/mcp-services/{instance_id}/proxy
+       → mcp_services_invoke(action='proxy')
+  - POST /projects/{project_id}/mcp-services/{instance_id}/scale
+       → mcp_services_invoke(action='scale')
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Optional
+
+import requests
+
+from app.tools.base import Tool, ToolRegistry
+
+
+# ---------------------------------------------------------------------------
+# Shared auth (mirror of platform_status.py:_resolve_credentials).
+# ---------------------------------------------------------------------------
+
+def _resolve_credentials() -> tuple[str, str]:
+    """Return (api_url, access_token) from env or `~/.prism/credentials.json`."""
+    api_url = os.environ.get(
+        "MARC27_API_URL", "https://api.marc27.com/api/v1"
+    ).rstrip("/")
+    api_key = os.environ.get("MARC27_API_KEY", "")
+
+    if not api_key:
+        try:
+            creds_path = Path.home() / ".prism" / "credentials.json"
+            if creds_path.exists():
+                creds = json.loads(creds_path.read_text())
+                api_key = creds.get("access_token", "")
+                if creds.get("platform_url"):
+                    api_url = creds["platform_url"].rstrip("/")
+                    if not api_url.endswith("/api/v1"):
+                        api_url = api_url + "/api/v1"
+        except Exception:
+            pass
+
+    return api_url, api_key
+
+
+def _resolve_project_id(explicit: Optional[str]) -> Optional[str]:
+    """Resolve project_id from arg → env → credentials.json. Returns None
+    if no source produces a value."""
+    if explicit:
+        return explicit
+    env_val = os.environ.get("MARC27_PROJECT_ID")
+    if env_val:
+        return env_val
+    try:
+        creds_path = Path.home() / ".prism" / "credentials.json"
+        if creds_path.exists():
+            creds = json.loads(creds_path.read_text())
+            pid = creds.get("project_id")
+            if pid:
+                return pid
+    except Exception:
+        pass
+    return None
+
+
+def _get(path: str) -> dict:
+    """GET helper. Returns dict with 'error' on failure, parsed JSON otherwise."""
+    api_url, token = _resolve_credentials()
+    if not token:
+        return {
+            "error": "Not authenticated to the MARC27 platform.",
+            "hint": "Run `prism login` first, then retry.",
+        }
+    try:
+        resp = requests.get(
+            f"{api_url}{path}",
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=10,
+        )
+        if resp.status_code != 200:
+            return {
+                "error": f"platform returned HTTP {resp.status_code}",
+                "body": resp.text[:500],
+            }
+        return resp.json()
+    except requests.exceptions.RequestException as e:
+        return {"error": f"network error: {e}"}
+
+
+def _post(path: str, body: dict) -> dict:
+    api_url, token = _resolve_credentials()
+    if not token:
+        return {
+            "error": "Not authenticated to the MARC27 platform.",
+            "hint": "Run `prism login` first, then retry.",
+        }
+    try:
+        resp = requests.post(
+            f"{api_url}{path}",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+            },
+            json=body,
+            # Proxy requests can ride a 60s upstream timeout; give the
+            # platform some headroom over that.
+            timeout=75,
+        )
+        if resp.status_code not in (200, 201):
+            return {
+                "error": f"platform returned HTTP {resp.status_code}",
+                "body": resp.text[:500],
+            }
+        return resp.json()
+    except requests.exceptions.RequestException as e:
+        return {"error": f"network error: {e}"}
+
+
+# ---------------------------------------------------------------------------
+# Read-only dispatcher
+# ---------------------------------------------------------------------------
+
+def _mcp_services(**kwargs: Any) -> dict:
+    """Read-only dispatcher. No approval gate.
+
+    Actions:
+      • list — GET /projects/{project_id}/mcp-services
+      • get  — GET /projects/{project_id}/mcp-services/{instance_id}
+    """
+    action = kwargs.pop("action", None)
+    if not action:
+        return {
+            "error": "Missing 'action'. Valid: list, get",
+            "hint": (
+                "mcp_services(action='list') / "
+                "mcp_services(action='get', instance_id='...')"
+            ),
+        }
+
+    project_id = _resolve_project_id(kwargs.get("project_id"))
+    if not project_id:
+        return {
+            "error": "No `project_id` resolved.",
+            "hint": (
+                "Pass project_id=… explicitly, set MARC27_PROJECT_ID env var, "
+                "or run `prism login` so ~/.prism/credentials.json carries it."
+            ),
+        }
+
+    if action == "list":
+        return _get(f"/projects/{project_id}/mcp-services")
+    if action == "get":
+        instance_id = kwargs.get("instance_id")
+        if not instance_id:
+            return {"error": "Action 'get' requires `instance_id`"}
+        return _get(f"/projects/{project_id}/mcp-services/{instance_id}")
+    return {"error": f"Unknown action '{action}'. Valid: list, get"}
+
+
+# ---------------------------------------------------------------------------
+# Approval-gated dispatcher
+# ---------------------------------------------------------------------------
+
+def _mcp_services_invoke(**kwargs: Any) -> dict:
+    """Approval-gated dispatcher.
+
+    Actions:
+      • proxy — POST /projects/{project_id}/mcp-services/{instance_id}/proxy
+      • scale — POST /projects/{project_id}/mcp-services/{instance_id}/scale
+    """
+    action = kwargs.pop("action", None)
+    if not action:
+        return {
+            "error": "Missing 'action'. Valid: proxy, scale",
+            "hint": (
+                "mcp_services_invoke(action='proxy', instance_id='...', path='/...') / "
+                "mcp_services_invoke(action='scale', instance_id='...', replicas=0|1)"
+            ),
+        }
+
+    project_id = _resolve_project_id(kwargs.get("project_id"))
+    if not project_id:
+        return {
+            "error": "No `project_id` resolved.",
+            "hint": (
+                "Pass project_id=… explicitly, set MARC27_PROJECT_ID env var, "
+                "or run `prism login` so ~/.prism/credentials.json carries it."
+            ),
+        }
+
+    instance_id = kwargs.get("instance_id")
+    if not instance_id:
+        return {"error": f"Action '{action}' requires `instance_id`"}
+
+    if action == "proxy":
+        path = kwargs.get("path")
+        if not path:
+            return {"error": "Action 'proxy' requires `path` (upstream URL path)"}
+        body: dict = {"path": path}
+        if kwargs.get("method"):
+            body["method"] = kwargs["method"]
+        if kwargs.get("body") is not None:
+            body["body"] = kwargs["body"]
+        if kwargs.get("headers") is not None:
+            body["headers"] = kwargs["headers"]
+        return _post(
+            f"/projects/{project_id}/mcp-services/{instance_id}/proxy",
+            body,
+        )
+
+    if action == "scale":
+        if "replicas" not in kwargs:
+            return {"error": "Action 'scale' requires `replicas` (0 or 1)"}
+        try:
+            replicas = int(kwargs["replicas"])
+        except (TypeError, ValueError):
+            return {"error": "`replicas` must be an integer (0 or 1)"}
+        if replicas not in (0, 1):
+            return {
+                "error": f"`replicas` must be 0 or 1 (got {replicas}); v1 does not support >1.",
+            }
+        return _post(
+            f"/projects/{project_id}/mcp-services/{instance_id}/scale",
+            {"replicas": replicas},
+        )
+
+    return {"error": f"Unknown action '{action}'. Valid: proxy, scale"}
+
+
+# ---------------------------------------------------------------------------
+# Tool descriptions
+# ---------------------------------------------------------------------------
+
+_MCP_SERVICES_DESCRIPTION = (
+    "Read MARC27 platform-hosted MCP service instances (Model Context "
+    "Protocol servers running in the platform, not locally). Read-only "
+    "— NO approval gate. ONE tool, two actions:\n"
+    "  • action='list' — list all MCP service instances for the active "
+    "project. Returns id, status, endpoint_url, health info per instance.\n"
+    "  • action='get' — fetch a single instance with current health. "
+    "Required: `instance_id`.\n"
+    "`project_id` is auto-resolved (env MARC27_PROJECT_ID or "
+    "~/.prism/credentials.json) but can be overridden explicitly.\n"
+    "To PROXY a request through an instance or SCALE it, use the separate "
+    "`mcp_services_invoke` tool — that one is approval-gated because "
+    "proxying executes upstream actions and scaling toggles compute usage."
+)
+
+
+_MCP_SERVICES_INVOKE_DESCRIPTION = (
+    "Invoke or scale a MARC27 platform-hosted MCP service instance. "
+    "BOTH actions are state-changing — proxying executes an upstream "
+    "request, scaling toggles compute. requires_approval=True; the "
+    "harness will prompt before each call.\n"
+    "  • action='proxy' — forward an HTTP request to the instance's "
+    "endpoint. Required: `instance_id`, `path` (upstream URL path). "
+    "Optional: `method` (default 'POST'), `body` (JSON), `headers` "
+    "(dict). Returns `{status_code, body, headers}` from the upstream.\n"
+    "  • action='scale' — set instance replica count. Required: "
+    "`instance_id`, `replicas` (0 or 1). v1 does NOT support >1 "
+    "replicas. Use replicas=0 to stop an instance, replicas=1 to start.\n"
+    "Use `mcp_services(action='list')` first to discover instance IDs."
+)
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+def create_mcp_services_tools(registry: ToolRegistry) -> None:
+    """Register the `mcp_services` (read) + `mcp_services_invoke`
+    (proxy + scale) tools."""
+    registry.register(Tool(
+        name="mcp_services",
+        description=_MCP_SERVICES_DESCRIPTION,
+        input_schema={
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["list", "get"],
+                    "description": "Which read operation.",
+                },
+                "project_id": {
+                    "type": "string",
+                    "description": "Optional project UUID. Defaults to env or credentials.json.",
+                },
+                "instance_id": {
+                    "type": "string",
+                    "description": "MCP service instance UUID. Required for action='get'.",
+                },
+            },
+            "required": ["action"],
+            "additionalProperties": False,
+        },
+        func=_mcp_services,
+    ))
+
+    registry.register(Tool(
+        name="mcp_services_invoke",
+        description=_MCP_SERVICES_INVOKE_DESCRIPTION,
+        input_schema={
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["proxy", "scale"],
+                    "description": "Proxy a request or scale the instance.",
+                },
+                "project_id": {
+                    "type": "string",
+                    "description": "Optional project UUID. Defaults to env or credentials.json.",
+                },
+                "instance_id": {
+                    "type": "string",
+                    "description": "MCP service instance UUID. Required.",
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Upstream URL path for action='proxy'.",
+                },
+                "method": {
+                    "type": "string",
+                    "description": "HTTP method for action='proxy'. Default 'POST'.",
+                },
+                "body": {
+                    "type": "object",
+                    "description": "JSON request body for action='proxy'.",
+                    "additionalProperties": True,
+                },
+                "headers": {
+                    "type": "object",
+                    "description": "Extra HTTP headers for action='proxy'.",
+                    "additionalProperties": {"type": "string"},
+                },
+                "replicas": {
+                    "type": "integer",
+                    "description": "Replica count (0 or 1) for action='scale'.",
+                },
+            },
+            "required": ["action", "instance_id"],
+            "additionalProperties": False,
+        },
+        func=_mcp_services_invoke,
+        requires_approval=True,
+    ))

--- a/app/tools/platform_jobs.py
+++ b/app/tools/platform_jobs.py
@@ -1,0 +1,367 @@
+"""Platform-jobs tools — thin wrappers over MARC27 platform `/jobs` endpoints.
+
+Closes the GAP-HIGH `/jobs` family from the v2.7.2 endpoint-coverage audit.
+
+Two tools, mirroring the compute / compute_submit and calphad /
+calphad_compute split:
+
+  - `platform_jobs`        — read + cancel + events. NOT money-spending.
+                             No approval gate.
+                             Actions: 'status', 'cancel', 'events'.
+
+  - `platform_jobs_submit` — submit a new job. MONEY-SPENDING.
+                             requires_approval=True.
+
+Auth path mirrors `app/tools/platform_status.py` exactly: `MARC27_API_KEY`
+env var with `~/.prism/credentials.json` access_token fallback.
+
+Endpoint coverage:
+  - POST /jobs                  → platform_jobs_submit
+  - GET  /jobs/{id}             → platform_jobs(action='status')
+  - POST /jobs/{id}/cancel      → platform_jobs(action='cancel')
+  - GET  /jobs/{id}/events      → platform_jobs(action='events')  (SSE)
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Optional
+
+import requests
+
+from app.tools.base import Tool, ToolRegistry
+
+
+# ---------------------------------------------------------------------------
+# Shared auth (mirror of platform_status.py:_resolve_credentials, kept private
+# here so each tool module can evolve its own auth handling later if needed).
+# ---------------------------------------------------------------------------
+
+def _resolve_credentials() -> tuple[str, str]:
+    """Return (api_url, access_token) from env or `~/.prism/credentials.json`."""
+    api_url = os.environ.get(
+        "MARC27_API_URL", "https://api.marc27.com/api/v1"
+    ).rstrip("/")
+    api_key = os.environ.get("MARC27_API_KEY", "")
+
+    if not api_key:
+        try:
+            creds_path = Path.home() / ".prism" / "credentials.json"
+            if creds_path.exists():
+                creds = json.loads(creds_path.read_text())
+                api_key = creds.get("access_token", "")
+                if creds.get("platform_url"):
+                    api_url = creds["platform_url"].rstrip("/")
+                    if not api_url.endswith("/api/v1"):
+                        api_url = api_url + "/api/v1"
+        except Exception:
+            pass
+
+    return api_url, api_key
+
+
+def _get(path: str) -> dict:
+    """GET helper. Returns dict with 'error' on failure, parsed JSON otherwise."""
+    api_url, token = _resolve_credentials()
+    if not token:
+        return {
+            "error": "Not authenticated to the MARC27 platform.",
+            "hint": "Run `prism login` first, then retry.",
+        }
+    try:
+        resp = requests.get(
+            f"{api_url}{path}",
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=10,
+        )
+        if resp.status_code != 200:
+            return {
+                "error": f"platform returned HTTP {resp.status_code}",
+                "body": resp.text[:500],
+            }
+        return resp.json()
+    except requests.exceptions.RequestException as e:
+        return {"error": f"network error: {e}"}
+
+
+def _post(path: str, body: dict) -> dict:
+    api_url, token = _resolve_credentials()
+    if not token:
+        return {
+            "error": "Not authenticated to the MARC27 platform.",
+            "hint": "Run `prism login` first, then retry.",
+        }
+    try:
+        resp = requests.post(
+            f"{api_url}{path}",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+            },
+            json=body,
+            timeout=15,
+        )
+        # /jobs returns 201 Created on success; cancel returns 200.
+        if resp.status_code not in (200, 201):
+            return {
+                "error": f"platform returned HTTP {resp.status_code}",
+                "body": resp.text[:500],
+            }
+        return resp.json()
+    except requests.exceptions.RequestException as e:
+        return {"error": f"network error: {e}"}
+
+
+def _get_sse(path: str, max_events: int = 10, read_timeout: int = 30) -> dict:
+    """Read up to `max_events` SSE frames from a streaming endpoint, then return.
+
+    Used for `GET /jobs/{id}/events`. The platform stream stays open for the
+    job's lifetime; the agent doesn't want to block forever, so we cap
+    at N events or `read_timeout` seconds, whichever comes first.
+    """
+    api_url, token = _resolve_credentials()
+    if not token:
+        return {
+            "error": "Not authenticated to the MARC27 platform.",
+            "hint": "Run `prism login` first, then retry.",
+        }
+    try:
+        resp = requests.get(
+            f"{api_url}{path}",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "text/event-stream",
+            },
+            stream=True,
+            timeout=(10, read_timeout),
+        )
+        if resp.status_code != 200:
+            return {
+                "error": f"platform returned HTTP {resp.status_code}",
+                "body": resp.text[:500],
+            }
+
+        events: list[dict] = []
+        current_event: dict[str, str] = {}
+        for raw in resp.iter_lines(decode_unicode=True):
+            if raw is None:
+                continue
+            line = raw.strip("\r")
+            if line == "":
+                # blank line = dispatch event
+                if current_event:
+                    events.append(dict(current_event))
+                    current_event = {}
+                    if len(events) >= max_events:
+                        break
+                continue
+            if line.startswith(":"):
+                # comment / keep-alive — ignore
+                continue
+            if ":" in line:
+                field, _, value = line.partition(":")
+                value = value.lstrip(" ")
+                if field == "data":
+                    # try JSON, fall back to raw text
+                    try:
+                        current_event["data"] = json.loads(value)
+                    except (ValueError, TypeError):
+                        current_event["data"] = value
+                elif field == "event":
+                    current_event["event"] = value
+                elif field == "id":
+                    current_event["id"] = value
+        # close the stream cleanly so the connection isn't leaked
+        try:
+            resp.close()
+        except Exception:
+            pass
+        return {"events": events, "count": len(events)}
+    except requests.exceptions.RequestException as e:
+        return {"error": f"network error: {e}"}
+
+
+# ---------------------------------------------------------------------------
+# Read-only / cancel dispatcher
+# ---------------------------------------------------------------------------
+
+def _platform_jobs(**kwargs: Any) -> dict:
+    """Read/cancel dispatcher. No approval gate.
+
+    Actions:
+      • status — GET  /jobs/{id}
+      • cancel — POST /jobs/{id}/cancel
+      • events — GET  /jobs/{id}/events  (SSE; reads up to `max_events`)
+    """
+    action = kwargs.pop("action", None)
+    if not action:
+        return {
+            "error": "Missing 'action'. Valid: status, cancel, events",
+            "hint": (
+                "platform_jobs(action='status', job_id='...') / "
+                "platform_jobs(action='cancel', job_id='...') / "
+                "platform_jobs(action='events', job_id='...', max_events=10)"
+            ),
+        }
+
+    job_id = kwargs.get("job_id")
+    if not job_id:
+        return {"error": f"Action '{action}' requires `job_id`"}
+
+    if action == "status":
+        return _get(f"/jobs/{job_id}")
+    if action == "cancel":
+        return _post(f"/jobs/{job_id}/cancel", {})
+    if action == "events":
+        max_events = int(kwargs.get("max_events", 10))
+        read_timeout = int(kwargs.get("read_timeout", 30))
+        return _get_sse(
+            f"/jobs/{job_id}/events",
+            max_events=max_events,
+            read_timeout=read_timeout,
+        )
+    return {"error": f"Unknown action '{action}'. Valid: status, cancel, events"}
+
+
+# ---------------------------------------------------------------------------
+# Submit (approval-gated)
+# ---------------------------------------------------------------------------
+
+def _platform_jobs_submit(**kwargs: Any) -> dict:
+    """Submit a new job. Money-spending — approval-gated."""
+    job_type = kwargs.get("job_type")
+    project_id = kwargs.get("project_id")
+    payload = kwargs.get("payload")
+
+    if not job_type:
+        return {"error": "Missing required argument `job_type`."}
+    if not project_id:
+        return {"error": "Missing required argument `project_id`."}
+    if payload is None:
+        return {"error": "Missing required argument `payload`."}
+
+    body: dict = {
+        "job_type": job_type,
+        "project_id": project_id,
+        "payload": payload,
+    }
+    if kwargs.get("resource_id"):
+        body["resource_id"] = kwargs["resource_id"]
+    if "priority" in kwargs:
+        body["priority"] = int(kwargs["priority"])
+    return _post("/jobs", body)
+
+
+# ---------------------------------------------------------------------------
+# Tool descriptions
+# ---------------------------------------------------------------------------
+
+_PLATFORM_JOBS_DESCRIPTION = (
+    "Read/cancel MARC27 platform jobs. Read-only and cancel — NOT "
+    "money-spending. ONE tool, three actions:\n"
+    "  • action='status' — fetch job state. Required: `job_id`.\n"
+    "  • action='cancel' — cancel a running or queued job. Required: "
+    "`job_id`. Idempotent (cancelling a finished job is a no-op).\n"
+    "  • action='events' — read live SSE events for the job. Required: "
+    "`job_id`. Optional: `max_events` (default 10), `read_timeout` "
+    "seconds (default 30). Returns up to N events then closes the "
+    "stream — does NOT block forever.\n"
+    "To submit a NEW job, use the separate `platform_jobs_submit` tool — "
+    "that one is approval-gated because it spends compute budget."
+)
+
+
+_PLATFORM_JOBS_SUBMIT_DESCRIPTION = (
+    "Submit a new job to the MARC27 platform. MONEY/COMPUTE-SPENDING — "
+    "requires_approval=True; the harness will prompt before each call.\n"
+    "Required:\n"
+    "  • job_type — backend job type slug (e.g. 'compute.simulation', "
+    "'embedding.batch'; see platform docs).\n"
+    "  • project_id — UUID of the project to bill the job against.\n"
+    "  • payload — opaque JSON dict the backend job worker consumes.\n"
+    "Optional:\n"
+    "  • resource_id — UUID of a specific resource (GPU SKU, dataset, "
+    "container image) to enforce per-resource quotas against.\n"
+    "  • priority — int16, default 0. Higher = sooner.\n"
+    "Returns the created `JobRow` (id, status, etc). Use "
+    "`platform_jobs(action='status', job_id=...)` to poll progress, "
+    "or `platform_jobs(action='events', job_id=...)` for live updates."
+)
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+def create_platform_jobs_tools(registry: ToolRegistry) -> None:
+    """Register the unified `platform_jobs` (read/cancel) + `platform_jobs_submit`
+    tools.
+
+    The split mirrors compute / compute_submit and calphad / calphad_compute:
+    money-spending actions stay isolated for per-tool approval gating.
+    """
+    registry.register(Tool(
+        name="platform_jobs",
+        description=_PLATFORM_JOBS_DESCRIPTION,
+        input_schema={
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["status", "cancel", "events"],
+                    "description": "Which read/cancel operation.",
+                },
+                "job_id": {
+                    "type": "string",
+                    "description": "Job UUID. Required for all actions.",
+                },
+                "max_events": {
+                    "type": "integer",
+                    "description": "Max SSE events to read for action='events'. Default 10.",
+                },
+                "read_timeout": {
+                    "type": "integer",
+                    "description": "SSE read timeout (seconds) for action='events'. Default 30.",
+                },
+            },
+            "required": ["action", "job_id"],
+            "additionalProperties": False,
+        },
+        func=_platform_jobs,
+    ))
+
+    registry.register(Tool(
+        name="platform_jobs_submit",
+        description=_PLATFORM_JOBS_SUBMIT_DESCRIPTION,
+        input_schema={
+            "type": "object",
+            "properties": {
+                "job_type": {
+                    "type": "string",
+                    "description": "Backend job type slug.",
+                },
+                "project_id": {
+                    "type": "string",
+                    "description": "Project UUID to bill against.",
+                },
+                "payload": {
+                    "type": "object",
+                    "description": "Job-type-specific JSON payload.",
+                    "additionalProperties": True,
+                },
+                "resource_id": {
+                    "type": "string",
+                    "description": "Optional resource UUID for quota enforcement.",
+                },
+                "priority": {
+                    "type": "integer",
+                    "description": "Priority int16. Default 0.",
+                },
+            },
+            "required": ["job_type", "project_id", "payload"],
+            "additionalProperties": False,
+        },
+        func=_platform_jobs_submit,
+        requires_approval=True,
+    ))

--- a/app/tools/platform_workflows.py
+++ b/app/tools/platform_workflows.py
@@ -1,0 +1,323 @@
+"""Platform-workflows tools — thin wrappers over MARC27 platform `/workflows`
+endpoints.
+
+Closes the GAP-HIGH `/workflows` family from the v2.7.2 endpoint-coverage audit.
+
+Two tools, mirroring the compute / compute_submit and calphad /
+calphad_compute split:
+
+  - `platform_workflows`     — list + list_specs + status + cancel.
+                               NOT money-spending. No approval gate.
+                               Actions: 'list', 'list_specs', 'status',
+                               'cancel'.
+
+  - `platform_workflows_run` — start a workflow + register a new spec.
+                               BOTH state-changing; `start` actually
+                               spends compute budget. requires_approval=True.
+                               Actions: 'start', 'register_spec'.
+
+Endpoint coverage:
+  - GET  /workflows          → platform_workflows(action='list')
+  - GET  /workflows/specs    → platform_workflows(action='list_specs')
+  - POST /workflows/specs    → platform_workflows_run(action='register_spec')
+  - POST /workflows          → platform_workflows_run(action='start')
+  - GET  /workflows/{id}     → platform_workflows(action='status')
+  - POST /workflows/{id}/cancel → platform_workflows(action='cancel')
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Optional
+
+import requests
+
+from app.tools.base import Tool, ToolRegistry
+
+
+# ---------------------------------------------------------------------------
+# Shared auth (mirror of platform_status.py:_resolve_credentials).
+# ---------------------------------------------------------------------------
+
+def _resolve_credentials() -> tuple[str, str]:
+    """Return (api_url, access_token) from env or `~/.prism/credentials.json`."""
+    api_url = os.environ.get(
+        "MARC27_API_URL", "https://api.marc27.com/api/v1"
+    ).rstrip("/")
+    api_key = os.environ.get("MARC27_API_KEY", "")
+
+    if not api_key:
+        try:
+            creds_path = Path.home() / ".prism" / "credentials.json"
+            if creds_path.exists():
+                creds = json.loads(creds_path.read_text())
+                api_key = creds.get("access_token", "")
+                if creds.get("platform_url"):
+                    api_url = creds["platform_url"].rstrip("/")
+                    if not api_url.endswith("/api/v1"):
+                        api_url = api_url + "/api/v1"
+        except Exception:
+            pass
+
+    return api_url, api_key
+
+
+def _get(path: str) -> dict:
+    """GET helper. Returns dict with 'error' on failure, parsed JSON otherwise."""
+    api_url, token = _resolve_credentials()
+    if not token:
+        return {
+            "error": "Not authenticated to the MARC27 platform.",
+            "hint": "Run `prism login` first, then retry.",
+        }
+    try:
+        resp = requests.get(
+            f"{api_url}{path}",
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=10,
+        )
+        if resp.status_code != 200:
+            return {
+                "error": f"platform returned HTTP {resp.status_code}",
+                "body": resp.text[:500],
+            }
+        return resp.json()
+    except requests.exceptions.RequestException as e:
+        return {"error": f"network error: {e}"}
+
+
+def _post(path: str, body: dict) -> dict:
+    api_url, token = _resolve_credentials()
+    if not token:
+        return {
+            "error": "Not authenticated to the MARC27 platform.",
+            "hint": "Run `prism login` first, then retry.",
+        }
+    try:
+        resp = requests.post(
+            f"{api_url}{path}",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+            },
+            json=body,
+            timeout=15,
+        )
+        # /workflows/* return 202 Accepted (start), 201 Created (spec),
+        # 204 No Content (cancel), or 200 OK depending on action.
+        if resp.status_code not in (200, 201, 202, 204):
+            return {
+                "error": f"platform returned HTTP {resp.status_code}",
+                "body": resp.text[:500],
+            }
+        if resp.status_code == 204 or not resp.content:
+            return {"status": "ok", "http_status": resp.status_code}
+        try:
+            return resp.json()
+        except ValueError:
+            return {"status": "ok", "http_status": resp.status_code, "body": resp.text[:500]}
+    except requests.exceptions.RequestException as e:
+        return {"error": f"network error: {e}"}
+
+
+# ---------------------------------------------------------------------------
+# Read / cancel dispatcher
+# ---------------------------------------------------------------------------
+
+def _platform_workflows(**kwargs: Any) -> dict:
+    """Read/cancel dispatcher. No approval gate.
+
+    Actions:
+      • list       — GET /workflows                (instances)
+      • list_specs — GET /workflows/specs          (registered spec catalog)
+      • status     — GET /workflows/{id}           (single instance)
+      • cancel     — POST /workflows/{id}/cancel
+    """
+    action = kwargs.pop("action", None)
+    if not action:
+        return {
+            "error": "Missing 'action'. Valid: list, list_specs, status, cancel",
+            "hint": (
+                "platform_workflows(action='list') / "
+                "platform_workflows(action='list_specs') / "
+                "platform_workflows(action='status', workflow_id='...') / "
+                "platform_workflows(action='cancel', workflow_id='...')"
+            ),
+        }
+
+    if action == "list":
+        return _get("/workflows")
+    if action == "list_specs":
+        return _get("/workflows/specs")
+    if action == "status":
+        workflow_id = kwargs.get("workflow_id")
+        if not workflow_id:
+            return {"error": "Action 'status' requires `workflow_id`"}
+        return _get(f"/workflows/{workflow_id}")
+    if action == "cancel":
+        workflow_id = kwargs.get("workflow_id")
+        if not workflow_id:
+            return {"error": "Action 'cancel' requires `workflow_id`"}
+        return _post(f"/workflows/{workflow_id}/cancel", {})
+    return {
+        "error": f"Unknown action '{action}'. Valid: list, list_specs, status, cancel"
+    }
+
+
+# ---------------------------------------------------------------------------
+# Run / register_spec dispatcher (approval-gated)
+# ---------------------------------------------------------------------------
+
+def _platform_workflows_run(**kwargs: Any) -> dict:
+    """Approval-gated dispatcher.
+
+    Actions:
+      • start         — POST /workflows
+      • register_spec — POST /workflows/specs
+    """
+    action = kwargs.pop("action", None)
+    if not action:
+        return {
+            "error": "Missing 'action'. Valid: start, register_spec",
+            "hint": (
+                "platform_workflows_run(action='start', spec='...', inputs={...}) / "
+                "platform_workflows_run(action='register_spec', spec_yaml='...')"
+            ),
+        }
+
+    if action == "start":
+        spec = kwargs.get("spec")
+        if not spec:
+            return {"error": "Action 'start' requires `spec` (slug or UUID)"}
+        body: dict = {"spec": spec}
+        if kwargs.get("inputs") is not None:
+            body["inputs"] = kwargs["inputs"]
+        if kwargs.get("project_id"):
+            body["project_id"] = kwargs["project_id"]
+        return _post("/workflows", body)
+
+    if action == "register_spec":
+        spec_yaml = kwargs.get("spec_yaml")
+        if not spec_yaml:
+            return {"error": "Action 'register_spec' requires `spec_yaml`"}
+        body = {"spec_yaml": spec_yaml}
+        if kwargs.get("access"):
+            body["access"] = kwargs["access"]
+        if kwargs.get("org_id"):
+            body["org_id"] = kwargs["org_id"]
+        return _post("/workflows/specs", body)
+
+    return {"error": f"Unknown action '{action}'. Valid: start, register_spec"}
+
+
+# ---------------------------------------------------------------------------
+# Tool descriptions
+# ---------------------------------------------------------------------------
+
+_PLATFORM_WORKFLOWS_DESCRIPTION = (
+    "Read/cancel MARC27 platform workflows. Read-only and cancel — NOT "
+    "money-spending. ONE tool, four actions:\n"
+    "  • action='list' — list the user's workflow instances.\n"
+    "  • action='list_specs' — list available workflow specs (org + public + "
+    "marketplace) the user can run.\n"
+    "  • action='status' — fetch a single workflow instance state. Required: "
+    "`workflow_id`.\n"
+    "  • action='cancel' — cancel a running or queued workflow. Required: "
+    "`workflow_id`. Idempotent.\n"
+    "To START a workflow or REGISTER a new spec, use the separate "
+    "`platform_workflows_run` tool — that one is approval-gated because "
+    "starting a workflow spends compute budget and registering a spec "
+    "publishes content."
+)
+
+
+_PLATFORM_WORKFLOWS_RUN_DESCRIPTION = (
+    "Start a workflow or register a new workflow spec. BOTH actions are "
+    "state-changing; `start` actually spends compute budget. "
+    "requires_approval=True; the harness will prompt before each call.\n"
+    "  • action='start' — kick off a workflow run. Required: `spec` "
+    "(slug or UUID). Optional: `inputs` (dict of input bindings), "
+    "`project_id` (UUID, scopes the run + billing).\n"
+    "  • action='register_spec' — publish a new YAML workflow spec. "
+    "Required: `spec_yaml` (the raw YAML text). Optional: `access` "
+    "('public', 'org', 'private'; default 'private'), `org_id` (UUID, "
+    "required if access='org').\n"
+    "Use `platform_workflows(action='list_specs')` first to discover "
+    "what's already published before running or registering."
+)
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+def create_platform_workflows_tools(registry: ToolRegistry) -> None:
+    """Register the `platform_workflows` (read/cancel) +
+    `platform_workflows_run` (start + register_spec) tools."""
+    registry.register(Tool(
+        name="platform_workflows",
+        description=_PLATFORM_WORKFLOWS_DESCRIPTION,
+        input_schema={
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["list", "list_specs", "status", "cancel"],
+                    "description": "Which workflow read/cancel operation.",
+                },
+                "workflow_id": {
+                    "type": "string",
+                    "description": "Workflow instance UUID. Required for status/cancel.",
+                },
+            },
+            "required": ["action"],
+            "additionalProperties": False,
+        },
+        func=_platform_workflows,
+    ))
+
+    registry.register(Tool(
+        name="platform_workflows_run",
+        description=_PLATFORM_WORKFLOWS_RUN_DESCRIPTION,
+        input_schema={
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["start", "register_spec"],
+                    "description": "Start a workflow or register a new spec.",
+                },
+                "spec": {
+                    "type": "string",
+                    "description": "Spec slug or UUID. Required for action='start'.",
+                },
+                "inputs": {
+                    "type": "object",
+                    "description": "Input bindings for action='start'.",
+                    "additionalProperties": True,
+                },
+                "project_id": {
+                    "type": "string",
+                    "description": "Project UUID for action='start'.",
+                },
+                "spec_yaml": {
+                    "type": "string",
+                    "description": "Raw YAML spec text. Required for action='register_spec'.",
+                },
+                "access": {
+                    "type": "string",
+                    "enum": ["public", "org", "private"],
+                    "description": "Visibility for action='register_spec'. Default 'private'.",
+                },
+                "org_id": {
+                    "type": "string",
+                    "description": "Org UUID for action='register_spec' with access='org'.",
+                },
+            },
+            "required": ["action"],
+            "additionalProperties": False,
+        },
+        func=_platform_workflows_run,
+        requires_approval=True,
+    ))

--- a/tests/test_agent_capabilities_tool.py
+++ b/tests/test_agent_capabilities_tool.py
@@ -1,0 +1,80 @@
+"""Tests for agent_capabilities tool.
+
+Wraps the MARC27 platform's GET /agent/capabilities self-discovery
+endpoint. Tests verify registration shape + clean failure when no
+auth is configured + that the dispatcher hits the right URL when
+credentials are present (network mocked at the `requests` level).
+
+The platform route itself is tested in marc27-core's own suite.
+"""
+from unittest.mock import patch
+
+import pytest
+
+from app.tools.base import ToolRegistry
+from app.tools.agent_capabilities import (
+    _agent_capabilities,
+    create_agent_capabilities_tool,
+)
+
+
+@pytest.fixture(autouse=True)
+def _no_credentials_env(monkeypatch, tmp_path):
+    """Run each test with empty creds env + a non-existent creds file
+    so the tool takes the "not authenticated" branch deterministically
+    unless a test opts back in."""
+    monkeypatch.delenv("MARC27_API_KEY", raising=False)
+    monkeypatch.delenv("MARC27_API_URL", raising=False)
+    # Point HOME at an empty tmpdir so credentials.json is missing.
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+
+class TestRegistration:
+    def test_registers_exactly_one_tool_named_agent_capabilities(self):
+        registry = ToolRegistry()
+        create_agent_capabilities_tool(registry)
+        tools = registry.list_tools()
+        assert len(tools) == 1
+        assert tools[0].name == "agent_capabilities"
+
+    def test_no_approval_required(self):
+        """Read-only — must not be approval-gated."""
+        registry = ToolRegistry()
+        create_agent_capabilities_tool(registry)
+        assert registry.get("agent_capabilities").requires_approval is False
+
+
+class TestAgentCapabilities:
+    def test_no_credentials_returns_login_hint(self):
+        result = _agent_capabilities()
+        assert "error" in result
+        assert "Not authenticated" in result["error"]
+        assert "prism login" in result.get("hint", "")
+
+    def test_hits_correct_endpoint_url(self, monkeypatch):
+        """With credentials present, the tool should GET exactly
+        `<api_url>/agent/capabilities`. Mock `requests.get` so we don't
+        depend on platform network reachability, and inspect the URL."""
+        called_urls = []
+
+        class _StubResp:
+            status_code = 200
+
+            def json(self):
+                return {"platform": "MARC27", "total_endpoints": 0}
+
+        def _stub_get(url, **_kwargs):
+            called_urls.append(url)
+            return _StubResp()
+
+        monkeypatch.setenv("MARC27_API_KEY", "fake-token")
+        monkeypatch.setenv("MARC27_API_URL", "https://example.invalid/api/v1")
+        monkeypatch.setattr(
+            "app.tools.agent_capabilities.requests.get", _stub_get
+        )
+
+        result = _agent_capabilities()
+        assert result == {"platform": "MARC27", "total_endpoints": 0}
+        assert called_urls == [
+            "https://example.invalid/api/v1/agent/capabilities"
+        ]

--- a/tests/test_knowledge_write_tool.py
+++ b/tests/test_knowledge_write_tool.py
@@ -1,0 +1,302 @@
+"""Tests for the `knowledge_write` dispatcher tool.
+
+Covers the WRITE side of the MARC27 Knowledge Service. Mirrors
+`tests/test_platform_status_tools.py` — registration shape, the
+not-authenticated branch, action validation, and per-action endpoint
+URL routing (with `requests.post` stubbed).
+
+Network-dependent behavior is mocked at the `requests` level; the
+underlying platform routes are tested in marc27-core's own suite.
+"""
+from unittest.mock import patch
+
+import pytest
+
+from app.tools.base import ToolRegistry
+from app.tools.knowledge_write import (
+    _knowledge_write,
+    create_knowledge_write_tool,
+)
+
+
+@pytest.fixture(autouse=True)
+def _no_credentials_env(monkeypatch, tmp_path):
+    """Run each test with empty creds env + a non-existent creds file
+    so the tool takes the "not authenticated" branch deterministically."""
+    monkeypatch.delenv("MARC27_API_KEY", raising=False)
+    monkeypatch.delenv("MARC27_API_URL", raising=False)
+    # Point HOME at an empty tmpdir so credentials.json is missing.
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+class TestRegistration:
+    def test_registers_exactly_one_tool_named_knowledge_write(self):
+        registry = ToolRegistry()
+        create_knowledge_write_tool(registry)
+        tools = registry.list_tools()
+        assert len(tools) == 1
+        assert tools[0].name == "knowledge_write"
+
+    def test_requires_approval_true(self):
+        """Every action mutates platform state and/or spends compute."""
+        registry = ToolRegistry()
+        create_knowledge_write_tool(registry)
+        assert registry.get("knowledge_write").requires_approval is True
+
+
+# ---------------------------------------------------------------------------
+# Action validation
+# ---------------------------------------------------------------------------
+
+class TestActionValidation:
+    def test_missing_action_returns_clear_error(self):
+        result = _knowledge_write()
+        assert "error" in result
+        assert "action" in result["error"].lower()
+        # Must list the valid actions in the hint.
+        hint = result.get("hint", "")
+        for action in (
+            "embed",
+            "embed_bulk",
+            "graph_seed",
+            "graph_ingest",
+            "research_web_search",
+        ):
+            assert action in hint, f"hint does not mention {action!r}"
+
+    def test_unknown_action_lists_valid_actions(self):
+        result = _knowledge_write(action="delete_everything")
+        assert "error" in result
+        assert "Unknown action" in result["error"]
+        # The error must enumerate the legal options so the agent can
+        # self-correct without another round-trip.
+        for action in (
+            "embed",
+            "embed_bulk",
+            "graph_seed",
+            "graph_ingest",
+            "research_web_search",
+        ):
+            assert action in result["error"], (
+                f"error does not mention valid action {action!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# No-credentials → login hint
+# ---------------------------------------------------------------------------
+
+class TestNoCredentials:
+    """Without auth, every valid action should hit the same login hint."""
+
+    def test_embed_no_credentials(self):
+        result = _knowledge_write(
+            action="embed", doc_id="d1", content="hello world"
+        )
+        assert "error" in result
+        assert "Not authenticated" in result["error"]
+        assert "prism login" in result.get("hint", "")
+
+    def test_embed_bulk_no_credentials(self):
+        result = _knowledge_write(
+            action="embed_bulk",
+            corpus_id="00000000-0000-4000-8000-000000000001",
+            documents=[{"doc_id": "d1", "content": "x"}],
+        )
+        assert "error" in result
+        assert "Not authenticated" in result["error"]
+
+    def test_graph_seed_no_credentials(self):
+        result = _knowledge_write(
+            action="graph_seed",
+            nodes_url="https://example.invalid/nodes.csv",
+            edges_url="https://example.invalid/edges.csv",
+        )
+        assert "error" in result
+        assert "Not authenticated" in result["error"]
+
+    def test_graph_ingest_no_credentials(self):
+        result = _knowledge_write(
+            action="graph_ingest", entities=[], relationships=[]
+        )
+        assert "error" in result
+        assert "Not authenticated" in result["error"]
+
+    def test_research_web_search_no_credentials(self):
+        result = _knowledge_write(action="research_web_search", query="alloy")
+        assert "error" in result
+        assert "Not authenticated" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Endpoint URL routing — with requests.post mocked
+# ---------------------------------------------------------------------------
+
+class TestEndpointRouting:
+    """Each valid action should POST to a distinct endpoint URL."""
+
+    def _stub(self, monkeypatch):
+        """Install a fake credentials env + capture every POST call."""
+        called = []
+
+        class _StubResp:
+            status_code = 200
+
+            def json(self):
+                return {"ok": True}
+
+        def _stub_post(url, **kwargs):
+            called.append({"url": url, "json": kwargs.get("json")})
+            return _StubResp()
+
+        monkeypatch.setenv("MARC27_API_KEY", "fake-token")
+        monkeypatch.setenv(
+            "MARC27_API_URL", "https://example.invalid/api/v1"
+        )
+        monkeypatch.setattr(
+            "app.tools.knowledge_write.requests.post", _stub_post
+        )
+        return called
+
+    def test_embed_hits_knowledge_embed(self, monkeypatch):
+        called = self._stub(monkeypatch)
+        result = _knowledge_write(
+            action="embed", doc_id="d1", content="hello"
+        )
+        assert result == {"ok": True}
+        assert len(called) == 1
+        assert called[0]["url"] == "https://example.invalid/api/v1/knowledge/embed"
+        # Body shape: doc_id + content forwarded; tenant/auth headers
+        # added by _post and not part of the JSON body.
+        assert called[0]["json"]["doc_id"] == "d1"
+        assert called[0]["json"]["content"] == "hello"
+
+    def test_embed_bulk_hits_knowledge_embed_bulk(self, monkeypatch):
+        called = self._stub(monkeypatch)
+        result = _knowledge_write(
+            action="embed_bulk",
+            corpus_id="00000000-0000-4000-8000-000000000001",
+            documents=[{"doc_id": "a", "content": "x"}],
+        )
+        assert result == {"ok": True}
+        assert called[0]["url"] == (
+            "https://example.invalid/api/v1/knowledge/embed/bulk"
+        )
+        assert called[0]["json"]["corpus_id"] == (
+            "00000000-0000-4000-8000-000000000001"
+        )
+        assert called[0]["json"]["documents"] == [
+            {"doc_id": "a", "content": "x"}
+        ]
+
+    def test_graph_seed_hits_knowledge_graph_seed(self, monkeypatch):
+        called = self._stub(monkeypatch)
+        result = _knowledge_write(
+            action="graph_seed",
+            nodes_url="https://example.invalid/nodes.csv",
+            edges_url="https://example.invalid/edges.csv",
+        )
+        assert result == {"ok": True}
+        assert called[0]["url"] == (
+            "https://example.invalid/api/v1/knowledge/graph/seed"
+        )
+        assert called[0]["json"] == {
+            "nodes_url": "https://example.invalid/nodes.csv",
+            "edges_url": "https://example.invalid/edges.csv",
+        }
+
+    def test_graph_ingest_hits_knowledge_graph_ingest(self, monkeypatch):
+        called = self._stub(monkeypatch)
+        entities = [
+            {"name": "Ti6Al4V", "entity_type": "Material", "label": "Material"}
+        ]
+        relationships = []
+        result = _knowledge_write(
+            action="graph_ingest",
+            entities=entities,
+            relationships=relationships,
+        )
+        assert result == {"ok": True}
+        assert called[0]["url"] == (
+            "https://example.invalid/api/v1/knowledge/graph/ingest"
+        )
+        assert called[0]["json"]["entities"] == entities
+        assert called[0]["json"]["relationships"] == relationships
+
+    def test_research_web_search_hits_knowledge_research_web_search(
+        self, monkeypatch
+    ):
+        called = self._stub(monkeypatch)
+        result = _knowledge_write(
+            action="research_web_search", query="titanium aluminide", limit=10
+        )
+        assert result == {"ok": True}
+        assert called[0]["url"] == (
+            "https://example.invalid/api/v1/knowledge/research/web-search"
+        )
+        assert called[0]["json"] == {
+            "query": "titanium aluminide",
+            "limit": 10,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Per-action required-arg validation (cheap sanity, no network needed)
+# ---------------------------------------------------------------------------
+
+class TestRequiredArgs:
+    """Required-arg checks should fire BEFORE the auth check so an agent
+    that forgets `content` doesn't get a misleading auth error."""
+
+    def test_embed_missing_doc_id(self):
+        with patch.dict("os.environ", {"MARC27_API_KEY": "fake"}):
+            result = _knowledge_write(action="embed", content="x")
+            assert "error" in result
+            assert "doc_id" in result["error"]
+
+    def test_embed_missing_content(self):
+        with patch.dict("os.environ", {"MARC27_API_KEY": "fake"}):
+            result = _knowledge_write(action="embed", doc_id="d1")
+            assert "error" in result
+            assert "content" in result["error"]
+
+    def test_embed_bulk_missing_corpus_id(self):
+        with patch.dict("os.environ", {"MARC27_API_KEY": "fake"}):
+            result = _knowledge_write(
+                action="embed_bulk",
+                documents=[{"doc_id": "a", "content": "x"}],
+            )
+            assert "error" in result
+            assert "corpus_id" in result["error"]
+
+    def test_embed_bulk_missing_documents(self):
+        with patch.dict("os.environ", {"MARC27_API_KEY": "fake"}):
+            result = _knowledge_write(
+                action="embed_bulk", corpus_id="abc"
+            )
+            assert "error" in result
+            assert "documents" in result["error"]
+
+    def test_graph_seed_missing_urls(self):
+        with patch.dict("os.environ", {"MARC27_API_KEY": "fake"}):
+            result = _knowledge_write(action="graph_seed")
+            assert "error" in result
+            assert "nodes_url" in result["error"]
+
+    def test_graph_ingest_missing_entities(self):
+        with patch.dict("os.environ", {"MARC27_API_KEY": "fake"}):
+            result = _knowledge_write(
+                action="graph_ingest", relationships=[]
+            )
+            assert "error" in result
+            assert "entities" in result["error"]
+
+    def test_research_web_search_missing_query(self):
+        with patch.dict("os.environ", {"MARC27_API_KEY": "fake"}):
+            result = _knowledge_write(action="research_web_search")
+            assert "error" in result
+            assert "query" in result["error"]

--- a/tests/test_mcp_services_tool.py
+++ b/tests/test_mcp_services_tool.py
@@ -1,0 +1,269 @@
+"""Tests for mcp_services / mcp_services_invoke tools.
+
+proxy + scale are broken out as approval-gated under
+`mcp_services_invoke`; list + get live in `mcp_services` with no
+approval gate.
+
+`project_id` is required for all four actions and is auto-resolved from
+explicit-arg → MARC27_PROJECT_ID env var → ~/.prism/credentials.json.
+
+Network-dependent behavior is mocked at the `requests` level; the
+underlying platform routes are tested in marc27-core's own suite.
+"""
+from unittest.mock import patch
+
+import pytest
+
+from app.tools.base import ToolRegistry
+from app.tools.mcp_services import (
+    _mcp_services,
+    _mcp_services_invoke,
+    create_mcp_services_tools,
+)
+
+
+@pytest.fixture(autouse=True)
+def _no_credentials_env(monkeypatch, tmp_path):
+    """Run each test with empty creds env + a non-existent creds file
+    so the tools take the "not authenticated" branch deterministically."""
+    monkeypatch.delenv("MARC27_API_KEY", raising=False)
+    monkeypatch.delenv("MARC27_API_URL", raising=False)
+    monkeypatch.delenv("MARC27_PROJECT_ID", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+
+class TestRegistration:
+    def test_registers_two_tools(self):
+        registry = ToolRegistry()
+        create_mcp_services_tools(registry)
+        names = {t.name for t in registry.list_tools()}
+        assert names == {"mcp_services", "mcp_services_invoke"}
+
+    def test_mcp_services_no_approval(self):
+        registry = ToolRegistry()
+        create_mcp_services_tools(registry)
+        assert registry.get("mcp_services").requires_approval is False
+
+    def test_mcp_services_invoke_requires_approval(self):
+        registry = ToolRegistry()
+        create_mcp_services_tools(registry)
+        assert registry.get("mcp_services_invoke").requires_approval is True
+
+    def test_state_changing_actions_not_in_read_tool_enum(self):
+        registry = ToolRegistry()
+        create_mcp_services_tools(registry)
+        actions = (
+            registry.get("mcp_services").input_schema["properties"]["action"]["enum"]
+        )
+        assert "proxy" not in actions
+        assert "scale" not in actions
+        assert set(actions) == {"list", "get"}
+
+
+class TestMcpServicesDispatcher:
+    def test_missing_action(self):
+        result = _mcp_services()
+        assert "error" in result
+        assert "Missing 'action'" in result["error"]
+
+    def test_unknown_action(self):
+        result = _mcp_services(action="bogus", project_id="p")
+        assert "error" in result
+        assert "Unknown action" in result["error"]
+
+    def test_no_project_id_returns_clear_error(self):
+        # Empty creds env + tmpdir HOME = no project_id source.
+        result = _mcp_services(action="list")
+        assert "error" in result
+        assert "project_id" in result["error"]
+
+    def test_get_requires_instance_id(self, monkeypatch):
+        monkeypatch.setenv("MARC27_PROJECT_ID", "00000000-0000-4000-8000-000000000001")
+        result = _mcp_services(action="get")
+        assert "error" in result
+        assert "instance_id" in result["error"]
+
+    def test_no_credentials_returns_login_hint(self, monkeypatch):
+        # project_id resolves but token doesn't.
+        monkeypatch.setenv("MARC27_PROJECT_ID", "00000000-0000-4000-8000-000000000001")
+        result = _mcp_services(action="list")
+        assert "error" in result
+        assert "Not authenticated" in result["error"]
+        assert "prism login" in result.get("hint", "")
+
+    def test_list_action_hits_correct_url(self, monkeypatch):
+        called = []
+
+        class _StubResp:
+            status_code = 200
+
+            def json(self):
+                return [{"id": "i-1"}]
+
+        def _stub_get(url, **_kwargs):
+            called.append(url)
+            return _StubResp()
+
+        monkeypatch.setenv("MARC27_API_KEY", "fake-token")
+        monkeypatch.setenv("MARC27_API_URL", "https://example.invalid/api/v1")
+        monkeypatch.setenv("MARC27_PROJECT_ID", "proj-1")
+        monkeypatch.setattr("app.tools.mcp_services.requests.get", _stub_get)
+
+        result = _mcp_services(action="list")
+        assert result == [{"id": "i-1"}]
+        assert called == ["https://example.invalid/api/v1/projects/proj-1/mcp-services"]
+
+    def test_get_action_hits_correct_url(self, monkeypatch):
+        called = []
+
+        class _StubResp:
+            status_code = 200
+
+            def json(self):
+                return {"id": "inst-1"}
+
+        def _stub_get(url, **_kwargs):
+            called.append(url)
+            return _StubResp()
+
+        monkeypatch.setenv("MARC27_API_KEY", "fake-token")
+        monkeypatch.setenv("MARC27_API_URL", "https://example.invalid/api/v1")
+        monkeypatch.setenv("MARC27_PROJECT_ID", "proj-1")
+        monkeypatch.setattr("app.tools.mcp_services.requests.get", _stub_get)
+
+        result = _mcp_services(action="get", instance_id="inst-1")
+        assert result == {"id": "inst-1"}
+        assert called == [
+            "https://example.invalid/api/v1/projects/proj-1/mcp-services/inst-1"
+        ]
+
+    def test_explicit_project_id_overrides_env(self, monkeypatch):
+        called = []
+
+        class _StubResp:
+            status_code = 200
+
+            def json(self):
+                return []
+
+        def _stub_get(url, **_kwargs):
+            called.append(url)
+            return _StubResp()
+
+        monkeypatch.setenv("MARC27_API_KEY", "fake-token")
+        monkeypatch.setenv("MARC27_API_URL", "https://example.invalid/api/v1")
+        monkeypatch.setenv("MARC27_PROJECT_ID", "env-proj")
+        monkeypatch.setattr("app.tools.mcp_services.requests.get", _stub_get)
+
+        _mcp_services(action="list", project_id="explicit-proj")
+        # Explicit beats env
+        assert called == [
+            "https://example.invalid/api/v1/projects/explicit-proj/mcp-services"
+        ]
+
+
+class TestMcpServicesInvoke:
+    def test_missing_action(self):
+        result = _mcp_services_invoke()
+        assert "error" in result
+        assert "Missing 'action'" in result["error"]
+
+    def test_unknown_action(self):
+        result = _mcp_services_invoke(
+            action="bogus", project_id="p", instance_id="i"
+        )
+        assert "error" in result
+        assert "Unknown action" in result["error"]
+
+    def test_no_project_id_returns_clear_error(self):
+        result = _mcp_services_invoke(action="proxy", instance_id="i", path="/x")
+        assert "error" in result
+        assert "project_id" in result["error"]
+
+    def test_proxy_requires_instance_id(self, monkeypatch):
+        monkeypatch.setenv("MARC27_PROJECT_ID", "p")
+        result = _mcp_services_invoke(action="proxy", path="/x")
+        assert "error" in result
+        assert "instance_id" in result["error"]
+
+    def test_proxy_requires_path(self, monkeypatch):
+        monkeypatch.setenv("MARC27_PROJECT_ID", "p")
+        result = _mcp_services_invoke(action="proxy", instance_id="i")
+        assert "error" in result
+        assert "path" in result["error"]
+
+    def test_scale_requires_replicas(self, monkeypatch):
+        monkeypatch.setenv("MARC27_PROJECT_ID", "p")
+        result = _mcp_services_invoke(action="scale", instance_id="i")
+        assert "error" in result
+        assert "replicas" in result["error"]
+
+    def test_scale_rejects_replicas_above_one(self, monkeypatch):
+        monkeypatch.setenv("MARC27_PROJECT_ID", "p")
+        result = _mcp_services_invoke(action="scale", instance_id="i", replicas=2)
+        assert "error" in result
+        assert "0 or 1" in result["error"]
+
+    def test_proxy_action_hits_correct_url(self, monkeypatch):
+        called = []
+        sent_bodies = []
+
+        class _StubResp:
+            status_code = 200
+
+            def json(self):
+                return {"status_code": 200, "body": {"ok": True}, "headers": {}}
+
+        def _stub_post(url, **kwargs):
+            called.append(url)
+            sent_bodies.append(kwargs.get("json"))
+            return _StubResp()
+
+        monkeypatch.setenv("MARC27_API_KEY", "fake-token")
+        monkeypatch.setenv("MARC27_API_URL", "https://example.invalid/api/v1")
+        monkeypatch.setenv("MARC27_PROJECT_ID", "proj-1")
+        monkeypatch.setattr("app.tools.mcp_services.requests.post", _stub_post)
+
+        result = _mcp_services_invoke(
+            action="proxy",
+            instance_id="inst-1",
+            path="/tools/list",
+            method="GET",
+        )
+        assert result["status_code"] == 200
+        assert called == [
+            "https://example.invalid/api/v1/projects/proj-1/mcp-services/inst-1/proxy"
+        ]
+        assert sent_bodies[0]["path"] == "/tools/list"
+        assert sent_bodies[0]["method"] == "GET"
+
+    def test_scale_action_hits_correct_url(self, monkeypatch):
+        called = []
+        sent_bodies = []
+
+        class _StubResp:
+            status_code = 200
+
+            def json(self):
+                return {"instance_id": "inst-1", "replicas": 0}
+
+        def _stub_post(url, **kwargs):
+            called.append(url)
+            sent_bodies.append(kwargs.get("json"))
+            return _StubResp()
+
+        monkeypatch.setenv("MARC27_API_KEY", "fake-token")
+        monkeypatch.setenv("MARC27_API_URL", "https://example.invalid/api/v1")
+        monkeypatch.setenv("MARC27_PROJECT_ID", "proj-1")
+        monkeypatch.setattr("app.tools.mcp_services.requests.post", _stub_post)
+
+        result = _mcp_services_invoke(
+            action="scale",
+            instance_id="inst-1",
+            replicas=0,
+        )
+        assert result == {"instance_id": "inst-1", "replicas": 0}
+        assert called == [
+            "https://example.invalid/api/v1/projects/proj-1/mcp-services/inst-1/scale"
+        ]
+        assert sent_bodies[0] == {"replicas": 0}

--- a/tests/test_platform_jobs_tool.py
+++ b/tests/test_platform_jobs_tool.py
@@ -1,0 +1,232 @@
+"""Tests for platform_jobs / platform_jobs_submit tools.
+
+The submit action is broken out as a standalone tool with
+`requires_approval=True`; the read/cancel/events actions live in the
+unified `platform_jobs` tool with no approval gate.
+
+Network-dependent behavior is mocked at the `requests` level; the
+underlying platform routes are tested in marc27-core's own suite.
+"""
+from unittest.mock import patch
+
+import pytest
+
+from app.tools.base import ToolRegistry
+from app.tools.platform_jobs import (
+    _platform_jobs,
+    _platform_jobs_submit,
+    create_platform_jobs_tools,
+)
+
+
+@pytest.fixture(autouse=True)
+def _no_credentials_env(monkeypatch, tmp_path):
+    """Run each test with empty creds env + a non-existent creds file
+    so the tools take the "not authenticated" branch deterministically."""
+    monkeypatch.delenv("MARC27_API_KEY", raising=False)
+    monkeypatch.delenv("MARC27_API_URL", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+
+class TestRegistration:
+    def test_registers_two_tools(self):
+        registry = ToolRegistry()
+        create_platform_jobs_tools(registry)
+        names = {t.name for t in registry.list_tools()}
+        assert names == {"platform_jobs", "platform_jobs_submit"}
+
+    def test_platform_jobs_no_approval(self):
+        registry = ToolRegistry()
+        create_platform_jobs_tools(registry)
+        assert registry.get("platform_jobs").requires_approval is False
+
+    def test_platform_jobs_submit_requires_approval(self):
+        registry = ToolRegistry()
+        create_platform_jobs_tools(registry)
+        assert registry.get("platform_jobs_submit").requires_approval is True
+
+    def test_submit_action_not_in_read_tool_enum(self):
+        """Submit must not appear in the read-only dispatcher's enum;
+        approval gating depends on it being a separate tool."""
+        registry = ToolRegistry()
+        create_platform_jobs_tools(registry)
+        actions = registry.get("platform_jobs").input_schema["properties"]["action"]["enum"]
+        assert "submit" not in actions
+        assert set(actions) == {"status", "cancel", "events"}
+
+
+class TestPlatformJobsDispatcher:
+    def test_missing_action(self):
+        result = _platform_jobs()
+        assert "error" in result
+        assert "Missing 'action'" in result["error"]
+
+    def test_unknown_action(self):
+        result = _platform_jobs(action="bogus", job_id="abc")
+        assert "error" in result
+        assert "Unknown action" in result["error"]
+
+    def test_status_requires_job_id(self):
+        result = _platform_jobs(action="status")
+        assert "error" in result
+        assert "job_id" in result["error"]
+
+    def test_cancel_requires_job_id(self):
+        result = _platform_jobs(action="cancel")
+        assert "error" in result
+        assert "job_id" in result["error"]
+
+    def test_events_requires_job_id(self):
+        result = _platform_jobs(action="events")
+        assert "error" in result
+        assert "job_id" in result["error"]
+
+    def test_no_credentials_returns_login_hint(self):
+        result = _platform_jobs(action="status", job_id="11111111-1111-4111-8111-111111111111")
+        assert "error" in result
+        assert "Not authenticated" in result["error"]
+        assert "prism login" in result.get("hint", "")
+
+    def test_status_action_hits_correct_url(self, monkeypatch):
+        called_paths = []
+
+        class _StubResp:
+            status_code = 200
+
+            def json(self):
+                return {"id": "abc", "status": "running"}
+
+        def _stub_get(url, **_kwargs):
+            called_paths.append(url)
+            return _StubResp()
+
+        monkeypatch.setenv("MARC27_API_KEY", "fake-token")
+        monkeypatch.setenv("MARC27_API_URL", "https://example.invalid/api/v1")
+        monkeypatch.setattr("app.tools.platform_jobs.requests.get", _stub_get)
+
+        result = _platform_jobs(action="status", job_id="job-xyz")
+        assert result == {"id": "abc", "status": "running"}
+        assert called_paths == ["https://example.invalid/api/v1/jobs/job-xyz"]
+
+    def test_cancel_action_hits_correct_url(self, monkeypatch):
+        called = []
+
+        class _StubResp:
+            status_code = 200
+
+            @property
+            def content(self):
+                return b'{"status": "cancelled"}'
+
+            def json(self):
+                return {"status": "cancelled"}
+
+        def _stub_post(url, **_kwargs):
+            called.append(url)
+            return _StubResp()
+
+        monkeypatch.setenv("MARC27_API_KEY", "fake-token")
+        monkeypatch.setenv("MARC27_API_URL", "https://example.invalid/api/v1")
+        monkeypatch.setattr("app.tools.platform_jobs.requests.post", _stub_post)
+
+        result = _platform_jobs(action="cancel", job_id="job-xyz")
+        assert result == {"status": "cancelled"}
+        assert called == ["https://example.invalid/api/v1/jobs/job-xyz/cancel"]
+
+    def test_events_action_reads_sse_frames(self, monkeypatch):
+        called = []
+
+        class _StubResp:
+            status_code = 200
+
+            def iter_lines(self, decode_unicode=True):
+                # Two events with `data:` and `event:` fields, separated by
+                # blank lines. The third frame is incomplete to verify we
+                # cap at max_events.
+                return iter([
+                    "event: created",
+                    'data: {"job_id": "abc"}',
+                    "",
+                    "event: started",
+                    'data: {"job_id": "abc"}',
+                    "",
+                ])
+
+            def close(self):
+                pass
+
+        def _stub_get(url, **_kwargs):
+            called.append(url)
+            return _StubResp()
+
+        monkeypatch.setenv("MARC27_API_KEY", "fake-token")
+        monkeypatch.setenv("MARC27_API_URL", "https://example.invalid/api/v1")
+        monkeypatch.setattr("app.tools.platform_jobs.requests.get", _stub_get)
+
+        result = _platform_jobs(action="events", job_id="abc", max_events=10)
+        assert result["count"] == 2
+        assert called == ["https://example.invalid/api/v1/jobs/abc/events"]
+        assert result["events"][0]["event"] == "created"
+        assert result["events"][0]["data"] == {"job_id": "abc"}
+        assert result["events"][1]["event"] == "started"
+
+
+class TestPlatformJobsSubmit:
+    def test_missing_job_type(self):
+        result = _platform_jobs_submit(project_id="p", payload={})
+        assert "error" in result
+        assert "job_type" in result["error"]
+
+    def test_missing_project_id(self):
+        result = _platform_jobs_submit(job_type="t", payload={})
+        assert "error" in result
+        assert "project_id" in result["error"]
+
+    def test_missing_payload(self):
+        result = _platform_jobs_submit(job_type="t", project_id="p")
+        assert "error" in result
+        assert "payload" in result["error"]
+
+    def test_no_credentials_returns_login_hint(self):
+        result = _platform_jobs_submit(
+            job_type="compute.simulation",
+            project_id="11111111-1111-4111-8111-111111111111",
+            payload={},
+        )
+        assert "error" in result
+        assert "Not authenticated" in result["error"]
+
+    def test_happy_path_hits_jobs_root(self, monkeypatch):
+        called = []
+        sent_bodies = []
+
+        class _StubResp:
+            status_code = 201
+
+            @property
+            def content(self):
+                return b'{"id": "job-1"}'
+
+            def json(self):
+                return {"id": "job-1", "status": "queued"}
+
+        def _stub_post(url, **kwargs):
+            called.append(url)
+            sent_bodies.append(kwargs.get("json"))
+            return _StubResp()
+
+        monkeypatch.setenv("MARC27_API_KEY", "fake-token")
+        monkeypatch.setenv("MARC27_API_URL", "https://example.invalid/api/v1")
+        monkeypatch.setattr("app.tools.platform_jobs.requests.post", _stub_post)
+
+        result = _platform_jobs_submit(
+            job_type="compute.simulation",
+            project_id="00000000-0000-4000-8000-000000000001",
+            payload={"input": "..."},
+            priority=5,
+        )
+        assert result == {"id": "job-1", "status": "queued"}
+        assert called == ["https://example.invalid/api/v1/jobs"]
+        assert sent_bodies[0]["job_type"] == "compute.simulation"
+        assert sent_bodies[0]["priority"] == 5
+        assert sent_bodies[0]["payload"] == {"input": "..."}

--- a/tests/test_platform_workflows_tool.py
+++ b/tests/test_platform_workflows_tool.py
@@ -1,0 +1,217 @@
+"""Tests for platform_workflows / platform_workflows_run tools.
+
+start + register_spec are broken out as approval-gated under
+`platform_workflows_run`; list/list_specs/status/cancel live in
+`platform_workflows` with no approval gate.
+
+Network-dependent behavior is mocked at the `requests` level; the
+underlying platform routes are tested in marc27-core's own suite.
+"""
+from unittest.mock import patch
+
+import pytest
+
+from app.tools.base import ToolRegistry
+from app.tools.platform_workflows import (
+    _platform_workflows,
+    _platform_workflows_run,
+    create_platform_workflows_tools,
+)
+
+
+@pytest.fixture(autouse=True)
+def _no_credentials_env(monkeypatch, tmp_path):
+    """Run each test with empty creds env + a non-existent creds file
+    so the tools take the "not authenticated" branch deterministically."""
+    monkeypatch.delenv("MARC27_API_KEY", raising=False)
+    monkeypatch.delenv("MARC27_API_URL", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+
+class TestRegistration:
+    def test_registers_two_tools(self):
+        registry = ToolRegistry()
+        create_platform_workflows_tools(registry)
+        names = {t.name for t in registry.list_tools()}
+        assert names == {"platform_workflows", "platform_workflows_run"}
+
+    def test_platform_workflows_no_approval(self):
+        registry = ToolRegistry()
+        create_platform_workflows_tools(registry)
+        assert registry.get("platform_workflows").requires_approval is False
+
+    def test_platform_workflows_run_requires_approval(self):
+        registry = ToolRegistry()
+        create_platform_workflows_tools(registry)
+        assert registry.get("platform_workflows_run").requires_approval is True
+
+    def test_state_changing_actions_not_in_read_tool_enum(self):
+        registry = ToolRegistry()
+        create_platform_workflows_tools(registry)
+        actions = (
+            registry.get("platform_workflows").input_schema["properties"]["action"]["enum"]
+        )
+        assert "start" not in actions
+        assert "register_spec" not in actions
+        assert set(actions) == {"list", "list_specs", "status", "cancel"}
+
+
+class TestPlatformWorkflowsDispatcher:
+    def test_missing_action(self):
+        result = _platform_workflows()
+        assert "error" in result
+        assert "Missing 'action'" in result["error"]
+
+    def test_unknown_action(self):
+        result = _platform_workflows(action="bogus")
+        assert "error" in result
+        assert "Unknown action" in result["error"]
+
+    def test_status_requires_workflow_id(self):
+        result = _platform_workflows(action="status")
+        assert "error" in result
+        assert "workflow_id" in result["error"]
+
+    def test_cancel_requires_workflow_id(self):
+        result = _platform_workflows(action="cancel")
+        assert "error" in result
+        assert "workflow_id" in result["error"]
+
+    def test_no_credentials_returns_login_hint(self):
+        result = _platform_workflows(action="list")
+        assert "error" in result
+        assert "Not authenticated" in result["error"]
+        assert "prism login" in result.get("hint", "")
+
+    def test_valid_actions_call_correct_endpoint(self, monkeypatch):
+        """list / list_specs / status hit distinct GET endpoints,
+        cancel hits a POST endpoint."""
+        called_get = []
+        called_post = []
+
+        class _StubResp:
+            status_code = 200
+
+            @property
+            def content(self):
+                return b'{"ok": true}'
+
+            def json(self):
+                return {"ok": True}
+
+        def _stub_get(url, **_kwargs):
+            called_get.append(url)
+            return _StubResp()
+
+        def _stub_post(url, **_kwargs):
+            called_post.append(url)
+            return _StubResp()
+
+        monkeypatch.setenv("MARC27_API_KEY", "fake-token")
+        monkeypatch.setenv("MARC27_API_URL", "https://example.invalid/api/v1")
+        monkeypatch.setattr("app.tools.platform_workflows.requests.get", _stub_get)
+        monkeypatch.setattr("app.tools.platform_workflows.requests.post", _stub_post)
+
+        assert _platform_workflows(action="list") == {"ok": True}
+        assert _platform_workflows(action="list_specs") == {"ok": True}
+        assert _platform_workflows(action="status", workflow_id="wf-1") == {"ok": True}
+        _platform_workflows(action="cancel", workflow_id="wf-1")
+
+        assert called_get == [
+            "https://example.invalid/api/v1/workflows",
+            "https://example.invalid/api/v1/workflows/specs",
+            "https://example.invalid/api/v1/workflows/wf-1",
+        ]
+        assert called_post == [
+            "https://example.invalid/api/v1/workflows/wf-1/cancel",
+        ]
+
+
+class TestPlatformWorkflowsRun:
+    def test_missing_action(self):
+        result = _platform_workflows_run()
+        assert "error" in result
+        assert "Missing 'action'" in result["error"]
+
+    def test_unknown_action(self):
+        result = _platform_workflows_run(action="bogus")
+        assert "error" in result
+        assert "Unknown action" in result["error"]
+
+    def test_start_requires_spec(self):
+        result = _platform_workflows_run(action="start")
+        assert "error" in result
+        assert "spec" in result["error"]
+
+    def test_register_spec_requires_spec_yaml(self):
+        result = _platform_workflows_run(action="register_spec")
+        assert "error" in result
+        assert "spec_yaml" in result["error"]
+
+    def test_no_credentials_returns_login_hint(self):
+        result = _platform_workflows_run(action="start", spec="my-spec")
+        assert "error" in result
+        assert "Not authenticated" in result["error"]
+
+    def test_start_action_hits_workflows_root(self, monkeypatch):
+        called = []
+        sent_bodies = []
+
+        class _StubResp:
+            status_code = 202
+
+            @property
+            def content(self):
+                return b'{"workflow_id": "wf-1"}'
+
+            def json(self):
+                return {"workflow_id": "wf-1", "status": "running"}
+
+        def _stub_post(url, **kwargs):
+            called.append(url)
+            sent_bodies.append(kwargs.get("json"))
+            return _StubResp()
+
+        monkeypatch.setenv("MARC27_API_KEY", "fake-token")
+        monkeypatch.setenv("MARC27_API_URL", "https://example.invalid/api/v1")
+        monkeypatch.setattr("app.tools.platform_workflows.requests.post", _stub_post)
+
+        result = _platform_workflows_run(
+            action="start",
+            spec="discover-mof",
+            inputs={"target": "co2"},
+            project_id="00000000-0000-4000-8000-000000000001",
+        )
+        assert result["workflow_id"] == "wf-1"
+        assert called == ["https://example.invalid/api/v1/workflows"]
+        assert sent_bodies[0]["spec"] == "discover-mof"
+        assert sent_bodies[0]["inputs"] == {"target": "co2"}
+        assert sent_bodies[0]["project_id"] == "00000000-0000-4000-8000-000000000001"
+
+    def test_register_spec_hits_specs_endpoint(self, monkeypatch):
+        called = []
+
+        class _StubResp:
+            status_code = 201
+
+            @property
+            def content(self):
+                return b'{"id": "spec-1"}'
+
+            def json(self):
+                return {"id": "spec-1", "name": "x"}
+
+        def _stub_post(url, **_kwargs):
+            called.append(url)
+            return _StubResp()
+
+        monkeypatch.setenv("MARC27_API_KEY", "fake-token")
+        monkeypatch.setenv("MARC27_API_URL", "https://example.invalid/api/v1")
+        monkeypatch.setattr("app.tools.platform_workflows.requests.post", _stub_post)
+
+        result = _platform_workflows_run(
+            action="register_spec",
+            spec_yaml="name: foo\nsteps: []\n",
+        )
+        assert result == {"id": "spec-1", "name": "x"}
+        assert called == ["https://example.invalid/api/v1/workflows/specs"]


### PR DESCRIPTION
## Summary

Closes the remaining endpoint coverage gaps from the v2.7.2 audit. Five new tool families, **eight registered tools** — money-spending or state-changing surfaces isolated into approval-gated tools (calphad / calphad_compute split pattern).

(Re-opens PR #102 — auto-closed when its base branch \`feat/agent-platform-tools\` was deleted on PR #100 merge. Now retargeted to \`main\` after rebase.)

## Tools

| Tool | Endpoint(s) | Approval |
|---|---|---|
| \`agent_capabilities\` | GET /agent/capabilities | no |
| \`knowledge_write\` | POST /knowledge/{embed, embed/bulk, graph/seed, graph/ingest, research/web-search} | **yes** |
| \`platform_jobs\` | GET /jobs/{id}, /jobs/{id}/events; POST /jobs/{id}/cancel | no |
| \`platform_jobs_submit\` | POST /jobs | **yes** |
| \`platform_workflows\` | GET /workflows, /workflows/specs, /workflows/{id}; POST /workflows/{id}/cancel | no |
| \`platform_workflows_run\` | POST /workflows, /workflows/specs | **yes** |
| \`mcp_services\` | GET /projects/{pid}/mcp-services, /mcp-services/{id} | no |
| \`mcp_services_invoke\` | POST /mcp-services/{id}/proxy, /scale | **yes** |

## Test plan

- [x] 103 tests pass: 4 + 21 + 18 + 17 + 21 + 9 + 13 = 103/103
- [x] Bootstrap smoke: agent surface goes 87 → 95 tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)