### PR TITLE
test(llm): pin vendor-PDF + search-engine-blacklist markers from #114/#115

### DIFF
--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -1207,9 +1207,51 @@ mod tests {
             ),
             ("Plan first, in writing", "plan-emission rule from #111"),
             ("FINAL ANSWER:", "deliberate-completion marker from #111"),
+            // Tightened from a bare `research` substring (which would match
+            // `research`, `prior_art_search`, `research_query`, and 12 other
+            // unrelated occurrences — the previous form was effectively a
+            // no-op). The new pin is the specific guidance string that
+            // PR #111 added to direct the agent at the RLM tool for deep
+            // multi-hop questions.
             (
-                "research",
-                "research() tool referenced in long-horizon flow",
+                "Use `research` for deep multi-hop questions",
+                "RLM-as-default rule from #111",
+            ),
+            // PR #114 — vendor-PDF clarifier. Without these pins, the
+            // entire "where materials data actually lives" block can be
+            // silently deleted with green tests. The end-to-end Test 3
+            // trace (2026-05-10 ODS-alloy prompt) confirmed the agent
+            // genuinely changes behaviour when this section is present.
+            (
+                "where materials data actually lives",
+                "vendor-PDF clarifier section header from #114",
+            ),
+            (
+                "Vendor PDFs",
+                "vendor-PDF do-not-call rule from #114",
+            ),
+            (
+                "Do not chain guesses at vendor URLs",
+                "anti-URL-enumeration rule from #114",
+            ),
+            // PR #115 — search engine + OSTI blacklist. Concrete domain
+            // names are pinned because the rule's effectiveness depends on
+            // the agent reading them verbatim.
+            (
+                "Search engines + government repos block",
+                "search-engine blacklist section header from #115",
+            ),
+            (
+                "google.com/search",
+                "blacklisted Google search URL pattern from #115",
+            ),
+            (
+                "osti.gov",
+                "blacklisted OSTI repo pattern from #115",
+            ),
+            (
+                "CrossRef API",
+                "allowed-fallback CrossRef pointer from #115",
             ),
         ];
         for (marker, why) in required_markers {
@@ -1217,7 +1259,7 @@ mod tests {
                 block.contains(marker),
                 "long-horizon marker `{marker}` missing from prompt block ({why}). \
                  If you intentionally removed it, update this test. If not, \
-                 you've silently regressed PR #109 or #111."
+                 you've silently regressed PR #109, #111, #114, or #115."
             );
         }
     }


### PR DESCRIPTION
## Why

Cleanup-audit finding (medium severity, surfaced by Code Reviewer sub-agent): the regression test \`long_horizon_orchestration_markers_present\` (PR #112) had no assertions for the markers introduced in PR #114 (vendor-PDF clarifier) or PR #115 (search-engine + OSTI blacklist). Without those pins, the entire "where materials data actually lives" block and the search-engine blacklist could be silently deleted from the system prompt and the test would still pass — the same regression risk PR #112 was meant to defend against, but only covered #109 + #111.

End-to-end **Test 3** (2026-05-10, ODS-alloy prompt) confirmed the agent genuinely changes behavior when these sections are present:
- \`research_query\` as the FIRST tool call instead of vendor URL GETs
- Zero \`google.com/search\` retries

Pinning protects that behavior under future refactors.

## Also tightening the loose \`research\` marker

The previous test asserted bare \`research\` substring exists. But \`research\` appears 14+ times in the rendered prompt (\`research\`, \`prior_art_search\`, \`research_query\`, etc.), so the assertion was effectively a no-op — the entire long-horizon section could be deleted and the test would still pass on \`prior_art_search\` alone. Replaced with the specific guidance string \`Use \`research\` for deep multi-hop questions\` that PR #111 added.

## Coverage now (14 markers, was 7)

| Marker | Defends |
|---|---|
| \`DO NOT GIVE UP\` | #109 recovery-rules header |
| \`NEVER respond with empty content\` | #109 anti-early-termination |
| \`Tool-composition patterns\` | #109 composition cookbook |
| \`Long-horizon discipline\` | #111 section header |
| \`Plan first, in writing\` | #111 plan-emission rule |
| \`FINAL ANSWER:\` | #111 deliberate-completion marker |
| **\`Use \\\`research\\\` for deep multi-hop questions\`** | #111 RLM-as-default *(tightened from bare \`research\`)* |
| **\`where materials data actually lives\`** | #114 vendor-PDF section header (NEW) |
| **\`Vendor PDFs\`** | #114 vendor-PDF do-not-call rule (NEW) |
| **\`Do not chain guesses at vendor URLs\`** | #114 anti-URL-enumeration (NEW) |
| **\`Search engines + government repos block\`** | #115 blacklist section header (NEW) |
| **\`google.com/search\`** | #115 specific blacklisted pattern (NEW) |
| **\`osti.gov\`** | #115 specific blacklisted pattern (NEW) |
| **\`CrossRef API\`** | #115 allowed-fallback pointer (NEW) |

## Test plan
- [x] All 7 prism-llm tests still pass (\`cargo test -p prism-llm --lib\`)
- [x] Each new marker verified to appear in the rendered prompt at least once
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)