### PR TITLE
test(llm): pin long-horizon orchestration markers

### DIFF
--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -1167,12 +1167,24 @@ mod tests {
         let block = build_tool_prompt_block(&[]);
         let required_markers: &[(&str, &str)] = &[
             ("DO NOT GIVE UP", "recovery-rules header from #109"),
-            ("NEVER respond with empty content", "anti-early-termination rule from #109"),
-            ("Tool-composition patterns", "composition cookbook header from #109"),
-            ("Long-horizon discipline", "long-horizon section header from #111"),
+            (
+                "NEVER respond with empty content",
+                "anti-early-termination rule from #109",
+            ),
+            (
+                "Tool-composition patterns",
+                "composition cookbook header from #109",
+            ),
+            (
+                "Long-horizon discipline",
+                "long-horizon section header from #111",
+            ),
             ("Plan first, in writing", "plan-emission rule from #111"),
             ("FINAL ANSWER:", "deliberate-completion marker from #111"),
-            ("research", "research() tool referenced in long-horizon flow"),
+            (
+                "research",
+                "research() tool referenced in long-horizon flow",
+            ),
         ];
         for (marker, why) in required_markers {
             assert!(

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -1149,6 +1149,41 @@ mod tests {
         }
     }
 
+    /// Pin the long-horizon orchestration patterns shipped in PRs #109 and #111.
+    ///
+    /// These markers exist because the BimoTech / Fraunhofer end-to-end test
+    /// surfaced two real failure modes: (1) the LLM gave up after one tool
+    /// error, and (2) the LLM wrapped up after 2-3 tool calls on a question
+    /// that needed 8-30. The fixes are SYSTEM PROMPT TEXT — they have no
+    /// other code path. If a future refactor silently drops these strings,
+    /// the regression isn't visible until a customer hits it. This test
+    /// catches the silent-drop case.
+    ///
+    /// Backed by the literature: arxiv 2604.11978 (Long-Horizon Mirage),
+    /// arxiv 2603.29231 (Beyond pass@1), arxiv 2512.24601 (RLM `FINAL()`),
+    /// arxiv 2605.02572 (empirical horizon-length study).
+    #[test]
+    fn long_horizon_orchestration_markers_present() {
+        let block = build_tool_prompt_block(&[]);
+        let required_markers: &[(&str, &str)] = &[
+            ("DO NOT GIVE UP", "recovery-rules header from #109"),
+            ("NEVER respond with empty content", "anti-early-termination rule from #109"),
+            ("Tool-composition patterns", "composition cookbook header from #109"),
+            ("Long-horizon discipline", "long-horizon section header from #111"),
+            ("Plan first, in writing", "plan-emission rule from #111"),
+            ("FINAL ANSWER:", "deliberate-completion marker from #111"),
+            ("research", "research() tool referenced in long-horizon flow"),
+        ];
+        for (marker, why) in required_markers {
+            assert!(
+                block.contains(marker),
+                "long-horizon marker `{marker}` missing from prompt block ({why}). \
+                 If you intentionally removed it, update this test. If not, \
+                 you've silently regressed PR #109 or #111."
+            );
+        }
+    }
+
     #[test]
     fn quick_reference_does_not_mention_renamed_tools() {
         // Belt-and-braces: explicit deny-list of names we've previously


### PR DESCRIPTION
## Why

PRs #109 and #111 ship behaviors as pure system-prompt text. There's no other code path — if a future refactor silently drops a section, no test fails until a customer hits the regression in a long-horizon question.

## What

One regression test, `long_horizon_orchestration_markers_present`, that asserts the seven load-bearing strings remain in the prompt block:

| Marker | From PR | Defends against |
|---|---|---|
| \`DO NOT GIVE UP\` | #109 | Removing the recovery-rules header |
| \`NEVER respond with empty content\` | #109 | Allowing empty-response early termination |
| \`Tool-composition patterns\` | #109 | Dropping the cookbook |
| \`Long-horizon discipline\` | #111 | Removing the long-horizon section |
| \`Plan first, in writing\` | #111 | Losing the plan-emission rule |
| \`FINAL ANSWER:\` | #111 | Losing the deliberate-completion marker |
| \`research\` | #111 | Removing the RLM tool reference from the long-horizon flow |

Same defensive pattern already used for tool-name drift (\`quick_reference_names_appear_in_prompt\` and \`quick_reference_does_not_mention_renamed_tools\`).

## Citations in the test docstring
- arxiv 2604.11978 — Long-Horizon Task Mirage
- arxiv 2603.29231 — Beyond pass@1
- arxiv 2512.24601 — Recursive Language Models
- arxiv 2605.02572 — Empirical study of horizon length

## Test plan
- [x] \`cargo test -p prism-llm long_horizon_orchestration_markers_present\` passes
- [x] All 7 prism-llm tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test validation to ensure the LLM system prompt contains required orchestration marker strings.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Darth-Hidious/PRISM/pull/112)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->