### PR TITLE
fix(cli): hot-swappable Bearer + fsevents creds watcher (Phase 1d)

### DIFF
--- a/crates/cli/src/forge_chat.rs
+++ b/crates/cli/src/forge_chat.rs
@@ -218,6 +218,37 @@ pub async fn run(
         _ => None,
     };
 
+    // Phase 1(d) auth-fix: spawn the creds watcher.
+    //
+    // When `prism login` completes in ANOTHER shell, OR when the inline
+    // re-auth path (Commands::Tui arm with the bounded retry from
+    // PR #125) refreshes the on-disk credentials, the running TUI's
+    // bridge holds the OLD access_token frozen in memory. Without this
+    // watcher the user would need to quit + restart the TUI to pick up
+    // new creds. The task polls ~/.prism/cli_state.json mtime every 5s
+    // and on change pushes the fresh access_token into the bridge's
+    // hot-swap slot via ProxyHandle::update_access_token.
+    //
+    // Polling (vs `notify` fsevents/inotify) is deliberate: state.json
+    // changes are user-driven and rare, so polling at 5s is cheap and
+    // dodges the cross-platform fsevents/inotify quirk surface entirely.
+    // The task leaks when forge_chat::run returns — fine, the process
+    // exits shortly after and tokio cleans the runtime.
+    if let Some(ref handle) = _proxy {
+        let access_lock = handle.access_token_lock();
+        // Re-discover paths inside the watcher — forge_chat::run doesn't
+        // currently take a PrismPaths param. discover() is idempotent
+        // (just reads HOME + .config) so re-running it is fine. If it
+        // fails (no HOME?), we silently skip the watcher — the chat
+        // session still works, the user just needs to restart on a
+        // creds refresh, same as before this fix existed.
+        if let Ok(paths_for_watcher) = prism_runtime::PrismPaths::discover() {
+            tokio::spawn(async move {
+                watch_creds_for_updates(paths_for_watcher, access_lock).await;
+            });
+        }
+    }
+
     let mut cli = ForgeCli::parse_from(["prism-chat"]);
 
     // `prism resume <id>` integration: prism CLI sets PRISM_RESUME_ID
@@ -576,4 +607,52 @@ fn register_prism_mcp_servers(project_root: &Path, python_path: &Path) -> Result
             .with_context(|| format!("writing {}", mcp_path.display()))?;
     }
     Ok(())
+}
+
+/// Watch the on-disk credentials file and propagate token refreshes
+/// to the bridge without restarting it.
+///
+/// Phase 1(d) auth-fix: closes the OAuth-tango loop the user originally
+/// named. Polls cli_state.json mtime every 5 s; on change, reloads
+/// the state, extracts the current access_token, and writes it into
+/// the bridge's hot-swap slot if it actually changed. Token comparison
+/// before writing avoids a no-op spin if mtime changed for an unrelated
+/// reason (preferred_python update, org/project switch, etc.).
+async fn watch_creds_for_updates(
+    paths: prism_runtime::PrismPaths,
+    access_token: std::sync::Arc<tokio::sync::RwLock<String>>,
+) {
+    let state_path = paths.cli_state_path();
+    let mut last_mtime: Option<std::time::SystemTime> = std::fs::metadata(&state_path)
+        .ok()
+        .and_then(|m| m.modified().ok());
+    loop {
+        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+        let now_mtime: Option<std::time::SystemTime> = std::fs::metadata(&state_path)
+            .ok()
+            .and_then(|m| m.modified().ok());
+        if now_mtime == last_mtime {
+            continue;
+        }
+        last_mtime = now_mtime;
+        // mtime changed. Re-read state, propagate token if different.
+        let Ok(state) = paths.load_cli_state() else {
+            tracing::warn!(
+                target: "platform_bridge::creds_watcher",
+                "cli_state.json mtime changed but reload failed — skipping this tick"
+            );
+            continue;
+        };
+        let Some(new_token) = state.credentials.as_ref().map(|c| c.access_token.clone()) else {
+            continue;
+        };
+        let mut guard = access_token.write().await;
+        if *guard != new_token {
+            *guard = new_token;
+            tracing::info!(
+                target: "platform_bridge::creds_watcher",
+                "credentials refreshed via fs watcher — propagated to bridge"
+            );
+        }
+    }
 }

--- a/crates/cli/src/platform_bridge.rs
+++ b/crates/cli/src/platform_bridge.rs
@@ -51,7 +51,15 @@ use crate::chat_config::ChatTarget;
 #[derive(Clone)]
 struct ProxyState {
     upstream_base: String, // e.g. "https://api.marc27.com/api/v1/projects/<pid>/llm"
-    access_token: String,
+    /// Bearer credential, wrapped for hot-swap. Phase 1(d) of the
+    /// auth-fix arc: when an outside actor (`prism login` in another
+    /// shell, the inline re-auth path in main.rs::Commands::Tui)
+    /// refreshes the on-disk credentials, the fsevents-watcher task
+    /// in forge_chat.rs updates this slot — the bridge picks up the
+    /// new token on the next request without tearing down. Each
+    /// handler reads at the top of the request via `.read().await`
+    /// so an in-flight refresh doesn't tear an in-flight request.
+    access_token: Arc<RwLock<String>>,
     http: reqwest::Client,
     /// Optional semantic tool router. When present, requests with a tools[]
     /// array are filtered to top-K=8 most relevant before forwarding to
@@ -84,6 +92,12 @@ struct ProxyState {
 pub struct ProxyHandle {
     pub url: String, // base URL forge should hit (proxy_url + "/v1")
     chat_target: Arc<RwLock<ChatTarget>>,
+    /// Hot-swappable Bearer credential. Shares the same RwLock the
+    /// bridge ProxyState reads from per-request — external callers
+    /// (the fsevents creds-watcher in forge_chat.rs) can update via
+    /// `update_access_token` and the bridge picks it up on the next
+    /// turn without restart. Phase 1(d) auth-fix.
+    access_token: Arc<RwLock<String>>,
     shutdown: Option<oneshot::Sender<()>>,
 }
 
@@ -96,6 +110,25 @@ impl ProxyHandle {
         if let Some(tx) = self.shutdown.take() {
             let _ = tx.send(());
         }
+    }
+
+    /// Replace the Bearer credential the bridge uses for upstream calls.
+    /// Used by the fsevents creds-watcher in forge_chat.rs when an
+    /// outside actor (`prism login` in another shell, or the inline
+    /// reauth path in Commands::Tui) refreshes the on-disk creds. The
+    /// bridge picks up the new token on the next request — no
+    /// listener teardown, no chat-session restart.
+    #[allow(dead_code)]
+    pub async fn update_access_token(&self, new_token: &str) {
+        let mut guard = self.access_token.write().await;
+        *guard = new_token.to_string();
+    }
+
+    /// Hand out the live access-token lock. The fsevents creds-watcher
+    /// task in forge_chat.rs holds a clone for the lifetime of the
+    /// TUI session and writes through it on state.json changes.
+    pub fn access_token_lock(&self) -> Arc<RwLock<String>> {
+        self.access_token.clone()
     }
 
     /// Hand out the live `ChatTarget` lock so callers (the `/use` slash
@@ -137,10 +170,15 @@ pub async fn start(
     );
 
     let chat_target = Arc::new(RwLock::new(initial_chat_target));
+    // Hot-swap slot for the Bearer credential — shared by reference
+    // between ProxyState (axum-side read at request time) and
+    // ProxyHandle (external write via update_access_token, used by
+    // the fsevents creds-watcher in forge_chat.rs).
+    let access_token = Arc::new(RwLock::new(access_token.to_string()));
 
     let state = ProxyState {
         upstream_base,
-        access_token: access_token.to_string(),
+        access_token: access_token.clone(),
         http: reqwest::Client::builder()
             // SSE streams can run for minutes — let the upstream control timing.
             .timeout(std::time::Duration::from_secs(600))
@@ -178,6 +216,7 @@ pub async fn start(
     Ok(ProxyHandle {
         url,
         chat_target,
+        access_token,
         shutdown: Some(tx),
     })
 }
@@ -188,12 +227,11 @@ pub async fn start(
 /// `{ "object": "list", "data": [{ id, object, created, owned_by }, …] }`.
 async fn list_models(State(state): State<Arc<ProxyState>>) -> Response {
     let upstream = format!("{}/models", state.upstream_base);
-    let res = state
-        .http
-        .get(&upstream)
-        .bearer_auth(&state.access_token)
-        .send()
-        .await;
+    // Read the hot-swappable token at request time. If the
+    // fsevents creds-watcher in forge_chat.rs just wrote a fresh
+    // token, this request uses it — no listener teardown needed.
+    let token = state.access_token.read().await.clone();
+    let res = state.http.get(&upstream).bearer_auth(&token).send().await;
 
     let resp = match res {
         Ok(r) => r,
@@ -652,7 +690,8 @@ async fn chat_completions(State(state): State<Arc<ProxyState>>, body: Bytes) -> 
         match target {
             ChatTarget::Marc27 { .. } => (
                 format!("{}/stream", state.upstream_base),
-                Some(state.access_token.clone()),
+                // Hot-swappable Bearer (Phase 1d): read fresh per request.
+                Some(state.access_token.read().await.clone()),
                 UpstreamShape::Marc27Sse,
             ),
             ChatTarget::Local { url, api_key, .. } => (


### PR DESCRIPTION
## Summary

Closes the **OAuth-tango loop** the user originally named. After this PR a \`prism login\` in another shell OR the inline re-auth path in \`Commands::Tui\` (the bounded retry from PR #125) propagates to a running TUI within ~5 s — no quit, no restart.

## Mechanism

| Change | Where |
|---|---|
| \`ProxyState.access_token: String\` → \`Arc<RwLock<String>>\` | \`platform_bridge.rs\` |
| Request handlers read fresh per request via \`.read().await.clone()\` | \`platform_bridge.rs:233, 698\` |
| \`ProxyHandle\` gains \`access_token_lock()\` + \`update_access_token()\` | \`platform_bridge.rs\` |
| Tokio task spawned after \`ProxyState::Ok(handle)\` — polls \`cli_state.json\` mtime every 5 s, on change reloads, writes through the shared Arc if token actually changed | \`forge_chat.rs\` |

## Why polling over notify

\`state.json\` changes are user-driven and rare (login flows, agent switches). Polling at 5 s is cheap, dodges the cross-platform fsevents/inotify quirk surface entirely, and a chat HTTP request takes ~50 ms anyway so perceived latency is indistinguishable from real-time. **No new deps.**

Token-comparison guard in the watcher: mtime can change for unrelated reasons (preferred_python update, org/project switch). Writing the Arc only fires when the token value actually changed → no log spam.

## Together with the other Phase 1 PRs

- PR #124 — bridge silent-death observability (\`tracing::error!\` on axum::serve exit, \`is_alive()\` probe)
- PR #125 — device-flow UI unification (commit 1) + bounded retry loop (commit 2)
- **PR #126 (this PR)** — hot-swap Bearer + creds watcher

Closes the "please log in again" UX failure across all four surfaces. The only remaining Phase 1 sub-task is **(e) bridge self-heal once stderr captures actual axum::serve Err cause** — gated on the observability from #124 actually firing.

## Test plan

- [x] \`cargo check\` clean
- [x] \`cargo fmt\` + \`cargo clippy\` clean
- [ ] Manual: drive \`prism\` TUI via iterm-tmux MCP. Verify chat works. \`touch ~/.prism/cli_state.json\` (or run \`prism login\` in another shell). Within 5 s, expect \`tracing::info!\` \"credentials refreshed via fs watcher\" in stderr. Subsequent chat requests use the new token.
- [ ] Manual: run with no creds. Watcher is not spawned (proxy_state != Ok). Verify no panic.

## Diff

+~90 / -~10 across \`platform_bridge.rs\` and \`forge_chat.rs\`. PRISM-client only, allowlisted path. No marc27-core changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic credential refresh capability that monitors for authentication token updates and applies them without requiring a proxy restart. Credentials are now seamlessly refreshed at regular intervals while the service continues running.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Darth-Hidious/PRISM/pull/126?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->