### PR TITLE
fix(llm): blacklist search engines + OSTI in system prompt

### DIFF
--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -891,6 +891,14 @@ fn build_tool_prompt_block(tools: &[ToolDefinition]) -> String {
         matweb.com, hightempmetals.com, …) are paywalled, robots-blocked, or \
         gated. The `web` tool WILL return 403 / 404 / robots.txt on them. \
         Do not chain guesses at vendor URLs — that loop never converges.\n\
+        - **Search engines + government repos block the `web` tool's User-Agent.** \
+        Do NOT call `web` GET on `google.com/search`, `bing.com/search`, \
+        `duckduckgo.com`, `osti.gov/servlets/*`, `osti.gov/biblio/*` — every one \
+        returns robots.txt or 403. Observed cost in real runs: ~15 wasted tool \
+        calls per question. Use `prior_art_search` (Semantic Scholar / arXiv / \
+        OpenAlex / PubMed) or `research` instead. The CrossRef API \
+        (`api.crossref.org/works`) IS accessible and is the right place for \
+        DOI-based citation lookups.\n\
         - For ANY question of the form \"compare property X of alloys A, B, C\" \
         or \"what is property Y of material Z\", your FIRST tool call should be \
         `materials_search` or `prior_art_search` — never a `web` GET against a \


### PR DESCRIPTION
## Why

From Test 3 trace (ODS ferritic alloy prompt, 2026-05-10): before hitting the MARC27 monthly quota, the agent burned ~15 tool calls on URLs that always return 403 / robots.txt:

| URL pattern | Calls in Test 3 | Result |
|---|---|---|
| \`google.com/search?q=...\` | 4 | robots.txt 403 |
| \`osti.gov/servlets/purl/...\` | 2 | robots.txt |
| \`osti.gov/biblio/...\` | 2 | robots.txt |
| \`bing.com\`, \`duckduckgo.com\` | (Tests 1-2) | same pattern |

Every one of these is wasted budget. PRISM's \`web\` tool is a vanilla reqwest GET with no cookie jar / no JS / no special UA — search engines and government repos all gate on robots.txt.

## Fix

Cheap interim — extend the existing "where materials data lives" block in the system prompt to explicitly name search-engine + OSTI domains as do-not-call. Pair with the existing guidance: use \`prior_art_search\` / \`research\` for paper discovery, CrossRef API for DOI lookups (which IS accessible and the agent already uses correctly).

## Why this is interim

The real fix is the headless-browser tool PR (in the tool-quality series). That replaces reqwest with Playwright/Chromium so most of these gated domains actually work. Until that lands, this prompt addition saves ~15 tool calls per long-horizon question.

## Test plan
- [x] All 7 prism-llm tests pass (including \`long_horizon_orchestration_markers_present\` regression)
- [ ] CI green
- [ ] Validate next time we test against a fresh long-horizon prompt: zero \`google.com/search\` calls in trace

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated system prompt guidance for improved web tool handling and awareness of potential domain access restrictions. The system now recommends alternative tools in certain scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Darth-Hidious/PRISM/pull/115)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->