### PR TITLE
chore(ci): route issue workflows to self-hosted rocky

### DIFF
--- a/.github/workflows/issue-fix-dispatch.yml
+++ b/.github/workflows/issue-fix-dispatch.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   dispatch-fix:
     name: Dispatch Fix
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, ARM64]
     if: >
       github.event_name == 'workflow_dispatch' ||
       (github.event.label.name == 'needs-fix')

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   triage:
     name: Auto-Triage
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, ARM64]
     timeout-minutes: 2
 
     steps:


### PR DESCRIPTION
## Summary
- `issue-fix-dispatch.yml`: `ubuntu-latest` → `[self-hosted, linux, ARM64]`
- `issue-triage.yml`: same

These two were the only PRISM workflows still on `ubuntu-latest`. The
Darth-Hidious GH Actions billing block prevents ubuntu-latest from
starting — same block we just routed around for marc27-platform.

The jobs are trivial (`gh issue comment` / `gh issue edit`, <2 min each).
`gh` 2.92.0 is installed system-wide on rocky for this purpose.

## Not touched
- `native-release.yml` — its matrix (ubuntu-latest x86_64, macos-14
  aarch64, windows-latest x86_64) builds platform-specific release
  binaries. Moving the ubuntu entry to rocky ARM64 would silently
  break the Linux x86_64 release artifact.

## Test plan
- [ ] CI on this PR turns green (existing PRISM workflows already
      use self-hosted, so this PR's checks are unaffected)
- [ ] Next opened issue gets auto-triaged via rocky (verify by
      watching `github-runner-prism.service` journal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow infrastructure configurations for build system optimization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Darth-Hidious/PRISM/pull/122)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->