### PR TITLE
feat(forge_repo): local messages + sync_outbox tables (Audit A)

### DIFF
--- a/crates/forge_repo/src/database/migrations/2026-05-10-100000_add_messages_and_outbox/down.sql
+++ b/crates/forge_repo/src/database/migrations/2026-05-10-100000_add_messages_and_outbox/down.sql
@@ -1,0 +1,5 @@
+DROP INDEX IF EXISTS idx_sync_outbox_created_at;
+DROP TABLE IF EXISTS sync_outbox;
+
+DROP INDEX IF EXISTS idx_messages_conversation_ordinal;
+DROP TABLE IF EXISTS messages;

--- a/crates/forge_repo/src/database/migrations/2026-05-10-100000_add_messages_and_outbox/up.sql
+++ b/crates/forge_repo/src/database/migrations/2026-05-10-100000_add_messages_and_outbox/up.sql
@@ -1,0 +1,39 @@
+-- Per-message storage (mirror of marc27-core 20260510000045_conversations.sql).
+-- ADDITIVE: existing conversations.context blob is untouched and remains the
+-- belt-and-braces hydration source. These tables introduce per-message
+-- storage so we can stop O(n^2) full-blob rewrites and sync per-turn
+-- write-throughs to the server.
+
+CREATE TABLE IF NOT EXISTS messages (
+    id                TEXT PRIMARY KEY NOT NULL,
+    conversation_id   TEXT NOT NULL,
+    ordinal           BIGINT NOT NULL,
+    role              TEXT NOT NULL CHECK (role IN ('system','user','assistant','tool')),
+    content           TEXT,
+    tool_calls_json   TEXT,
+    tool_results_json TEXT,
+    usage_json        TEXT,
+    created_at        BIGINT NOT NULL,
+    UNIQUE (conversation_id, ordinal)
+);
+
+CREATE INDEX IF NOT EXISTS idx_messages_conversation_ordinal
+    ON messages (conversation_id, ordinal DESC);
+
+-- Write-through retry queue. Drain worker pops the lowest id, fetches the
+-- [low_ordinal, high_ordinal] slice from `messages`, POSTs to
+-- /v1/conversations/{id}/messages, and deletes on success. Failed attempts
+-- bump `attempts` + `last_error` + `last_attempt_at`.
+CREATE TABLE IF NOT EXISTS sync_outbox (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    conversation_id TEXT NOT NULL,
+    low_ordinal     BIGINT NOT NULL,
+    high_ordinal    BIGINT NOT NULL,
+    attempts        INTEGER NOT NULL DEFAULT 0,
+    last_attempt_at BIGINT,
+    last_error      TEXT,
+    created_at      BIGINT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_sync_outbox_created_at
+    ON sync_outbox (created_at);

--- a/crates/forge_repo/src/database/schema.rs
+++ b/crates/forge_repo/src/database/schema.rs
@@ -11,3 +11,30 @@ diesel::table! {
         metrics -> Nullable<Text>,
     }
 }
+
+diesel::table! {
+    messages (id) {
+        id -> Text,
+        conversation_id -> Text,
+        ordinal -> BigInt,
+        role -> Text,
+        content -> Nullable<Text>,
+        tool_calls_json -> Nullable<Text>,
+        tool_results_json -> Nullable<Text>,
+        usage_json -> Nullable<Text>,
+        created_at -> BigInt,
+    }
+}
+
+diesel::table! {
+    sync_outbox (id) {
+        id -> Integer,
+        conversation_id -> Text,
+        low_ordinal -> BigInt,
+        high_ordinal -> BigInt,
+        attempts -> Integer,
+        last_attempt_at -> Nullable<BigInt>,
+        last_error -> Nullable<Text>,
+        created_at -> BigInt,
+    }
+}

--- a/crates/forge_repo/src/lib.rs
+++ b/crates/forge_repo/src/lib.rs
@@ -6,6 +6,7 @@ mod database;
 mod forge_repo;
 mod fs_snap;
 mod fuzzy_search;
+mod messages;
 mod provider;
 mod skill;
 mod validation;

--- a/crates/forge_repo/src/messages/message_record.rs
+++ b/crates/forge_repo/src/messages/message_record.rs
@@ -1,0 +1,77 @@
+//! Diesel record for the `messages` table.
+//!
+//! Mirrors the marc27-core server schema in `20260510000045_conversations.sql`
+//! (UUID -> TEXT on SQLite, JSONB -> TEXT-storing-JSON, TIMESTAMPTZ -> BIGINT
+//! unix epoch ms). This is append-only per-message storage that runs
+//! alongside the legacy `conversations.context` blob — both are written
+//! during the v2.7.2 transition and the blob remains the canonical
+//! hydration source until the per-message read path is wired up.
+//!
+//! The record only models the storage shape. Conversion to/from
+//! `forge_domain::ContextMessage` lives at the call site — fan-out from a
+//! single `Context` into a row stream needs ordinal allocation that this
+//! type doesn't own.
+//!
+//! Currently dormant — wiring the read/write paths to these types lands in
+//! a follow-up PR. `dead_code` is allowed module-wide so the build stays
+//! warning-free while the schema settles.
+
+#![allow(dead_code)]
+
+use crate::database::schema::messages;
+
+/// Allowed values for `messages.role`. The CHECK constraint in DDL is the
+/// source of truth; this enum exists so call sites don't fat-finger the
+/// string. Keep the `as_str` mapping in sync with the migration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MessageRole {
+    System,
+    User,
+    Assistant,
+    Tool,
+}
+
+impl MessageRole {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::System => "system",
+            Self::User => "user",
+            Self::Assistant => "assistant",
+            Self::Tool => "tool",
+        }
+    }
+}
+
+/// Database model for the `messages` table.
+///
+/// Field-by-field mirror of the server schema:
+/// - `id` — UUID rendered as TEXT (Diesel SQLite convention).
+/// - `conversation_id` — soft FK; SQLite enforcement is loose, server
+///   enforces the real cascade.
+/// - `ordinal` — monotonic per conversation, client-assigned.
+///   `(conversation_id, ordinal)` is the idempotent upsert key.
+/// - `role` — one of `system|user|assistant|tool` (CHECK in DDL).
+/// - `content` / `tool_calls_json` / `tool_results_json` / `usage_json` —
+///   nullable; payloads are JSON-encoded TEXT on SQLite (JSONB on Postgres).
+///   `tool_results_json` should reference artifact IDs once the artifact
+///   table lands; never inline raw bytes.
+/// - `created_at` — unix epoch ms. BIGINT instead of `Timestamp` because
+///   we need a stable monotonic value for outbox ordering and clock-skew
+///   debugging across the local/server pair. The legacy `conversations`
+///   table uses `Timestamp` for historical reasons; not propagating here.
+#[derive(
+    Debug, Clone, diesel::Queryable, diesel::Selectable, diesel::Insertable, diesel::AsChangeset,
+)]
+#[diesel(table_name = messages)]
+#[diesel(check_for_backend(diesel::sqlite::Sqlite))]
+pub(crate) struct MessageRecord {
+    pub id: String,
+    pub conversation_id: String,
+    pub ordinal: i64,
+    pub role: String,
+    pub content: Option<String>,
+    pub tool_calls_json: Option<String>,
+    pub tool_results_json: Option<String>,
+    pub usage_json: Option<String>,
+    pub created_at: i64,
+}

--- a/crates/forge_repo/src/messages/mod.rs
+++ b/crates/forge_repo/src/messages/mod.rs
@@ -1,0 +1,2 @@
+mod message_record;
+mod sync_outbox_record;

--- a/crates/forge_repo/src/messages/sync_outbox_record.rs
+++ b/crates/forge_repo/src/messages/sync_outbox_record.rs
@@ -1,0 +1,49 @@
+//! Diesel record for the `sync_outbox` table.
+//!
+//! Write-through retry queue for the conversation mirror. After each local
+//! commit of one or more `messages` rows, the writer enqueues a row here
+//! describing the `[low_ordinal, high_ordinal]` slice for a conversation.
+//! A background worker pops the lowest `id`, fetches the slice, POSTs to
+//! `/v1/conversations/{id}/messages`, and deletes the outbox row on
+//! success. On failure it bumps `attempts` and updates `last_error` +
+//! `last_attempt_at`. The worker, retry policy, and TUI surfacing of
+//! poisoned rows (cap of 10 attempts per spec) are out of scope for this
+//! migration — only the storage shape lands here.
+//!
+//! Dormant alongside `MessageRecord` until the drain worker lands; see that
+//! file for the `dead_code` rationale.
+
+#![allow(dead_code)]
+
+use crate::database::schema::sync_outbox;
+
+/// Database model for an existing `sync_outbox` row (read path). The `id`
+/// column is `INTEGER PRIMARY KEY AUTOINCREMENT`; on insert use
+/// [`NewSyncOutboxRecord`], which omits `id` so SQLite assigns it.
+#[derive(Debug, Clone, diesel::Queryable, diesel::Selectable, diesel::AsChangeset)]
+#[diesel(table_name = sync_outbox)]
+#[diesel(check_for_backend(diesel::sqlite::Sqlite))]
+pub(crate) struct SyncOutboxRecord {
+    pub id: i32,
+    pub conversation_id: String,
+    pub low_ordinal: i64,
+    pub high_ordinal: i64,
+    pub attempts: i32,
+    pub last_attempt_at: Option<i64>,
+    pub last_error: Option<String>,
+    pub created_at: i64,
+}
+
+/// Insert-only shape that lets SQLite assign the AUTOINCREMENT id.
+#[derive(Debug, Clone, diesel::Insertable)]
+#[diesel(table_name = sync_outbox)]
+#[diesel(check_for_backend(diesel::sqlite::Sqlite))]
+pub(crate) struct NewSyncOutboxRecord {
+    pub conversation_id: String,
+    pub low_ordinal: i64,
+    pub high_ordinal: i64,
+    pub attempts: i32,
+    pub last_attempt_at: Option<i64>,
+    pub last_error: Option<String>,
+    pub created_at: i64,
+}


### PR DESCRIPTION
## Summary

Step 2 of the conversation server-side mirror, after marc27-core PR #9 (schema, merged) + marc27-sdk PR #1 (ConversationsAPI, merged) + marc27-core PR #11 (API routes, in CI).

Adds local SQLite tables that mirror the server-side schema. **Strictly additive** — the existing \`conversations.context\` blob path keeps running in parallel until per-message storage is wired in (next PR). No active code path changes.

## New tables

| Table | Why |
|---|---|
| \`messages\` | Append-only, mirrors marc27-core/migrations/20260510000045. UNIQUE \`(conversation_id, ordinal)\` for idempotent upsert; index \`(conversation_id, ordinal DESC)\` for latest-N hydrate. |
| \`sync_outbox\` | Write-through retry queue. \`INTEGER PRIMARY KEY AUTOINCREMENT\` for monotonic FIFO drain. Range fields \`(low_ordinal, high_ordinal)\` so one outbox row covers a batch. \`attempts\` + \`last_attempt_at\` + \`last_error\` for backoff. |

## Stacked sequence

1. ~~marc27-core #9 (schema)~~ — merged
2. ~~marc27-sdk #1 (ConversationsAPI)~~ — merged
3. **marc27-core #11 (API routes)** — in CI
4. **THIS PR** (local tables, additive)
5. Followup: \`upsert_conversation\` modification — extract messages, write to \`messages\` table, enqueue outbox row
6. Followup: outbox drain worker
7. Followup: wire drain into chat loop

Each step independently mergeable.

## Test plan

- [x] \`cargo check -p forge_repo\` clean
- [x] \`cargo test -p forge_repo --lib conversation\` — 39/39 pass (migration runs against in-memory pool)
- [x] \`cargo fmt\` + \`cargo clippy --lib -- -D warnings\` clean

## Concerns flagged by sub-agent

- \`created_at\` is BIGINT (epoch ms) per spec, not Diesel \`Timestamp\` (which the legacy \`conversations\` table uses). Trade-off: outbox FIFO drain wants BIGINT semantics; cross-table comparison will need explicit conversion.
- JSON columns are TEXT (SQLite has no JSONB). Wire encoders need \`serde_json::from_str\` on read.
- \`role\` CHECK constraint exists in DDL only (Diesel SQLite doesn't surface CHECK in schema.rs). Enforcement on writes via \`MessageRole\` enum.
- No FK on \`messages.conversation_id\` (SQLite is loose; just index per spec). Conversation deletion will need explicit \`DELETE FROM messages WHERE conversation_id = ?\` in the future.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistent message storage with conversation-based organization and ordering
  * Introduced message synchronization queue with automatic retry handling and error tracking
  * Support for tracking message metadata including roles, content, tool interactions, and usage information

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Darth-Hidious/PRISM/pull/104)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->