### PR TITLE
fix(cli): Phase 1(b)+(c) auth UX — kill 'please log in again' across all surfaces

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2586,9 +2586,7 @@ async fn main() -> Result<()> {
                                 eprintln!(
                                     "  Check \x1b[1mcurl https://api.marc27.com/health\x1b[0m, then"
                                 );
-                                eprintln!(
-                                    "  run \x1b[1mprism login\x1b[0m from a fresh shell."
-                                );
+                                eprintln!("  run \x1b[1mprism login\x1b[0m from a fresh shell.");
                                 eprintln!();
                                 return Ok(());
                             }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2536,24 +2536,92 @@ async fn main() -> Result<()> {
                 .iter()
                 .any(|c| c.name == "Auth" && c.result.starts_with("token rejected"))
             {
-                eprintln!();
-                eprintln!("\x1b[33mYour MARC27 session has expired — re-authenticating…\x1b[0m");
-                eprintln!();
-                if let Err(e) = perform_full_login(
-                    &paths,
-                    &endpoints,
-                    &python,
-                    LoginMode::Device { no_browser: false },
-                )
-                .await
-                {
-                    eprintln!("\x1b[31mInline re-login failed:\x1b[0m {e}");
+                // Bounded in-process retry instead of bouncing the user
+                // out to `prism login` + restart. The original "Run prism
+                // login manually, then start prism tui again" exit was
+                // Phase 1's biggest UX wart — users hit it when the
+                // device-flow inline-login failed for ANY reason (network
+                // blip, timeout, refresh-token revoked) and lost their
+                // whole TUI session. Now: up to MAX_ATTEMPTS tries with
+                // an explicit `[Enter] retry / [q] quit` prompt between
+                // attempts, plus a TTY guard so piped/CI invocations
+                // don't infinite-loop on prompts. PR #125 fixed the
+                // device-flow UI itself (URL+code always visible); this
+                // closes the loop on the *fallback* when device-flow
+                // itself errors.
+                use std::io::{IsTerminal, Write};
+                const MAX_ATTEMPTS: usize = 3;
+                let mut attempt = 0_usize;
+                loop {
+                    attempt += 1;
                     eprintln!();
-                    eprintln!(
-                        "  Run \x1b[1mprism login\x1b[0m manually, then start \x1b[1mprism tui\x1b[0m again."
-                    );
+                    if attempt == 1 {
+                        eprintln!(
+                            "\x1b[33mYour MARC27 session has expired — re-authenticating…\x1b[0m"
+                        );
+                    } else {
+                        eprintln!(
+                            "\x1b[33mRe-authenticating… (attempt {attempt}/{MAX_ATTEMPTS})\x1b[0m"
+                        );
+                    }
                     eprintln!();
-                    return Ok(());
+
+                    match perform_full_login(
+                        &paths,
+                        &endpoints,
+                        &python,
+                        LoginMode::Device { no_browser: false },
+                    )
+                    .await
+                    {
+                        Ok(()) => break,
+                        Err(e) => {
+                            eprintln!();
+                            eprintln!("\x1b[31mInline re-login failed:\x1b[0m {e}");
+                            eprintln!();
+                            if attempt >= MAX_ATTEMPTS {
+                                eprintln!(
+                                    "  Tried {MAX_ATTEMPTS} times — likely a server-side issue."
+                                );
+                                eprintln!(
+                                    "  Check \x1b[1mcurl https://api.marc27.com/health\x1b[0m, then"
+                                );
+                                eprintln!(
+                                    "  run \x1b[1mprism login\x1b[0m from a fresh shell."
+                                );
+                                eprintln!();
+                                return Ok(());
+                            }
+                            if !std::io::stdin().is_terminal() {
+                                // Non-interactive (piped input, CI, etc.)
+                                // — can't prompt. Exit cleanly with the
+                                // same guidance as exhaustion.
+                                eprintln!(
+                                    "  (Non-interactive stdin — can't prompt for retry. Run \x1b[1mprism login\x1b[0m and try again.)"
+                                );
+                                eprintln!();
+                                return Ok(());
+                            }
+                            eprintln!(
+                                "  Press \x1b[1mEnter\x1b[0m to retry, or type \x1b[1mq\x1b[0m + Enter to quit."
+                            );
+                            eprint!("  > ");
+                            std::io::stderr().flush().ok();
+                            let mut buf = String::new();
+                            if std::io::stdin().read_line(&mut buf).is_err() {
+                                // stdin closed mid-prompt — treat as quit
+                                eprintln!();
+                                return Ok(());
+                            }
+                            let trimmed = buf.trim();
+                            if trimmed.eq_ignore_ascii_case("q")
+                                || trimmed.eq_ignore_ascii_case("quit")
+                            {
+                                return Ok(());
+                            }
+                            // Empty / 'r' / 'retry' / anything else → loop
+                        }
+                    }
                 }
                 state = paths.load_cli_state().ok().unwrap_or_default();
                 boot_checks =

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -5736,29 +5736,50 @@ async fn run_device_login_with_opts(
     let start: DeviceCodeResponse =
         DeviceFlowAuth::start_device_flow(&http, &endpoints.api_base).await?;
 
+    // Unified login UI — same numbered format in both paths so the URL
+    // and code are always visible regardless of browser-open success.
+    //
+    // The original split (no_browser=true with the clean numbered block,
+    // no_browser=false with prose) caused the "please log in again" UX
+    // failure described in feedback_longhorizon_workflow_and_working_style:
+    // if open_browser() silently fails (no default-browser handler in the
+    // user's terminal context, iTerm/tmux quirk, etc.) the user never saw
+    // the URL clearly, the device flow timed out, and PRISM bounced them
+    // to a manual `prism login` retry loop. Now: clean numbered block
+    // always renders, browser-open is best-effort, and the "where to
+    // open it" hint mirrors the actual outcome.
     println!();
+    println!("\u{2501}\u{2501} PRISM login \u{2501}\u{2501}");
+    println!();
+    println!("  1. Open this URL in a browser:");
+    println!("       {}", start.verification_uri);
+    println!("  2. Enter this code when prompted:");
+    println!("       {}", start.user_code);
+    println!("  3. Approve the session.");
+    println!();
+
     if no_browser {
-        // Headless block — no auto-open, structure the output so the
-        // user can clearly see what to do on a different machine.
-        println!("\u{2501}\u{2501} PRISM headless login \u{2501}\u{2501}");
-        println!();
-        println!("  1. Open this URL on any browser (laptop, phone, …):");
-        println!("       {}", start.verification_uri);
-        println!("  2. Enter this code:");
-        println!("       {}", start.user_code);
-        println!("  3. Approve the session.");
-        println!();
-        println!("  Waiting here until you approve. Ctrl+C to abort.");
+        println!(
+            "  (Headless mode — no auto-open. Use any browser, including a different device.)"
+        );
     } else {
-        println!("PRISM setup needs MARC27 platform login.");
-        println!("Open: {}", start.verification_uri);
-        println!("Code: {}", start.user_code);
-        println!();
-        if let Err(err) = open_browser(&start.verification_uri) {
-            eprintln!("warning: failed to open browser automatically: {err}");
+        // Best-effort browser auto-open. URL is already on screen, so a
+        // failure here is a nuisance not a blocker. Report the outcome
+        // truthfully — "tried and failed" lets the user act; the silent
+        // failure was the old bug.
+        match open_browser(&start.verification_uri) {
+            Ok(_) => println!("  (Tried to open your default browser automatically.)"),
+            Err(err) => {
+                println!(
+                    "  (Couldn't auto-open your browser — please open the URL above manually."
+                );
+                println!("   Reason: {err})");
+            }
         }
-        println!("Approve the device in your browser, then return here.");
     }
+    println!();
+    println!("  Waiting until you approve. Ctrl+C to abort.");
+    println!();
 
     let token: TokenResponse = DeviceFlowAuth::poll_for_token(
         &http,


### PR DESCRIPTION
## Summary

Two commits, one logical fix: eliminate the "please log in again" UX failure across **all three surfaces** it appeared in.

| Commit | Phase | What |
|---|---|---|
| 8e64394 | 1(b) | Unify device-login UI — clean numbered block in both with-browser and headless paths; URL+code always visible; \`open_browser()\` becomes truthful best-effort assist (PR #124 already shipped bridge observability) |
| b6ef1e0 | 1(c) | Bounded retry loop on inline re-login failure — up to 3 attempts, explicit \`[Enter] retry / [q] quit\` prompt, TTY guard for non-interactive stdin, clearer exit guidance after exhaustion |

## The "please log in again" failure had three surfaces

1. **Initial device-flow presentation** (Phase 1b, commit 8e64394) — \`open_browser()\` silently failed in iTerm/tmux contexts, user missed the URL line buried in prose, device flow timed out. **Fixed**: clean numbered block always renders, URL+code always visible.
2. **Inline-login fallback** (Phase 1c, commit b6ef1e0) — when \`perform_full_login\` errored (network blip, refresh token revoked, etc.), the binary exited with "Run \`prism login\` manually, then start \`prism tui\` again." **Fixed**: bounded retry with explicit user prompt; after 3 failures, exits with a real diagnostic and recovery path.
3. **Bridge silent-death between turns** (Phase 1a, separate PR #124) — \`platform_bridge\` proxy died mid-session, forge hit \`Connection refused\`, no diagnostic. **Fixed in PR #124**: tracing::error! on \`axum::serve\` exit + \`ProxyHandle::is_alive()\` TCP probe.

Together, PR #124 + PR #125 close the "please log in again" UX failure end-to-end across all surfaces the user identified.

## Test plan

- [x] \`cargo check --bin prism\` — both commits compile clean
- [ ] Manual: \`prism login\` on macOS → see numbered block + auto-open message (commit 1)
- [ ] Manual: \`BROWSER=/bin/false prism login\` → numbered block + "Couldn't auto-open" + reason (commit 1)
- [ ] Manual: trigger a refresh-token-revoked scenario → see retry prompt → press Enter → device flow rerun → success (commit 2)
- [ ] Manual: 3 consecutive failures → see exhaustion message with curl-health-check suggestion (commit 2)
- [ ] Manual: \`echo "" | prism\` (piped stdin) → no infinite prompt loop, clean exit on first failure (commit 2 TTY guard)

## Diff

Both commits in \`crates/cli/src/main.rs\` only. No new deps. Open client, allowlisted path.

- Commit 1: +39/-18 in \`run_device_login_with_opts\`
- Commit 2: +84/-16 in \`Commands::Tui\` arm
- Total: +123/-34

## Follow-ons (separate PRs)

- Phase 1(d): fsevents/inotify creds-updated watcher for live propagation to already-running agent processes (the OAuth tango)
- Phase 1(e): self-heal for \`platform_bridge\` once PR #124's stderr captures actual \`axum::serve\` error cause
- Phase 1(f): visual chat-bar polish — bordered input vs bare \`❯\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  - Enhanced login resilience: Auth token rejection during TUI operations now triggers an interactive retry loop (up to 3 attempts), with clear prompts to retry or quit between attempts, providing graceful exit guidance when exhausted.
  - Unified OAuth instructions: Device flow login instructions are now consistently formatted and presented across all modes, removing UI inconsistencies between headless and browser-based authentication paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Darth-Hidious/PRISM/pull/125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->