### PR TITLE
fix(llm): tell the agent where materials data actually lives

### DIFF
--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -881,7 +881,25 @@ fn build_tool_prompt_block(tools: &[ToolDefinition]) -> String {
         ## Tool-composition patterns (USE THESE for the common tasks)\n\n\
         PRISM is a materials-discovery strategy engine, not just a chat model. \
         For non-trivial questions you should COMPOSE multiple tools instead of \
-        relying on a single one. The most common patterns:\n\n\
+        relying on a single one.\n\n\
+        **CRITICAL — where materials data actually lives:**\n\
+        - Materials property data (creep, modulus, density, band gap, etc.) \
+        lives in `materials_search` (federated DB across MP / OPTIMADE / 18 \
+        others) and in academic papers via `prior_art_search`. NOT on vendor \
+        websites.\n\
+        - Vendor PDFs (specialmetals.com, haynesintl.com, nickelinstitute.org, \
+        matweb.com, hightempmetals.com, …) are paywalled, robots-blocked, or \
+        gated. The `web` tool WILL return 403 / 404 / robots.txt on them. \
+        Do not chain guesses at vendor URLs — that loop never converges.\n\
+        - For ANY question of the form \"compare property X of alloys A, B, C\" \
+        or \"what is property Y of material Z\", your FIRST tool call should be \
+        `materials_search` or `prior_art_search` — never a `web` GET against a \
+        vendor domain.\n\
+        - `research` (the server-side RLM) is the right call when the question \
+        spans multiple alloy systems + multiple properties + needs synthesis. \
+        It already searches Semantic Scholar / arXiv / OpenAlex / the KG \
+        internally; you do not need to do that hop yourself.\n\n\
+        The most common patterns:\n\n\
         - **Materials-discovery**: \
         `materials_search` (federated DB lookup) → `prior_art_search` (literature \
         cross-check on the candidates that came back) → `predict` (only if you \


### PR DESCRIPTION
## Found by driving the system end-to-end (round 2)

After PR #113 (grpc panic fix) unblocked the loop, I reran the same creep-comparison prompt end-to-end through pty-debug. **No panic this time** — but a different failure: the agent picked `web` GETs against vendor domains as its FIRST tool calls, hit 403 / robots.txt on every one, and the tool-failure circuit breaker tripped at 7 retries. **Never once invoked `materials_search`, `prior_art_search`, or `research()`.**

## Why

The composition pattern from PR #109 said:
> Materials-discovery: \`materials_search\` → \`prior_art_search\` → \`predict\`

The LLM read this as advisory and went with what feels like the most direct path to the data: \`wget\` against the actual vendor website. For a question like "compare creep performance of Inconel 718, René 95, Waspaloy" the chat model defaults to "fetch the datasheet PDF from specialmetals.com" — but those URLs are 403'd / paywalled / robots-blocked.

## Fix

Adds one **CRITICAL** block at the top of the composition section that names:

1. WHERE materials property data actually lives — \`materials_search\`, \`prior_art_search\`, the KG. NOT vendor PDFs.
2. The exact vendor domains the LLM keeps trying (specialmetals.com, haynesintl.com, nickelinstitute.org, matweb.com, hightempmetals.com) and the rule "do not chain guesses at vendor URLs — that loop never converges."
3. The form of question that should trigger \`materials_search\` / \`prior_art_search\` first.
4. When \`research\` (the RLM) is the right call — multi-alloy + multi-property + synthesis — and that it already does the Semantic Scholar / arXiv / KG hops internally.

## Why three system-prompt PRs in a row

#109 = recovery rules (don't give up on tool error)
#111 = long-horizon discipline (plan, persist, FINAL ANSWER)
**this** = where to look for materials data

Each one addressed a different behavior surfaced by actually running the system end-to-end. The recovery rules and long-horizon discipline are necessary but not sufficient — without this PR, the LLM persists alright, just persistently in the wrong direction.

## Test plan
- [x] All 7 prism-llm tests still pass (including \`long_horizon_orchestration_markers_present\` from #112)
- [ ] CI green
- [ ] Rebuild binary, rerun the creep-comparison prompt, verify FIRST tool call is \`materials_search\` or \`prior_art_search\` (not \`web\` GET against a vendor domain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)