### PR TITLE
fix(tools): query_materials_project — 3-tier auth fallback (local → platform proxy → suggest materials_search)

### DIFF
--- a/app/tools/data.py
+++ b/app/tools/data.py
@@ -63,33 +63,161 @@ def _search_materials(**kwargs) -> dict:
 
 
 def _query_materials_project(**kwargs) -> dict:
+    """Query Materials Project. Tries local MP_API_KEY first, then the
+    MARC27 platform proxy (which has the key set on the server side
+    for ESA / paid programs), then suggests `materials_search` as a
+    keyless fallback (OPTIMADE federation includes MP).
+
+    Three-tier auth so the LLM doesn't hit a hard wall on day one:
+      1. Local MP_API_KEY env var  → direct mp_api.client call.
+      2. MARC27 platform proxy     → POST /v1/data/materials-project
+                                      with the user's bearer token.
+      3. Keyless OPTIMADE alt      → error message points to
+                                      `materials_search`.
+    """
     formula = kwargs.get("formula")
     material_id = kwargs.get("material_id")
-    properties = kwargs.get("properties", ["material_id", "formula_pretty", "band_gap", "formation_energy_per_atom", "energy_above_hull", "is_metal"])
+    properties = kwargs.get(
+        "properties",
+        [
+            "material_id",
+            "formula_pretty",
+            "band_gap",
+            "formation_energy_per_atom",
+            "energy_above_hull",
+            "is_metal",
+        ],
+    )
+    if not formula and not material_id:
+        return {"error": "Provide either 'formula' or 'material_id'"}
+
+    import os
+
+    # Tier 1: local key
+    api_key = os.getenv("MP_API_KEY")
+    if api_key:
+        try:
+            from mp_api.client import MPRester
+
+            with MPRester(api_key) as mpr:
+                if material_id:
+                    docs = mpr.materials.summary.search(
+                        material_ids=[material_id], fields=properties
+                    )
+                else:
+                    docs = mpr.materials.summary.search(formula=formula, fields=properties)
+                results = []
+                for doc in docs[:20]:
+                    entry = {}
+                    for prop in properties:
+                        val = getattr(doc, prop, None)
+                        if val is not None:
+                            entry[prop] = (
+                                val
+                                if isinstance(val, (str, int, float, bool))
+                                else str(val)
+                            )
+                    results.append(entry)
+                return {
+                    "results": results,
+                    "count": len(results),
+                    "source": "local_mp_api_key",
+                }
+        except Exception as e:
+            # Local key present but mp_api.client failed (e.g. invalid key,
+            # network blocked). Fall through to the platform proxy below.
+            local_err = str(e)
+        else:
+            local_err = None
+    else:
+        local_err = None
+
+    # Tier 2: platform proxy
+    proxy_result = _query_materials_project_via_platform(
+        formula=formula,
+        material_id=material_id,
+        properties=properties,
+    )
+    if proxy_result is not None and "error" not in proxy_result:
+        proxy_result["source"] = "marc27_platform_proxy"
+        return proxy_result
+
+    # Tier 3: tell the LLM the fallback. The system prompt's recovery
+    # rules will pick `materials_search` next.
+    error_lines = [
+        "Materials Project query failed.",
+        "  - Local MP_API_KEY: " + (local_err or "not set"),
+        "  - MARC27 platform proxy: "
+        + ((proxy_result or {}).get("error") or "not reachable"),
+        "Recommended next tool: `materials_search` (OPTIMADE federation, "
+        "no key required, covers Materials Project + 19 other databases).",
+    ]
+    return {"error": "\n".join(error_lines)}
+
+
+def _query_materials_project_via_platform(
+    formula=None, material_id=None, properties=None
+) -> dict | None:
+    """POST /v1/data/materials-project on the MARC27 platform.
+
+    Uses the user's bearer token (read by `_resolve_credentials` in
+    research.py / platform_status.py); the platform server holds the
+    actual MP_API_KEY in its env. Returns the parsed JSON or `None` if
+    the user isn't authenticated. An `{"error": ...}` dict on any
+    HTTP / network / decode failure (the caller distinguishes via the
+    presence of an `error` key).
+    """
     try:
-        from mp_api.client import MPRester
-        import os
-        api_key = os.getenv("MP_API_KEY")
-        if not api_key:
-            return {"error": "MP_API_KEY not set. Configure with: prism configure --mp-api-key YOUR_KEY"}
-        with MPRester(api_key) as mpr:
-            if material_id:
-                docs = mpr.materials.summary.search(material_ids=[material_id], fields=properties)
-            elif formula:
-                docs = mpr.materials.summary.search(formula=formula, fields=properties)
-            else:
-                return {"error": "Provide either 'formula' or 'material_id'"}
-            results = []
-            for doc in docs[:20]:
-                entry = {}
-                for prop in properties:
-                    val = getattr(doc, prop, None)
-                    if val is not None:
-                        entry[prop] = val if isinstance(val, (str, int, float, bool)) else str(val)
-                results.append(entry)
-            return {"results": results, "count": len(results)}
-    except Exception as e:
-        return {"error": str(e)}
+        import json
+        from pathlib import Path
+
+        import requests
+    except Exception:
+        return None
+
+    # Mirrors `_resolve_credentials` from app/tools/research.py to avoid
+    # cross-module coupling at this layer.
+    api_url = os.getenv("MARC27_API_URL", "https://api.marc27.com/api/v1").rstrip("/")
+    api_key = os.getenv("MARC27_API_KEY", "")
+    if not api_key:
+        try:
+            creds_path = Path.home() / ".prism" / "credentials.json"
+            if creds_path.exists():
+                creds = json.loads(creds_path.read_text())
+                api_key = creds.get("access_token", "")
+                if creds.get("platform_url"):
+                    api_url = creds["platform_url"].rstrip("/")
+                    if not api_url.endswith("/api/v1"):
+                        api_url = api_url + "/api/v1"
+        except Exception:
+            pass
+    if not api_key:
+        return None
+
+    body = {"properties": properties}
+    if material_id:
+        body["material_id"] = material_id
+    if formula:
+        body["formula"] = formula
+
+    try:
+        resp = requests.post(
+            f"{api_url}/data/materials-project",
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            json=body,
+            timeout=30,
+        )
+        if resp.status_code != 200:
+            return {
+                "error": f"platform proxy returned HTTP {resp.status_code}",
+                "body": resp.text[:500],
+            }
+        return resp.json()
+    except requests.exceptions.RequestException as e:
+        return {"error": f"platform proxy network error: {e}"}
 
 
 def _import_dataset(**kwargs) -> dict:


### PR DESCRIPTION
## Summary

Live end-to-end test of the BimoTech / Fraunhofer / ArianeGroup ESA prompt failed because \`query_materials_project\` reads \`os.getenv('MP_API_KEY')\` only — but the Railway server has the key, not the user's local env. Fatal for the deck's \"AI-driven PRISM strategy engine\" framing.

## Three-tier auth chain

| Tier | When | Path |
|---|---|---|
| 1. Local key | \`MP_API_KEY\` env set | Direct \`mp_api.client.MPRester\` (legacy path, fastest) |
| 2. Platform proxy | No local key, valid \`~/.prism/credentials.json\` | POST \`/v1/data/materials-project\` with bearer auth (companion PR: marc27-core feat/data-mp-proxy) |
| 3. Keyless suggestion | Both above failed | Structured error pointing at \`materials_search\` (OPTIMADE — covers MP + 19 others) |

The error message in tier 3 is structured so the system prompt's recovery rules (PR #109) can route to \`materials_search\` next turn.

## Why all three

- Tier 1 stays for power users with their own keys.
- Tier 2 is the **ESA-program path** — every PRISM seat works out of the box once the marc27-core proxy lands.
- Tier 3 is the day-one fallback if neither the local key NOR the platform proxy is reachable.

## Companion

Server-side broker is in marc27-core PR #12 (\`feat/data-mp-proxy\`). Both should land together for tier 2 to actually work; ship order is marc27-core first, then this.

## Test plan

- [x] \`python3 -c \"from app.tools.data import _query_materials_project, _query_materials_project_via_platform\"\` — imports clean.
- [x] \`pytest tests/test_bootstrap.py tests/test_platform_status_tools.py\` — 22/22 pass.
- [ ] Manual: with no local MP_API_KEY but a valid \`~/.prism/credentials.json\`, call the tool with \`formula='WMoTaNb'\` → should land on tier 2 and return real MP entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)