### PR TITLE
fix(llm): long-horizon orchestration discipline in system prompt

### DIFF
--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -901,7 +901,44 @@ fn build_tool_prompt_block(tools: &[ToolDefinition]) -> String {
         For ANY recommendation you give the user: cite the source. \
         \"Composition X has property Y\" must come with a tool result reference \
         (DB id, paper DOI, predict() output id). \"It's a known refractory \
-        alloy\" without a citation is hallucination, not strategy.\n\
+        alloy\" without a citation is hallucination, not strategy.\n\n\
+        ## Long-horizon discipline (the difference between PRISM and a chatbot)\n\n\
+        Real materials questions take MANY tool calls — typically 8 to 30 — \
+        and span minutes, not seconds. The literature shows that LLMs at long \
+        horizons fail in two predictable ways: they (a) terminate early after \
+        2–3 tool calls, returning a thin answer, or (b) forget the original \
+        constraint by turn 10. Both are unacceptable here. The user is paying \
+        for a strategy engine; behave like one.\n\n\
+        **For any non-trivial question (not a single-fact lookup), follow this \
+        loop:**\n\n\
+        1. **Plan first, in writing.** Before ANY tool call, emit a numbered \
+        plan listing the sub-questions you need to answer and which tool you \
+        will use for each. This is your scratchpad and your contract with \
+        the user. Re-read it before every subsequent tool call.\n\
+        2. **Use `research` for deep multi-hop questions.** `research(question=...)` \
+        runs a server-side Recursive Language Model that does iterative \
+        decomposition + literature search + KG traversal in ONE call. Prefer \
+        ONE `research` call over five hand-rolled `prior_art_search` + `web` \
+        calls when the question is open-ended (\"design an alloy for X\", \
+        \"compare approaches to Y\"). It exists because of arxiv:2512.24601; \
+        you are the one calling it.\n\
+        3. **Persist past the urge to wrap up.** If you've made fewer than \
+        five tool calls on a multi-part question, you are NOT done. Asking \
+        yourself \"do I have enough?\" after two calls is the failure mode. \
+        Instead ask: \"which sub-question on my plan is still un-answered?\" \
+        and call the next tool.\n\
+        4. **Re-anchor on the original goal every ~5 turns.** Quote the \
+        user's original ask back to yourself in your reasoning. The most \
+        common long-horizon failure is silently drifting from \"design an RHEA \
+        for LPBF at 2200 °C\" to \"list some refractory metals\".\n\
+        5. **Deliberate completion.** When you ARE done, emit the marker \
+        `FINAL ANSWER:` followed by the synthesized answer with citations. \
+        This is the only acceptable way to end a research turn. An empty \
+        response, or a response that just summarizes one tool's output \
+        without synthesis, is not completion — it is giving up.\n\n\
+        Long horizon is the product. The compaction system, the research \
+        tool, and the recovery rules above all exist so you can sustain \
+        20+ tool calls on one question without losing the thread. Use them.\n\
     ");
 
     block


### PR DESCRIPTION
## Why

Yesterday's BimoTech / Fraunhofer end-to-end test surfaced the *real* product problem: PRISM's chat LLM gives up after 2-3 tool calls on questions that legitimately need 8-30. Materials-discovery questions are long-horizon by definition. The recovery rules in #109 fixed *one* class of premature termination (giving up after a single tool error). The empirical literature shows there's a second, larger class — the LLM "decides it's done" mid-task and returns a thin answer.

## What the literature actually says

| Paper | Finding relevant to PRISM |
|---|---|
| **Long-Horizon Task Mirage** (arxiv 2604.11978) | Two of the seven dominant failure modes are catastrophic forgetting (#5) and false assumptions (#7). Both are about the agent silently drifting from the original constraint. |
| **Beyond pass@1: Reliability Science Framework** (arxiv 2603.29231) | Quantifies "reliability decay curve". Recommends MOP-triggered context-reset interventions and explicit checkpoint-and-restart policies. |
| **Empirical study on horizon length** (arxiv 2605.02572) | GLM-4.5 Air early-termination rate rises from 1% (short) to 25% (very long). DeepSeek V3 from 2% to 11%. The sharpest jump is at the long-to-very-long boundary — exactly where BimoTech-class questions sit. |
| **Recursive Language Models** (arxiv 2512.24601, MIT CSAIL Zhang/Kraska/Khattab) | The `FINAL()` / `FINAL_VAR()` markers in RLM exist specifically to *force deliberate completion* and prevent empty-response early exits. PRISM already implements this paper as the server-side `research()` tool — but the chat LLM doesn't know to use it. |
| **Building AI Coding Agents for the Terminal** (arxiv 2603.05344) | Context Engineering Layer = System Reminders + Prompt Composer + Memory + Compaction. PRISM has the compaction half (#96, #98) but the system-reminders half is thin. |

## What this PR adds

Five system-prompt patterns, ~30 lines added, no code changes:

1. **Plan-first.** Emit a numbered plan before any tool call, re-read it before each subsequent one. Direct mitigation for catastrophic forgetting.
2. **Use `research()` for deep questions.** PRISM already runs an RLM server-side; promote it from a one-line tool reference to the canonical first move for open-ended materials questions.
3. **Persistence framing.** Explicit "fewer than 5 tool calls on a multi-part question = not done" — directly combats the measured 1% → 25% early-termination curve.
4. **Re-anchor every ~5 turns.** Quote the user's original ask back to oneself. "Design an RHEA for LPBF at 2200 °C" must not silently become "list some refractory metals" by turn 12.
5. **Deliberate completion via `FINAL ANSWER:` marker.** Echoes RLM's `FINAL()` mechanism — completion is an explicit speech act, not a default fall-through when the model runs out of ideas.

## What this PR is NOT

- Not a code change. System prompt only.
- Not a re-test of the BimoTech prompt. Per @Darth-Hidious: real-world testing is about whether the *class* of long-horizon questions works, not about memorizing one prompt.
- Not the end of long-horizon work. Reliability decay still warrants per-turn budget tracking; that's a follow-up PR if metrics show it's needed.

## Test plan
- [x] `cargo check -p prism-llm` passes locally
- [ ] CI green
- [ ] Local rebuild + spot-check on a non-BimoTech multi-part materials question (e.g. "compare creep performance of three nickel superalloys for turbine blade application at 1100 °C")
- [ ] Verify the LLM (a) emits a plan, (b) calls `research()` rather than five hand-rolled lookups, (c) ends with `FINAL ANSWER:` + citations

🤖 Generated with [Claude Code](https://claude.com/claude-code)