### PR TITLE
fix(infra): grpc channel returns Err on empty URL instead of panicking

### DIFF
--- a/crates/forge_infra/src/grpc.rs
+++ b/crates/forge_infra/src/grpc.rs
@@ -30,6 +30,16 @@ impl ForgeGrpcClient {
     ///
     /// Channels are cheap to clone and can be shared across multiple clients.
     /// The channel is created on first call and cached for subsequent calls.
+    ///
+    /// Returns `Err` (instead of panicking) when the configured `server_url`
+    /// is empty or malformed, so the caller can surface the failure into the
+    /// chat loop's normal tool-error recovery path. Previously this used
+    /// `.expect("Invalid server URL")` which would panic the entire chat UI
+    /// if any code path constructed a `ForgeGrpcClient` with an empty URL
+    /// (default `services_url` is `""` per `forge_config::config`). PRISM's
+    /// long-horizon agent runs touched this path during semantic-search /
+    /// fuzzy-search calls and crashed mid-conversation; see the BimoTech /
+    /// Fraunhofer end-to-end trace for the failing case.
     pub fn channel(&self) -> anyhow::Result<Channel> {
         let mut guard = self.channel.lock().unwrap();
 
@@ -37,8 +47,20 @@ impl ForgeGrpcClient {
             return Ok(channel.clone());
         }
 
+        if self.server_url.is_empty() {
+            anyhow::bail!(
+                "Forge services URL is not configured \
+                 (`services_url` is empty in config) — \
+                 the gRPC channel cannot be opened. \
+                 Set `services_url` in .forge.toml or skip the gRPC-backed \
+                 indexing path"
+            );
+        }
+
         let mut channel = Channel::from_shared(self.server_url.to_string())
-            .expect("Invalid server URL")
+            .map_err(|e| {
+                anyhow::anyhow!("invalid services URL `{}`: {e}", self.server_url)
+            })?
             .concurrency_limit(256);
 
         // Enable TLS for https URLs (webpki-roots is faster than native-roots)
@@ -62,5 +84,45 @@ impl ForgeGrpcClient {
     pub fn hydrate(&self) {
         let mut guard = self.channel.lock().unwrap();
         *guard = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression: empty `server_url` must not panic the chat UI.
+    ///
+    /// Default `forge_config::ForgeConfig::services_url` is `""` (serde
+    /// `#[serde(default)]` on a `String`). When PRISM's long-horizon agent
+    /// loop reached a `context_engine` / `fuzzy_search` step, the resulting
+    /// `ForgeGrpcClient::channel()` panicked at `.expect("Invalid server URL")`,
+    /// taking down the whole chat UI mid-conversation. The fix is to return
+    /// `Err` so the chat loop's recovery rules can do their job.
+    #[test]
+    fn channel_returns_err_on_empty_url_instead_of_panicking() {
+        let client = ForgeGrpcClient::new(String::new());
+        let result = client.channel();
+        assert!(
+            result.is_err(),
+            "empty server_url must produce an Err, not a Channel"
+        );
+        let msg = format!("{:#}", result.unwrap_err());
+        assert!(
+            msg.contains("services_url") || msg.contains("not configured"),
+            "error must explain the misconfiguration, got: {msg}"
+        );
+    }
+
+    /// Belt-and-braces: a syntactically invalid URL must also propagate as
+    /// `Err`, not panic. (`Channel::from_shared` returns the error path.)
+    #[test]
+    fn channel_returns_err_on_malformed_url_instead_of_panicking() {
+        let client = ForgeGrpcClient::new("not a url".to_string());
+        let result = client.channel();
+        assert!(
+            result.is_err(),
+            "malformed server_url must produce an Err, not a Channel"
+        );
     }
 }

--- a/crates/forge_infra/src/grpc.rs
+++ b/crates/forge_infra/src/grpc.rs
@@ -58,9 +58,7 @@ impl ForgeGrpcClient {
         }
 
         let mut channel = Channel::from_shared(self.server_url.to_string())
-            .map_err(|e| {
-                anyhow::anyhow!("invalid services URL `{}`: {e}", self.server_url)
-            })?
+            .map_err(|e| anyhow::anyhow!("invalid services URL `{}`: {e}", self.server_url))?
             .concurrency_limit(256);
 
         // Enable TLS for https URLs (webpki-roots is faster than native-roots)


### PR DESCRIPTION
## Found by driving the system end-to-end

Set up \`pty-debug\` MCP, spawned \`prism tui\` with the new (post-#109/#111) binary, sent a fresh long-horizon materials prompt: *"Compare creep performance of Inconel 718, René 95, and Waspaloy at 1100°C for turbine disk applications, and recommend which is best suited for additive manufacturing via LPBF. Cite sources for each property claim."*

**The good news first** — the long-horizon discipline from #109/#111 is working:

- ✅ Agent emitted a plan at 15:20:37 (\`Plan-first\`)
- ✅ Agent persisted past 15+ tool calls (\`persistence framing\`)
- ✅ Agent escalated to \`research_query\` (the RLM tool) twice after URL fetches failed (\`research()-as-default for deep questions\`)
- ✅ Agent didn't give up after 3 consecutive 403 errors (\`recovery rules\`)

**Then at 4:42m the chat UI panicked:**

\`\`\`
[prism] chat UI panic: panicked at crates/forge_infra/src/grpc.rs:41:14:
Invalid server URL: InvalidUri(Empty)
\`\`\`

## Root cause

\`forge_config::ForgeConfig::services_url\` is \`String\` with \`#[serde(default)]\`, so an absent config field becomes \`""\`. \`ForgeGrpcClient::new("")\` sat dormant in \`ForgeInfra\` until the agent loop hit a code path calling \`channel()\` (semantic-search / fuzzy-search). At that point \`Channel::from_shared("")\` returned an error and \`.expect("Invalid server URL")\` panicked the whole chat UI mid-conversation.

After the panic, the agent visibly lost in-flight context and reverted to retrying the same URLs in a tight loop — see the trace going from sensible CrossRef DOI lookups before the panic to repeated retries of the same 403'd specialmetals.com URLs after.

## Fix

Two layers in \`channel()\`:

1. **Short-circuit on empty URL** with an \`anyhow::bail!\` that names the misconfiguration (\`services_url\` is empty in config).
2. **Replace \`.expect()\` with \`.map_err(...)?\`** for non-empty-but-malformed URLs.

All existing call sites already do \`.channel()?\` so the new \`Err\` path flows into the chat loop's normal tool-error recovery (PR #109).

## Regression tests

\`channel_returns_err_on_empty_url_instead_of_panicking\` and \`channel_returns_err_on_malformed_url_instead_of_panicking\`. Both pass.

## Test plan
- [x] \`cargo test -p forge_infra grpc\` — both regression tests pass
- [x] Full forge_infra crate compiles
- [ ] CI green
- [ ] Rebuild + rerun the same prompt, confirm no panic, observe whether the URL-retry loop also resolves (suspected: the panic itself was triggering the loop by resetting context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during server connection setup to gracefully handle invalid or missing URLs without crashing, providing clear diagnostic error messages for easier troubleshooting instead of unexpected failures.

* **Tests**
  * Added comprehensive unit tests to verify the system properly handles empty and syntactically invalid server URLs with appropriate error responses.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Darth-Hidious/PRISM/pull/113)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->