### PR TITLE
fix(cli): doctor auto-refreshes rejected token instead of demanding prism login

### DIFF
--- a/crates/cli/src/doctor.rs
+++ b/crates/cli/src/doctor.rs
@@ -129,10 +129,44 @@ pub async fn run(project_root: &std::path::Path, python_bin: &std::path::Path) -
     boot::section("Platform Connectivity");
 
     let paths = PrismPaths::discover()?;
-    let state = paths.load_cli_state().unwrap_or_default();
+    let mut state = paths.load_cli_state().unwrap_or_default();
     let endpoints = PlatformEndpoints::from_env();
-    let platform_checks =
+    let mut platform_checks =
         boot_checks::run_boot_checks(state.credentials.as_ref(), &endpoints).await;
+
+    // Match the boot-flow contract (main.rs ~line 991): if Auth shows
+    // "token rejected" and we have a refresh_token, the access token
+    // was likely server-side rotated. Silently refresh once and redo
+    // the checks. Only if the refresh ALSO fails do we surface
+    // "run prism login" — the user shouldn't have to log in just
+    // because the diagnostic command was used instead of the boot
+    // command. We own the platform; the doctor's job is to recover
+    // what's recoverable, not relay stale state.
+    let auth_rejected = platform_checks
+        .iter()
+        .any(|c| c.name == "Auth" && c.result.starts_with("token rejected"));
+    if auth_rejected
+        && let Some(creds) = state.credentials.as_ref()
+        && !creds.refresh_token.is_empty()
+    {
+        match crate::refresh_access_token(&endpoints, creds).await {
+            Ok(new_creds) => {
+                tracing::info!("doctor: access token refreshed after server-side rejection");
+                state.credentials = Some(new_creds);
+                paths.save_cli_state(&state)?;
+                // Redo the checks with the fresh token so the rest of
+                // the platform-connectivity lines (KG / Models /
+                // Compute / Marketplace / Policy) reflect post-refresh
+                // state too — they all use the same Bearer.
+                platform_checks =
+                    boot_checks::run_boot_checks(state.credentials.as_ref(), &endpoints).await;
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "doctor: refresh failed, keeping rejected state");
+            }
+        }
+    }
+
     print_check_lines(&platform_checks);
 
     println!();

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -6056,7 +6056,7 @@ where
         .ok_or_else(|| anyhow!("selection out of range"))
 }
 
-async fn refresh_access_token(
+pub(crate) async fn refresh_access_token(
     endpoints: &PlatformEndpoints,
     creds: &StoredCredentials,
 ) -> Result<StoredCredentials> {


### PR DESCRIPTION
Closes the ESA-grade prod-readiness gap surfaced today: `prism doctor` was demanding `prism login` when the refresh_token was valid and a silent refresh would have worked. See commit message for full diagnosis + verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The `prism doctor` command's Platform Connectivity check now automatically attempts to refresh access tokens when authentication fails due to token rejection. Upon successful refresh, diagnostic checks are re-run to reflect the updated authentication state, providing more accurate results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Darth-Hidious/PRISM/pull/127?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->