### PR TITLE
feat(marketplace): `prism marketplace find` — semantic discovery from the CLI

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -631,6 +631,30 @@ enum MarketplaceCommands {
         /// Name of the tool or workflow.
         name: String,
     },
+    /// Semantic discovery — find marketplace tools/models/datasets by what
+    /// they do, not by exact name. Wraps `POST /marketplace/find` which
+    /// does RBAC-aware cosine search over the prism-resource-registry
+    /// corpus.
+    ///
+    /// Use this when the curated tool list doesn't have what you need —
+    /// the marketplace has the long tail (custom predictors, vendor MCPs,
+    /// user-uploaded skills) that isn't worth listing in the prompt.
+    Find {
+        /// Natural-language description of what you're looking for.
+        /// E.g. `"predict elastic moduli of a Ti-Al alloy"`.
+        query: String,
+        /// Restrict to specific resource_type values. Pass multiple times
+        /// for an OR. Omit to search every type.
+        #[arg(long = "type", value_name = "TYPE")]
+        types: Vec<String>,
+        /// Max number of hits to return. Typical: 3–10.
+        #[arg(long, default_value_t = 5)]
+        limit: usize,
+        /// Return the raw JSON response instead of the human-readable
+        /// summary. Useful from agent tools.
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -2171,6 +2195,49 @@ async fn main() -> Result<()> {
                     let kind = if workflow { "workflow" } else { "tool" };
                     println!("Installed {kind} '{name}' to {}", dest.display());
                     println!("It will be auto-discovered on next prism run.");
+                }
+                MarketplaceCommands::Find {
+                    query,
+                    types,
+                    limit,
+                    json,
+                } => {
+                    let hits = marketplace.find_tool(&query, &types, limit).await?;
+                    if json {
+                        // Stable structured output for agent-tool consumption.
+                        println!("{}", serde_json::to_string_pretty(&hits)?);
+                    } else if hits.is_empty() {
+                        println!("No semantic matches for `{query}`.");
+                        println!(
+                            "Try a different phrasing, or `prism marketplace search <query>` for \
+                             lexical search."
+                        );
+                    } else {
+                        println!("Top {} marketplace matches for `{query}`:\n", hits.len());
+                        for hit in &hits {
+                            let display = if hit.display_name.is_empty() {
+                                &hit.canonical_name
+                            } else {
+                                &hit.display_name
+                            };
+                            // score uses 2-decimal width so all rows line up under "score=0.91"
+                            println!(
+                                "  score={:.2}  {}  [{}]  ← {}",
+                                hit.score, hit.canonical_name, hit.category, display,
+                            );
+                            if !hit.description.is_empty() {
+                                println!("    {}", hit.description);
+                            }
+                            if !hit.execution_target.is_empty() {
+                                println!("    execution_target: {}", hit.execution_target);
+                            }
+                            println!();
+                        }
+                        println!(
+                            "Invoke a hit by its canonical_name. Cite both name and score in your \
+                             final answer."
+                        );
+                    }
                 }
                 MarketplaceCommands::Info { name } => {
                     let tool = marketplace.get_tool(&name).await?;

--- a/crates/client/src/marketplace.rs
+++ b/crates/client/src/marketplace.rs
@@ -30,6 +30,29 @@ pub struct MarketplaceTool {
     pub license: Option<String>,
 }
 
+/// A single hit from the semantic find_resource search. Mirrors the
+/// JSON shape the platform returns from `POST /marketplace/find`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MarketplaceFindHit {
+    /// Canonical name the agent invokes (e.g. `predict.elastic_moduli.mace`).
+    pub canonical_name: String,
+    #[serde(default)]
+    pub display_name: String,
+    #[serde(default)]
+    pub description: String,
+    /// Resource type (e.g. `model`, `cli_tool`, `procedural_skill`).
+    #[serde(default)]
+    pub category: String,
+    /// How the tool dispatches when invoked: `inference`, `local_shell`,
+    /// `mcp_server`, etc. Empty when not applicable to this resource type.
+    #[serde(default)]
+    pub execution_target: String,
+    /// Cosine similarity in [0, 1]; higher = closer to the query. Used by
+    /// the agent to decide whether to invoke or fall back.
+    #[serde(default)]
+    pub score: f32,
+}
+
 /// Client for the MARC27 marketplace endpoints.
 #[derive(Debug)]
 pub struct MarketplaceClient<'a> {
@@ -59,6 +82,43 @@ impl<'a> MarketplaceClient<'a> {
         let path = format!("/marketplace/resources/{name}");
         debug!(%path, "fetching marketplace resource");
         self.platform.get(&path).await
+    }
+
+    /// Semantic discovery of marketplace resources via the platform's
+    /// `find_resource` cosine-similarity search.
+    ///
+    /// Pairs with `POST /api/v1/marketplace/find` (marc27-core #33). The
+    /// platform side is the same path the research-engine REPL uses
+    /// internally via the injected `find_tool()` function; this client
+    /// wraps it for the PRISM CLI surface so chat-LLM tools can call it
+    /// directly without going through the research-engine REPL.
+    ///
+    /// `types` restricts to specific resource_type values (e.g. `["model",
+    /// "cli_tool"]`); pass `&[]` to search every type. `limit` caps the
+    /// number of hits returned (typical: 3–10).
+    pub async fn find_tool(
+        &self,
+        query: &str,
+        types: &[String],
+        limit: usize,
+    ) -> Result<Vec<MarketplaceFindHit>> {
+        #[derive(Serialize)]
+        struct FindRequest<'a> {
+            query: &'a str,
+            #[serde(skip_serializing_if = "<[String]>::is_empty")]
+            types: &'a [String],
+            limit: usize,
+        }
+        let body = FindRequest {
+            query,
+            types,
+            limit,
+        };
+        debug!(%query, ?types, limit, "POST /marketplace/find");
+        self.platform
+            .post("/marketplace/find", &body)
+            .await
+            .context("marketplace/find request failed")
     }
 
     /// Get the install URL for a resource (used by `prism marketplace install`).


### PR DESCRIPTION
PRISM half of find_tool dual-repo wiring (marc27-core #33 ships the platform endpoint). Adds a `prism marketplace find <query>` subcommand backed by `MarketplaceClient::find_tool` POSTing to `/marketplace/find`. Human format aligns scores; `--json` returns raw response for agent-tool consumers. Chat-LLM tool registration + system prompt advertising is a separate follow-up.